### PR TITLE
Use new ubuntu-image feature to build a rootfs easily

### DIFF
--- a/imagecraft/plugins/gadget.py
+++ b/imagecraft/plugins/gadget.py
@@ -69,4 +69,5 @@ class GadgetPlugin(plugins.Plugin):
         return [
             f"make {gadget_target}",
             "cp -a $CRAFT_PART_BUILD/install/* $CRAFT_PART_INSTALL/",
+            "ln -s $CRAFT_PART_INSTALL/ $CRAFT_PART_INSTALL/install",
         ]

--- a/imagecraft/ubuntu_image.py
+++ b/imagecraft/ubuntu_image.py
@@ -97,7 +97,6 @@ def ubuntu_image_cmds_build_rootfs(  # noqa: PLR0913
         f"cat << EOF > craft.yaml\n{definition_yaml}\nEOF",
         "ubuntu-image classic --workdir work -O output/ craft.yaml",
         "mv work/chroot/* $CRAFT_PART_INSTALL/",
-        #  "ubuntu-image control build-rootfs craft.yaml",
     ]
 
 

--- a/imagecraft/ubuntu_image.py
+++ b/imagecraft/ubuntu_image.py
@@ -56,7 +56,6 @@ revision: 1
 class: preinstalled
 architecture: {arch}
 series: {series}
-class: preinstalled
 {kernel_line}
 
 rootfs:
@@ -68,10 +67,6 @@ rootfs:
     pocket: {pocket}
 
 {customization}
-
-artifacts:
-  manifest:
-    name: craft.manifest
 """
 
 
@@ -100,8 +95,7 @@ def ubuntu_image_cmds_build_rootfs(  # noqa: PLR0913
     )
     return [
         f"cat << EOF > craft.yaml\n{definition_yaml}\nEOF",
-        "ubuntu-image classic --workdir work -O output/ --thru"
-        "=preseed_image craft.yaml",
+        "ubuntu-image classic --workdir work -O output/ craft.yaml",
         "mv work/chroot/* $CRAFT_PART_INSTALL/",
         #  "ubuntu-image control build-rootfs craft.yaml",
     ]

--- a/tests/unit/plugins/test_gadget.py
+++ b/tests/unit/plugins/test_gadget.py
@@ -102,6 +102,7 @@ def test_get_build_commands(gadget_plugin):
     assert gadget_plugin.get_build_commands() == [
         "make ",
         "cp -a $CRAFT_PART_BUILD/install/* $CRAFT_PART_INSTALL/",
+        "ln -s $CRAFT_PART_INSTALL/ $CRAFT_PART_INSTALL/install",
     ]
 
 
@@ -109,4 +110,5 @@ def test_get_build_commands_with_target(gadget_plugin_with_target):
     assert gadget_plugin_with_target.get_build_commands() == [
         "make test_target",
         "cp -a $CRAFT_PART_BUILD/install/* $CRAFT_PART_INSTALL/",
+        "ln -s $CRAFT_PART_INSTALL/ $CRAFT_PART_INSTALL/install",
     ]

--- a/tests/unit/test_ubuntu_image.py
+++ b/tests/unit/test_ubuntu_image.py
@@ -45,7 +45,6 @@ revision: 1
 class: preinstalled
 architecture: amd64
 series: mantic
-class: preinstalled
 kernel: linux-image-generic
 
 rootfs:
@@ -62,10 +61,6 @@ customization:
     - name: lxd
     - name: snapd
 
-
-artifacts:
-  manifest:
-    name: craft.manifest
 """
     )
 
@@ -87,7 +82,6 @@ revision: 1
 class: preinstalled
 architecture: amd64
 series: mantic
-class: preinstalled
 
 
 rootfs:
@@ -99,10 +93,6 @@ rootfs:
     pocket: updates
 
 
-
-artifacts:
-  manifest:
-    name: craft.manifest
 """
     )
 
@@ -125,7 +115,7 @@ def test_ubuntu_image_cmds_build_rootfs(mocker):
         extra_snaps=["lxd", "snapd"],
     ) == [
         "cat << EOF > craft.yaml\ntest\nEOF",
-        "ubuntu-image classic --workdir work -O output/ --thru=preseed_image craft.yaml",
+        "ubuntu-image classic --workdir work -O output/ craft.yaml",
         "mv work/chroot/* $CRAFT_PART_INSTALL/",
     ]
 


### PR DESCRIPTION
Ubuntu-image now enable building a rootfs (only) without using the `--thru` flag to stop the build. Moreover, the `artifacts` key is not mandatory anymore and can be omitted.

Imagecraft can now call ubuntu-image in a cleaner way.

This PR also fixes LP#2045336

Fixes: FR-6416