### PR TITLE
Sync imagecraft with current imagecraft.yaml proposition

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -116,7 +116,7 @@ jobs:
 
   tics-report:
     runs-on: ubuntu-latest
-    needs: [lint,unit,integration]
+    needs: [lint, unit, integration]
     if: ${{ github.event_name == 'push' || github.ref == 'refs/heads/main' }}
     steps:
       - uses: actions/checkout@v4

--- a/examples/ubuntu-server-amd64.yaml
+++ b/examples/ubuntu-server-amd64.yaml
@@ -12,6 +12,8 @@ parts:
     plugin: gadget
     source: https://github.com/snapcore/pc-gadget.git
     source-branch: classic
+    gadget-type: git
+    gadget-target: server
   rootfs:
     plugin: ubuntu-seed
     ubuntu-seed-sources:

--- a/examples/ubuntu-server-amd64.yaml
+++ b/examples/ubuntu-server-amd64.yaml
@@ -26,7 +26,18 @@ parts:
       - main
       - restricted
     ubuntu-seed-pocket: updates
+    ubuntu-seed-germinate:
+      urls:
+        - "git://git.launchpad.net/~ubuntu-core-dev/ubuntu-seeds/+git/"
+      branch: jammy
+      vcs: true
+      names:
+        - server
+        - minimal
+        - standard
+    ubuntu-seed-kernel: linux-image-generic
     ubuntu-seed-extra-snaps: [core20, snapd]
+    ubuntu-seed-extra-packages: [hello-ubuntu-image-public]
     ubuntu-seed-active-kernel: linux-generic
     stage:
       - -etc/cloud/cloud.cfg.d/90_dpkg.cfg

--- a/imagecraft/architectures.py
+++ b/imagecraft/architectures.py
@@ -1,0 +1,28 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2023 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Architecture definitions."""
+
+
+# The keys are valid debian architectures.
+SUPPORTED_ARCHS: list[str] = [
+    "amd64",
+    "armhf",
+    "arm64",
+    "i386",
+    "ppc64el",
+    "riscv64",
+    "s390x",
+]

--- a/imagecraft/models/__init__.py
+++ b/imagecraft/models/__init__.py
@@ -15,6 +15,6 @@
 # with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Data models for Imagecraft."""
 
-from imagecraft.models.project import Project
+from imagecraft.models.project import Project, Platform
 
-__all__ = ["Project"]
+__all__ = ["Project", "Platform"]

--- a/imagecraft/models/project.py
+++ b/imagecraft/models/project.py
@@ -130,6 +130,12 @@ class Project(ProjectModel):
     @classmethod
     def preprocess_all_platforms(cls, platforms: dict[str, Any]) -> dict[str, Any]:
         """Convert the simplified form of platform to the full one."""
+        if platforms is None:
+            raise CraftValidationError(
+                "No platforms were specified.",
+                details="At least one platform must be given when using this configuration key.",
+            )
+
         for platform_label, platform in platforms.items():
             if platform is None:
                 if platform_label not in SUPPORTED_ARCHS:

--- a/imagecraft/models/project.py
+++ b/imagecraft/models/project.py
@@ -130,7 +130,7 @@ class Project(ProjectModel):
     @classmethod
     def preprocess_all_platforms(cls, platforms: dict[str, Any]) -> dict[str, Any]:
         """Convert the simplified form of platform to the full one."""
-        if platforms is None:
+        if platforms is None: # pyright: ignore[reportUnnecessaryComparison] false positive
             raise CraftValidationError(
                 "No platforms were specified.",
                 details="At least one platform must be given when using this configuration key.",

--- a/imagecraft/plugins/ubuntu_seed.py
+++ b/imagecraft/plugins/ubuntu_seed.py
@@ -55,7 +55,8 @@ class UbuntuSeedPluginProperties(plugins.PluginProperties):
 
     ubuntu_seed_germinate: GerminateProperties
     ubuntu_seed_extra_snaps: UniqueStrList | None = None
-    ubuntu_seed_active_kernel: str | None = None
+    ubuntu_seed_extra_packages: UniqueStrList | None = None
+    ubuntu_seed_kernel: str | None = None
 
     @classmethod
     def unmarshal(cls, data: dict[str, Any]) -> Self:

--- a/imagecraft/plugins/ubuntu_seed.py
+++ b/imagecraft/plugins/ubuntu_seed.py
@@ -105,8 +105,11 @@ class UbuntuSeedPlugin(plugins.Plugin):
         if not source_branch:
             source_branch = series
 
+        version = self._part_info.project_info.get_project_var("version", raw_read=True)
+
         ubuntu_seed_cmd = ubuntu_image_cmds_build_rootfs(
             series,
+            version,
             arch,
             options.ubuntu_seed_germinate.urls,
             source_branch,

--- a/imagecraft/plugins/ubuntu_seed.py
+++ b/imagecraft/plugins/ubuntu_seed.py
@@ -19,7 +19,7 @@
 from typing import TYPE_CHECKING, Any, cast
 
 from craft_parts import plugins
-from pydantic import conlist
+from pydantic import AnyUrl, conlist
 from typing_extensions import Self
 
 from imagecraft.errors import NoValidSeriesError
@@ -34,16 +34,26 @@ if TYPE_CHECKING:
 else:
     UniqueStrList = conlist(str, unique_items=True, min_items=1)
 
+if TYPE_CHECKING:
+    UniqueUrlList = list[str]
+else:
+    UniqueUrlList = conlist(AnyUrl, unique_items=True, min_items=1)
+
+class GerminateProperties(plugins.PluginProperties):
+    """Supported attributes for the 'Germinate' section of the UbuntuSeedPlugin plugin."""
+
+    urls: UniqueUrlList
+    branch: str | None
+    names: UniqueStrList
+    vcs: bool | None = True
 
 class UbuntuSeedPluginProperties(plugins.PluginProperties):
     """Supported attributes for the 'UbuntuSeedPlugin' plugin."""
 
-    ubuntu_seed_sources: UniqueStrList
-    ubuntu_seed_source_branch: str | None
-    ubuntu_seed_seeds: UniqueStrList
     ubuntu_seed_components: UniqueStrList
     ubuntu_seed_pocket: str = "updates"
 
+    ubuntu_seed_germinate: GerminateProperties
     ubuntu_seed_extra_snaps: UniqueStrList | None = None
     ubuntu_seed_active_kernel: str | None = None
 
@@ -90,19 +100,19 @@ class UbuntuSeedPlugin(plugins.Plugin):
         if not series:
             raise NoValidSeriesError
 
-        source_branch = options.ubuntu_seed_source_branch
+        source_branch = options.ubuntu_seed_germinate.branch
         if not source_branch:
             source_branch = series
 
         ubuntu_seed_cmd = ubuntu_image_cmds_build_rootfs(
             series,
             arch,
-            options.ubuntu_seed_sources,
+            options.ubuntu_seed_germinate.urls,
             source_branch,
-            options.ubuntu_seed_seeds,
+            options.ubuntu_seed_germinate.names,
             options.ubuntu_seed_components,
             options.ubuntu_seed_pocket,
-            options.ubuntu_seed_active_kernel,
+            options.ubuntu_seed_kernel,
             options.ubuntu_seed_extra_snaps,
         )
 

--- a/imagecraft/services/lifecycle.py
+++ b/imagecraft/services/lifecycle.py
@@ -16,6 +16,7 @@
 
 """Imagecraft Lifecycle service."""
 
+from pathlib import Path
 from typing import cast
 
 from craft_application import AppMetadata, LifecycleService, ServiceFactory, util
@@ -37,8 +38,8 @@ class ImagecraftLifecycleService(LifecycleService):
         app: AppMetadata,
         services: ServiceFactory,
         *,
-        cache_dir: str,
-        work_dir: str,
+        cache_dir: Path | str,
+        work_dir: Path | str,
         project: Project,
         build_for: str,
         platform: str | None,

--- a/imagecraft/services/lifecycle.py
+++ b/imagecraft/services/lifecycle.py
@@ -92,4 +92,3 @@ class ImagecraftLifecycleService(LifecycleService):
         )
 
         super().setup()
-

--- a/imagecraft/services/lifecycle.py
+++ b/imagecraft/services/lifecycle.py
@@ -93,9 +93,3 @@ class ImagecraftLifecycleService(LifecycleService):
 
         super().setup()
 
-    @override
-    def run(self, step_name: str | None, part_names: list[str] | None = None) -> None:
-        """Run the lifecycle manager for the parts."""
-        # TODO: Add overriding package repositories here.
-
-        super().run(step_name, part_names)

--- a/imagecraft/services/pack.py
+++ b/imagecraft/services/pack.py
@@ -46,7 +46,9 @@ class ImagecraftPackService(PackageService):
     def pack(self, prime_dir: pathlib.Path, dest: pathlib.Path) -> list[pathlib.Path]:
         """Pack the image.
 
-        :param dest: Directory into which to write the gadget
+        :param prime_dir: Directory path to the prime directory.
+        :param dest: Directory into which to write the package(s).
+        :returns: A list of paths to created packages.
         """
         gadget_path = "$CRAFT_PART_INSTALL/install"
 

--- a/imagecraft/ubuntu_image.py
+++ b/imagecraft/ubuntu_image.py
@@ -18,7 +18,7 @@
 
 import subprocess
 
-import yaml
+from craft_application.util import dump_yaml
 from craft_cli import emit
 from pydantic import BaseModel, Field
 
@@ -158,13 +158,12 @@ def generate_image_def_yaml(  # noqa: PLR0913
             extra_packages=extra_packages_obj,
         )
 
-    return yaml.dump(
+    return dump_yaml(
         image_definition.dict(
             exclude_unset=True,
             exclude_none=True,
             by_alias=True,
         ),
-        sort_keys=False,
     )
 
 

--- a/imagecraft/ubuntu_image.py
+++ b/imagecraft/ubuntu_image.py
@@ -110,7 +110,7 @@ class ImageDefinition(BaseModel):
         alias_generator = _alias_generator
 
 
-def generate_legacy_def_rootfs(  # noqa: PLR0913
+def generate_image_def_yaml(  # noqa: PLR0913
     series: str,
     revision: str,
     arch: str,
@@ -181,7 +181,7 @@ def ubuntu_image_cmds_build_rootfs(  # noqa: PLR0913
     extra_snaps: list[str] | None = None,
 ) -> list[str]:
     """List commands to ubuntu-image to generate a rootfs."""
-    definition_yaml = generate_legacy_def_rootfs(
+    definition_yaml = generate_image_def_yaml(
         series,
         version,
         arch,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -78,12 +78,6 @@ def default_project(extra_project_params):
 
 
 @pytest.fixture()
-def default_build_plan(default_project):
-    from imagecraft.models.project import BuildPlanner
-
-    return BuildPlanner.unmarshal(default_project.marshal()).get_build_plan()
-
-@pytest.fixture()
 def default_factory(default_project):
     from imagecraft.application import APP_METADATA
     from imagecraft.services import ImagecraftServiceFactory
@@ -130,4 +124,18 @@ def lifecycle_service_no_platform(default_project, default_factory):
         services=default_factory,
         work_dir=Path("work/"),
         cache_dir=Path("cache/"),
+    )
+
+
+@pytest.fixture()
+def pack_service(default_project, default_factory):
+    from imagecraft.application import APP_METADATA
+    from imagecraft.services import ImagecraftPackService
+
+    return ImagecraftPackService(
+        app=APP_METADATA,
+        build_for="amd64",
+        platform="amd64",
+        project=default_project,
+        services=default_factory,
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -115,3 +115,19 @@ def lifecycle_service(default_project, default_factory):
         work_dir=Path("work/"),
         cache_dir=Path("cache/"),
     )
+
+
+@pytest.fixture()
+def lifecycle_service_no_platform(default_project, default_factory):
+    from imagecraft.application import APP_METADATA
+    from imagecraft.services import ImagecraftLifecycleService
+
+    return ImagecraftLifecycleService(
+        app=APP_METADATA,
+        build_for="amd64",
+        platform=None,
+        project=default_project,
+        services=default_factory,
+        work_dir=Path("work/"),
+        cache_dir=Path("cache/"),
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,7 @@
 # You should have received a copy of the GNU General Public License along
 # with this program.  If not, see <http://www.gnu.org/licenses/>.
 import types
+from pathlib import Path
 
 import pytest
 from craft_application.models.constraints import ProjectName, SummaryStr
@@ -77,6 +78,12 @@ def default_project(extra_project_params):
 
 
 @pytest.fixture()
+def default_build_plan(default_project):
+    from imagecraft.models.project import BuildPlanner
+
+    return BuildPlanner.unmarshal(default_project.marshal()).get_build_plan()
+
+@pytest.fixture()
 def default_factory(default_project):
     from imagecraft.application import APP_METADATA
     from imagecraft.services import ImagecraftServiceFactory
@@ -92,3 +99,19 @@ def default_application(default_factory):
     from imagecraft.application import APP_METADATA, Imagecraft
 
     return Imagecraft(APP_METADATA, default_factory)
+
+
+@pytest.fixture()
+def lifecycle_service(default_project, default_factory):
+    from imagecraft.application import APP_METADATA
+    from imagecraft.services import ImagecraftLifecycleService
+
+    return ImagecraftLifecycleService(
+        app=APP_METADATA,
+        build_for="amd64",
+        platform="amd64",
+        project=default_project,
+        services=default_factory,
+        work_dir=Path("work/"),
+        cache_dir=Path("cache/"),
+    )

--- a/tests/unit/models/test_project.py
+++ b/tests/unit/models/test_project.py
@@ -201,3 +201,10 @@ def test_project_all_platforms_invalid(yaml_loaded_data):
     assert "build image for target architecture noarch" in reload_project_platforms(
         mock_platforms,
     )
+
+    mock_platforms = {
+        "unsupported": None,
+    }
+    assert "Invalid platform unsupported" in reload_project_platforms(
+        mock_platforms,
+    )

--- a/tests/unit/models/test_project.py
+++ b/tests/unit/models/test_project.py
@@ -36,14 +36,15 @@ parts:
     source-branch: classic
   rootfs:
     plugin: ubuntu-seed
-    ubuntu-seed-sources:
-      - "git://git.launchpad.net/~ubuntu-core-dev/ubuntu-seeds/+git/"
-    ubuntu-seed-source-branch: jammy
-    ubuntu-seed-seeds:
-      - server
-      - minimal
-      - standard
-      - cloud-image
+    ubuntu-seed-germinate:
+      urls:
+        - "git://git.launchpad.net/~ubuntu-core-dev/ubuntu-seeds/+git/"
+      branch: jammy
+      names:
+        - server
+        - minimal
+        - standard
+        - cloud-image
     ubuntu-seed-components:
       - main
       - restricted

--- a/tests/unit/models/test_project.py
+++ b/tests/unit/models/test_project.py
@@ -50,7 +50,7 @@ parts:
       - restricted
     ubuntu-seed-pocket: updates
     ubuntu-seed-extra-snaps: [core20, snapd]
-    ubuntu-seed-active-kernel: linux-generic
+    ubuntu-seed-kernel: linux-generic
     stage:
       - -etc/cloud/cloud.cfg.d/90_dpkg.cfg
 """

--- a/tests/unit/models/test_project.py
+++ b/tests/unit/models/test_project.py
@@ -168,8 +168,7 @@ def test_project_platform_invalid():
 
 def test_project_all_platforms_invalid(yaml_loaded_data):
     def reload_project_platforms(new_platforms=None):
-        if new_platforms:
-            yaml_loaded_data["platforms"] = mock_platforms
+        yaml_loaded_data["platforms"] = mock_platforms
         with pytest.raises(CraftValidationError) as err:
             Project.unmarshal(yaml_loaded_data)
 
@@ -206,5 +205,10 @@ def test_project_all_platforms_invalid(yaml_loaded_data):
         "unsupported": None,
     }
     assert "Invalid platform unsupported" in reload_project_platforms(
+        mock_platforms,
+    )
+
+    mock_platforms = None
+    assert "No platforms were specified." in reload_project_platforms(
         mock_platforms,
     )

--- a/tests/unit/models/test_project.py
+++ b/tests/unit/models/test_project.py
@@ -72,6 +72,33 @@ parts:
     source-branch: classic
 """
 
+IMAGECRAFT_YAML_MINIMAL_PLATFORM = """
+name: ubuntu-server-amd64
+version: "22.04"
+series: jammy
+platforms:
+  amd64:
+parts:
+  gadget:
+    plugin: gadget
+    source: https://github.com/snapcore/pc-gadget.git
+    source-branch: classic
+"""
+
+IMAGECRAFT_YAML_NO_BUILD_FOR_PLATFORM = """
+name: ubuntu-server-amd64
+version: "22.04"
+series: jammy
+platforms:
+  amd64:
+    build-on: amd64
+parts:
+  gadget:
+    plugin: gadget
+    source: https://github.com/snapcore/pc-gadget.git
+    source-branch: classic
+"""
+
 
 @pytest.fixture()
 def yaml_loaded_data():
@@ -87,6 +114,8 @@ def load_project_yaml(yaml_loaded_data) -> Project:
     [
         IMAGECRAFT_YAML_GENERIC,
         IMAGECRAFT_YAML_SIMPLE_PLATFORM,
+        IMAGECRAFT_YAML_MINIMAL_PLATFORM,
+        IMAGECRAFT_YAML_NO_BUILD_FOR_PLATFORM,
     ],
 )
 def test_project_unmarshal(yaml_data):

--- a/tests/unit/plugins/test_ubuntu_seed.py
+++ b/tests/unit/plugins/test_ubuntu_seed.py
@@ -25,28 +25,29 @@ from imagecraft.plugins import ubuntu_seed
 
 UBUNTU_SEED_BASIC_SPEC = {
     "plugin": "ubuntu-seed",
-    "ubuntu-seed-sources": [
-        "git://git.launchpad.net/~ubuntu-core-dev/ubuntu-seeds/+git/",
-    ],
-    "ubuntu-seed-source-branch": "jammy",
-    "ubuntu-seed-seeds": ["server", "minimal", "standard", "cloud-image"],
     "ubuntu-seed-components": ["main", "restricted"],
     "ubuntu-seed-pocket": "updates",
     "ubuntu-seed-extra-snaps": ["core20", "snapd"],
-    "ubuntu-seed-active-kernel": "linux-generic",
+    "ubuntu-seed-extra-packages": ["apt"],
+    "ubuntu-seed-kernel": "linux-generic",
+    "ubuntu-seed-germinate": {
+        "urls": ["git://git.launchpad.net/~ubuntu-core-dev/ubuntu-seeds/+git/"],
+        "branch": "jammy",
+        "names": ["server", "minimal", "standard", "cloud-image"],
+    },
 }
 
 
 UBUNTU_SEED_NO_SOURCE_BRANCH = {
     "plugin": "ubuntu-seed",
-    "ubuntu-seed-sources": [
-        "git://git.launchpad.net/~ubuntu-core-dev/ubuntu-seeds/+git/",
-    ],
-    "ubuntu-seed-seeds": ["server", "minimal", "standard", "cloud-image"],
     "ubuntu-seed-components": ["main", "restricted"],
     "ubuntu-seed-pocket": "updates",
     "ubuntu-seed-extra-snaps": ["core20", "snapd"],
-    "ubuntu-seed-active-kernel": "linux-generic",
+    "ubuntu-seed-kernel": "linux-generic",
+    "ubuntu-seed-germinate": {
+        "urls": ["git://git.launchpad.net/~ubuntu-core-dev/ubuntu-seeds/+git/"],
+        "names": ["server", "minimal", "standard", "cloud-image"],
+    },
 }
 
 
@@ -101,15 +102,12 @@ def test_missing_properties():
             {"gadget-something-invalid": True},
         )
     err = raised.value.errors()
-    assert len(err) == 3
-    assert err[0]["loc"] == ("ubuntu-seed-sources",)
+    assert len(err) == 2
+    assert err[0]["loc"] == ("ubuntu-seed-components",)
     assert err[0]["type"] == "value_error.missing"
 
-    assert err[1]["loc"] == ("ubuntu-seed-seeds",)
+    assert err[1]["loc"] == ("ubuntu-seed-germinate",)
     assert err[1]["type"] == "value_error.missing"
-
-    assert err[2]["loc"] == ("ubuntu-seed-components",)
-    assert err[2]["type"] == "value_error.missing"
 
 
 def test_get_build_snaps(ubuntu_seed_plugin, tmp_path):
@@ -145,11 +143,11 @@ def test_get_build_commands(ubuntu_seed_plugin, mocker, tmp_path):
         ]
 
         build_rootfs_patcher.assert_called_with(
-            UBUNTU_SEED_BASIC_SPEC["ubuntu-seed-source-branch"],
+            UBUNTU_SEED_BASIC_SPEC["ubuntu-seed-germinate"].get("branch"),
             "amd64",
-            UBUNTU_SEED_BASIC_SPEC["ubuntu-seed-sources"],
-            UBUNTU_SEED_BASIC_SPEC["ubuntu-seed-source-branch"],
-            UBUNTU_SEED_BASIC_SPEC["ubuntu-seed-seeds"],
+            UBUNTU_SEED_BASIC_SPEC["ubuntu-seed-germinate"].get("urls"),
+            UBUNTU_SEED_BASIC_SPEC["ubuntu-seed-germinate"].get("branch"),
+            UBUNTU_SEED_BASIC_SPEC["ubuntu-seed-germinate"].get("names"),
             UBUNTU_SEED_BASIC_SPEC["ubuntu-seed-components"],
             UBUNTU_SEED_BASIC_SPEC["ubuntu-seed-pocket"],
             UBUNTU_SEED_BASIC_SPEC["ubuntu-seed-active-kernel"],
@@ -172,9 +170,9 @@ def test_get_build_commands(ubuntu_seed_plugin, mocker, tmp_path):
         build_rootfs_patcher.assert_called_with(
             "jammy",
             "amd64",
-            UBUNTU_SEED_BASIC_SPEC["ubuntu-seed-sources"],
-            UBUNTU_SEED_BASIC_SPEC["ubuntu-seed-source-branch"],
-            UBUNTU_SEED_BASIC_SPEC["ubuntu-seed-seeds"],
+            UBUNTU_SEED_BASIC_SPEC["ubuntu-seed-germinate"].get("urls"),
+            UBUNTU_SEED_BASIC_SPEC["ubuntu-seed-germinate"].get("branch"),
+            UBUNTU_SEED_BASIC_SPEC["ubuntu-seed-germinate"].get("names"),
             UBUNTU_SEED_BASIC_SPEC["ubuntu-seed-components"],
             UBUNTU_SEED_BASIC_SPEC["ubuntu-seed-pocket"],
             UBUNTU_SEED_BASIC_SPEC["ubuntu-seed-active-kernel"],

--- a/tests/unit/plugins/test_ubuntu_seed.py
+++ b/tests/unit/plugins/test_ubuntu_seed.py
@@ -150,7 +150,7 @@ def test_get_build_commands(ubuntu_seed_plugin, mocker, tmp_path):
             UBUNTU_SEED_BASIC_SPEC["ubuntu-seed-germinate"].get("names"),
             UBUNTU_SEED_BASIC_SPEC["ubuntu-seed-components"],
             UBUNTU_SEED_BASIC_SPEC["ubuntu-seed-pocket"],
-            UBUNTU_SEED_BASIC_SPEC["ubuntu-seed-active-kernel"],
+            UBUNTU_SEED_BASIC_SPEC["ubuntu-seed-kernel"],
             UBUNTU_SEED_BASIC_SPEC["ubuntu-seed-extra-snaps"],
         )
 
@@ -175,7 +175,7 @@ def test_get_build_commands(ubuntu_seed_plugin, mocker, tmp_path):
             UBUNTU_SEED_BASIC_SPEC["ubuntu-seed-germinate"].get("names"),
             UBUNTU_SEED_BASIC_SPEC["ubuntu-seed-components"],
             UBUNTU_SEED_BASIC_SPEC["ubuntu-seed-pocket"],
-            UBUNTU_SEED_BASIC_SPEC["ubuntu-seed-active-kernel"],
+            UBUNTU_SEED_BASIC_SPEC["ubuntu-seed-kernel"],
             UBUNTU_SEED_BASIC_SPEC["ubuntu-seed-extra-snaps"],
         )
 

--- a/tests/unit/plugins/test_ubuntu_seed.py
+++ b/tests/unit/plugins/test_ubuntu_seed.py
@@ -68,10 +68,14 @@ def ubuntu_seed_plugin():
             project_dirs=project_dirs,
             plugin_properties=plugin_properties,
         )
+        project_vars = {
+            "version": "22.04",
+        }
         project_info = craft_parts.ProjectInfo(
             application_name="test",
             project_dirs=project_dirs,
             cache_dir=tmp_path,
+            project_vars=project_vars,
         )
         part_info = craft_parts.PartInfo(project_info=project_info, part=part)
 
@@ -144,6 +148,7 @@ def test_get_build_commands(ubuntu_seed_plugin, mocker, tmp_path):
 
         build_rootfs_patcher.assert_called_with(
             UBUNTU_SEED_BASIC_SPEC["ubuntu-seed-germinate"].get("branch"),
+            "22.04",
             "amd64",
             UBUNTU_SEED_BASIC_SPEC["ubuntu-seed-germinate"].get("urls"),
             UBUNTU_SEED_BASIC_SPEC["ubuntu-seed-germinate"].get("branch"),
@@ -169,6 +174,7 @@ def test_get_build_commands(ubuntu_seed_plugin, mocker, tmp_path):
 
         build_rootfs_patcher.assert_called_with(
             "jammy",
+            "22.04",
             "amd64",
             UBUNTU_SEED_BASIC_SPEC["ubuntu-seed-germinate"].get("urls"),
             UBUNTU_SEED_BASIC_SPEC["ubuntu-seed-germinate"].get("branch"),

--- a/tests/unit/services/test_lifecycle.py
+++ b/tests/unit/services/test_lifecycle.py
@@ -23,10 +23,14 @@ from craft_parts import (
 
 
 def test_lifecycle_args(
-    lifecycle_service, mocker, monkeypatch,
+    lifecycle_service,
+    mocker,
+    monkeypatch,
 ):
     mock_lifecycle = mocker.patch.object(
-        LifecycleManager, "__init__", return_value=None,
+        LifecycleManager,
+        "__init__",
+        return_value=None,
     )
 
     lifecycle_service.setup()
@@ -46,10 +50,14 @@ def test_lifecycle_args(
 
 
 def test_lifecycle_args_no_platform(
-    lifecycle_service_no_platform, mocker, monkeypatch,
+    lifecycle_service_no_platform,
+    mocker,
+    monkeypatch,
 ):
     mock_lifecycle = mocker.patch.object(
-        LifecycleManager, "__init__", return_value=None,
+        LifecycleManager,
+        "__init__",
+        return_value=None,
     )
 
     lifecycle_service_no_platform.setup()

--- a/tests/unit/services/test_lifecycle.py
+++ b/tests/unit/services/test_lifecycle.py
@@ -16,6 +16,7 @@
 
 from pathlib import Path
 
+from craft_application import util
 from craft_parts import (
     LifecycleManager,
 )
@@ -38,9 +39,32 @@ def test_lifecycle_args(
         work_dir=Path("work"),
         ignore_local_sources=[],
         platform="amd64",
-        base=None,
-
+        base="ubuntu@22.04",
         project_name="default",
         project_vars={"version": "1.0"},
     )
 
+
+def test_lifecycle_args_no_platform(
+    lifecycle_service_no_platform, mocker, monkeypatch,
+):
+    mock_lifecycle = mocker.patch.object(
+        LifecycleManager, "__init__", return_value=None,
+    )
+
+    lifecycle_service_no_platform.setup()
+
+    mock_lifecycle.assert_called_once_with(
+        {"parts": {}},
+        application_name="imagecraft",
+        arch="x86_64",
+        cache_dir=Path("cache"),
+        work_dir=Path("work"),
+        ignore_local_sources=[],
+        platform=None,
+        base="ubuntu@22.04",
+        project_name="default",
+        project_vars={"version": "1.0"},
+    )
+
+    assert lifecycle_service_no_platform._platform == util.get_host_architecture()

--- a/tests/unit/services/test_lifecycle.py
+++ b/tests/unit/services/test_lifecycle.py
@@ -1,0 +1,46 @@
+# This file is part of imagecraft.
+#
+# Copyright (C) 2022 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from pathlib import Path
+
+from craft_parts import (
+    LifecycleManager,
+)
+
+
+def test_lifecycle_args(
+    lifecycle_service, mocker, monkeypatch,
+):
+    mock_lifecycle = mocker.patch.object(
+        LifecycleManager, "__init__", return_value=None,
+    )
+
+    lifecycle_service.setup()
+
+    mock_lifecycle.assert_called_once_with(
+        {"parts": {}},
+        application_name="imagecraft",
+        arch="x86_64",
+        cache_dir=Path("cache"),
+        work_dir=Path("work"),
+        ignore_local_sources=[],
+        platform="amd64",
+        base=None,
+
+        project_name="default",
+        project_vars={"version": "1.0"},
+    )
+

--- a/tests/unit/services/test_pack.py
+++ b/tests/unit/services/test_pack.py
@@ -1,0 +1,37 @@
+# Copyright 2023 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+from pathlib import Path
+
+from imagecraft.services import pack
+from imagecraft.services.pack import pathlib
+
+
+def test_pack(pack_service, default_factory, mocker):
+    mock_inner_ubuntu_image_pack = mocker.patch.object(pack, "ubuntu_image_pack")
+
+    mocker.patch.object(pathlib.Path, "mkdir", return_value=True)
+
+    prime = "prime"
+    prime_dir=Path(prime)
+    dest_path = Path()
+
+    pack_service.pack(prime_dir, dest=dest_path)
+
+    # Check that ubuntu_image_pack() was called with the correct
+    # parameters.
+    mock_inner_ubuntu_image_pack.assert_called_once_with(
+        prime,
+        "$CRAFT_PART_INSTALL/install",
+        str(dest_path),
+    )

--- a/tests/unit/services/test_pack.py
+++ b/tests/unit/services/test_pack.py
@@ -23,7 +23,7 @@ def test_pack(pack_service, default_factory, mocker):
     mocker.patch.object(pathlib.Path, "mkdir", return_value=True)
 
     prime = "prime"
-    prime_dir=Path(prime)
+    prime_dir = Path(prime)
     dest_path = Path()
 
     pack_service.pack(prime_dir, dest=dest_path)

--- a/tests/unit/test_application.py
+++ b/tests/unit/test_application.py
@@ -30,14 +30,15 @@ parts:
     source-branch: classic
   rootfs:
     plugin: ubuntu-seed
-    ubuntu-seed-sources:
-      - "git://git.launchpad.net/~ubuntu-core-dev/ubuntu-seeds/+git/"
-    ubuntu-seed-source-branch: jammy
-    ubuntu-seed-seeds:
-      - server
-      - minimal
-      - standard
-      - cloud-image
+    ubuntu-seed-germinate:
+      urls:
+        - "git://git.launchpad.net/~ubuntu-core-dev/ubuntu-seeds/+git/"
+      branch: jammy
+      names:
+        - server
+        - minimal
+        - standard
+        - cloud-image
     ubuntu-seed-components:
       - main
       - restricted
@@ -60,14 +61,15 @@ platforms:
 parts:
   rootfs:
     plugin: ubuntu-seed
-    ubuntu-seed-sources:
-      - "git://git.launchpad.net/~ubuntu-core-dev/ubuntu-seeds/+git/"
-    ubuntu-seed-source-branch: jammy
-    ubuntu-seed-seeds:
-      - server
-      - minimal
-      - standard
-      - cloud-image
+    ubuntu-seed-germinate:
+      names:
+        - server
+        - minimal
+        - standard
+        - cloud-image
+      urls:
+        - "git://git.launchpad.net/~ubuntu-core-dev/ubuntu-seeds/+git/"
+      branch: jammy
     ubuntu-seed-components:
       - main
       - restricted
@@ -95,4 +97,4 @@ def test_application_no_gadget(default_application, new_dir):
 
     project = default_application.project
 
-    assert project.parts["rootfs"].get("ubuntu-seed-source-branch") == "jammy"
+    assert project.parts["rootfs"].get("ubuntu-seed-germinate").get("branch") == "jammy"

--- a/tests/unit/test_application.py
+++ b/tests/unit/test_application.py
@@ -44,7 +44,7 @@ parts:
       - restricted
     ubuntu-seed-pocket: updates
     ubuntu-seed-extra-snaps: [core20, snapd]
-    ubuntu-seed-active-kernel: linux-generic
+    ubuntu-seed-kernel: linux-generic
     stage:
       - -etc/cloud/cloud.cfg.d/90_dpkg.cfg
 """
@@ -75,7 +75,7 @@ parts:
       - restricted
     ubuntu-seed-pocket: updates
     ubuntu-seed-extra-snaps: [core20, snapd]
-    ubuntu-seed-active-kernel: linux-generic
+    ubuntu-seed-kernel: linux-generic
 """
 
 

--- a/tests/unit/test_ubuntu_image.py
+++ b/tests/unit/test_ubuntu_image.py
@@ -29,6 +29,7 @@ def test_generate_legacy_def_rootfs():
     assert (
         generate_legacy_def_rootfs(
             series="mantic",
+            revision="22.04",
             arch="amd64",
             sources=["source1", "source2"],
             seed_branch="mantic",
@@ -37,36 +38,82 @@ def test_generate_legacy_def_rootfs():
             pocket="updates",
             kernel="linux-image-generic",
             extra_snaps=["lxd", "snapd"],
+            extra_packages=["apt", "dpkg"],
         )
-        == """
-name: craft-driver
+        == """name: craft-driver
 display-name: Craft Driver
-revision: 1
+revision: '22.04'
 class: preinstalled
 architecture: amd64
 series: mantic
 kernel: linux-image-generic
-
 rootfs:
-  components: [main, restricted]
+  components:
+  - main
+  - restricted
   seed:
-    urls: ["source1", "source2"]
+    urls:
+    - source1
+    - source2
     branch: mantic
-    names: ["server", "minimal"]
+    names:
+    - server
+    - minimal
     pocket: updates
-
-
 customization:
   extra-snaps:
-    - name: lxd
-    - name: snapd
-
+  - name: lxd
+  - name: snapd
+  extra-packages:
+  - name: apt
+  - name: dpkg
 """
     )
 
     assert (
         generate_legacy_def_rootfs(
             series="mantic",
+            revision="22.04",
+            arch="amd64",
+            sources=["source1", "source2"],
+            seed_branch="mantic",
+            seeds=["server", "minimal"],
+            components_list=["main", "restricted"],
+            pocket="updates",
+            kernel="linux-image-generic",
+            extra_packages=["apt", "dpkg"],
+        )
+        == """name: craft-driver
+display-name: Craft Driver
+revision: '22.04'
+class: preinstalled
+architecture: amd64
+series: mantic
+kernel: linux-image-generic
+rootfs:
+  components:
+  - main
+  - restricted
+  seed:
+    urls:
+    - source1
+    - source2
+    branch: mantic
+    names:
+    - server
+    - minimal
+    pocket: updates
+customization:
+  extra-packages:
+  - name: apt
+  - name: dpkg
+"""
+    )
+
+    assert (
+        generate_legacy_def_rootfs(
+            series="mantic",
+            revision="22.04",
             arch="amd64",
             sources=[],
             seed_branch="mantic",
@@ -75,15 +122,12 @@ customization:
             pocket="updates",
             extra_snaps=[],
         )
-        == """
-name: craft-driver
+        == """name: craft-driver
 display-name: Craft Driver
-revision: 1
+revision: '22.04'
 class: preinstalled
 architecture: amd64
 series: mantic
-
-
 rootfs:
   components: []
   seed:
@@ -91,8 +135,6 @@ rootfs:
     branch: mantic
     names: []
     pocket: updates
-
-
 """
     )
 
@@ -105,6 +147,7 @@ def test_ubuntu_image_cmds_build_rootfs(mocker):
 
     assert ubuntu_image_cmds_build_rootfs(
         series="mantic",
+        version="22.04",
         arch="amd64",
         sources=["source1", "source2"],
         seed_branch="mantic",
@@ -132,7 +175,7 @@ def test_ubuntu_image_pack(mocker):
 
     subprocess_patcher.assert_called_with(
         [
-            "./ubuntu-image",
+            "ubuntu-image",
             "pack",
             "--gadget-dir",
             "gadget/test",
@@ -153,7 +196,7 @@ def test_ubuntu_image_pack(mocker):
 
     subprocess_patcher.assert_called_with(
         [
-            "./ubuntu-image",
+            "ubuntu-image",
             "pack",
             "--gadget-dir",
             "gadget/test",

--- a/tests/unit/test_ubuntu_image.py
+++ b/tests/unit/test_ubuntu_image.py
@@ -19,15 +19,15 @@ import subprocess
 import pytest
 from imagecraft.errors import UbuntuImageError
 from imagecraft.ubuntu_image import (
-    generate_legacy_def_rootfs,
+    generate_image_def_yaml,
     ubuntu_image_cmds_build_rootfs,
     ubuntu_image_pack,
 )
 
 
-def test_generate_legacy_def_rootfs():
+def test_generate_image_def_yaml():
     assert (
-        generate_legacy_def_rootfs(
+        generate_image_def_yaml(
             series="mantic",
             revision="22.04",
             arch="amd64",
@@ -71,7 +71,7 @@ customization:
     )
 
     assert (
-        generate_legacy_def_rootfs(
+        generate_image_def_yaml(
             series="mantic",
             revision="22.04",
             arch="amd64",
@@ -111,7 +111,7 @@ customization:
     )
 
     assert (
-        generate_legacy_def_rootfs(
+        generate_image_def_yaml(
             series="mantic",
             revision="22.04",
             arch="amd64",
@@ -141,7 +141,7 @@ rootfs:
 
 def test_ubuntu_image_cmds_build_rootfs(mocker):
     mocker.patch(
-        "imagecraft.ubuntu_image.generate_legacy_def_rootfs",
+        "imagecraft.ubuntu_image.generate_image_def_yaml",
         return_value="test",
     )
 


### PR DESCRIPTION
Get the current proposition of the YAML configuration file supported in the current imagecraft PoC. Specific fields needing rework in other libs (ex. `package-repositories`) are excluded.

Fixes: FR-7199
