### PR TITLE
Rename the UbuntuSeed plugin as UbuntuBootstrap

### DIFF
--- a/docs/howto/code/basic_imagecraft.yaml
+++ b/docs/howto/code/basic_imagecraft.yaml
@@ -20,9 +20,9 @@ parts:
     source: https://github.com/snapcore/pc-gadget.git
     source-branch: classic
   rootfs:
-    plugin: ubuntu-seed
-    ubuntu-seed-pocket: updates
-    ubuntu-seed-germinate:
+    plugin: ubuntu-bootstrap
+    ubuntu-bootstrap-pocket: updates
+    ubuntu-bootstrap-germinate:
       urls:
         - "git://git.launchpad.net/~ubuntu-core-dev/ubuntu-seeds/+git/"
       branch: noble
@@ -32,8 +32,8 @@ parts:
         - minimal
         - standard
         - cloud-image
-    ubuntu-seed-kernel: linux-image-generic
-    ubuntu-seed-extra-snaps: [snapd]
+    ubuntu-bootstrap-kernel: linux-image-generic
+    ubuntu-bootstrap-extra-snaps: [snapd]
     stage:
       - -rootfs/etc/cloud/cloud.cfg.d/90_dpkg.cfg
       - -rootfs/dev/stderr  # workaround until u-i cleans it

--- a/docs/reference/code/example/imagecraft.yaml
+++ b/docs/reference/code/example/imagecraft.yaml
@@ -20,9 +20,9 @@ parts:
     source: https://github.com/snapcore/pc-gadget.git
     source-branch: classic
   rootfs:
-    plugin: ubuntu-seed
-    ubuntu-seed-pocket: updates
-    ubuntu-seed-germinate:
+    plugin: ubuntu-bootstrap
+    ubuntu-bootstrap-pocket: updates
+    ubuntu-bootstrap-germinate:
       urls:
         - "git://git.launchpad.net/~ubuntu-core-dev/ubuntu-seeds/+git/"
       branch: noble
@@ -32,8 +32,8 @@ parts:
         - minimal
         - standard
         - cloud-image
-    ubuntu-seed-kernel: linux-image-generic
-    ubuntu-seed-extra-snaps: [snapd]
+    ubuntu-bootstrap-kernel: linux-image-generic
+    ubuntu-bootstrap-extra-snaps: [snapd]
     stage:
       - -rootfs/etc/cloud/cloud.cfg.d/90_dpkg.cfg
   cloud-init:

--- a/docs/reference/plugins.rst
+++ b/docs/reference/plugins.rst
@@ -11,4 +11,4 @@ Imagecraft.
    :maxdepth: 1
 
    plugins/gadget_plugin
-   plugins/ubuntu_seed_plugin
+   plugins/ubuntu_bootstrap_plugin

--- a/docs/reference/plugins/ubuntu_bootstrap_plugin.rst
+++ b/docs/reference/plugins/ubuntu_bootstrap_plugin.rst
@@ -1,7 +1,7 @@
-Ubuntu Seed plugin
-==================
+Ubuntu Bootstrap plugin
+=======================
 
-The Ubuntu Seed plugin can be used to build define needed information to build a rootfs via ubuntu-image.
+The Ubuntu Bootstrap plugin can be used to build define needed information to build a rootfs via ubuntu-image.
 
 Keywords
 --------
@@ -11,8 +11,8 @@ This plugin uses the common :ref:`plugin <part-properties-plugin>` keywords.
 Additionally, this plugin provides the plugin-specific keywords defined in the
 following sections.
 
-ubuntu_seed_pocket
-~~~~~~~~~~~~~~~~~~
+ubuntu_bootstrap_pocket
+~~~~~~~~~~~~~~~~~~~~~~~
 **Type:** string
 
 **Default value:** "updates"
@@ -20,29 +20,29 @@ ubuntu_seed_pocket
 Pocket to use when configuring the sources list.
 
 
-ubuntu_seed_extra_snaps
-~~~~~~~~~~~~~~~~~~~~~~~
+ubuntu_bootstrap_extra_snaps
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 **Type:** list of strings
 
 List of snaps to add to the resulting image.
 
 
-ubuntu_seed_extra_packages
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+ubuntu_bootstrap_extra_packages
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 **Type:** list of strings
 
 List of packages to add to the resulting image.
 
-ubuntu_seed_kernel
-~~~~~~~~~~~~~~~~~~
+ubuntu_bootstrap_kernel
+~~~~~~~~~~~~~~~~~~~~~~~
 **Type:** string
 
 
 Kernel package to install explicitly.
 
 
-ubuntu_seed_germinate
-~~~~~~~~~~~~~~~~~~~~~
+ubuntu_bootstrap_germinate
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 **Type:** GerminateProperties
 
 
@@ -82,9 +82,9 @@ Example
 .. code-block:: yaml
     
   rootfs:
-    plugin: ubuntu-seed
-    ubuntu-seed-pocket: updates
-    ubuntu-seed-germinate:
+    plugin: ubuntu-bootstrap
+    ubuntu-bootstrap-pocket: updates
+    ubuntu-bootstrap-germinate:
       urls:
         - "git://git.launchpad.net/~ubuntu-core-dev/ubuntu-seeds/+git/"
       branch: jammy
@@ -93,6 +93,6 @@ Example
         - server
         - minimal
         - standard
-    ubuntu-seed-kernel: linux-image-generic
-    ubuntu-seed-extra-snaps: [core20, snapd]
-    ubuntu-seed-extra-packages: [hello-ubuntu-image-public]
+    ubuntu-bootstrap-kernel: linux-image-generic
+    ubuntu-bootstrap-extra-snaps: [core20, snapd]
+    ubuntu-bootstrap-extra-packages: [hello-ubuntu-image-public]

--- a/imagecraft/plugins/_setup.py
+++ b/imagecraft/plugins/_setup.py
@@ -16,7 +16,7 @@
 
 from craft_parts import plugins
 
-from imagecraft.plugins import gadget, ubuntu_seed
+from imagecraft.plugins import gadget, ubuntu_bootstrap
 
 
 def setup_plugins() -> None:
@@ -24,6 +24,6 @@ def setup_plugins() -> None:
     plugins.register(
         {
             "gadget": gadget.GadgetPlugin,
-            "ubuntu-seed": ubuntu_seed.UbuntuSeedPlugin,
+            "ubuntu-bootstrap": ubuntu_bootstrap.UbuntuBootstrapPlugin,
         },
     )

--- a/imagecraft/plugins/ubuntu_bootstrap.py
+++ b/imagecraft/plugins/ubuntu_bootstrap.py
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License along
 # with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""UbuntuSeed plugin."""
+"""UbuntuBootstrap plugin."""
 
 from typing import TYPE_CHECKING, Any, Self, cast
 
@@ -42,21 +42,21 @@ else:
     UniqueUrlList = conlist(AnyUrl, unique_items=True, min_items=1)
 
 class GerminateProperties(plugins.PluginProperties):
-    """Supported attributes for the 'Germinate' section of the UbuntuSeedPlugin plugin."""
+    """Supported attributes for the 'Germinate' section of the UbuntuBootstrapPlugin plugin."""
 
     urls: UniqueUrlList
     branch: str | None
     names: UniqueStrList
     vcs: bool | None = True
 
-class UbuntuSeedPluginProperties(plugins.PluginProperties):
-    """Supported attributes for the 'UbuntuSeedPlugin' plugin."""
+class UbuntuBootstrapPluginProperties(plugins.PluginProperties):
+    """Supported attributes for the 'UbuntuBootstrapPlugin' plugin."""
 
-    ubuntu_seed_pocket: str = "updates"
-    ubuntu_seed_germinate: GerminateProperties
-    ubuntu_seed_extra_snaps: UniqueStrList | None = None
-    ubuntu_seed_extra_packages: UniqueStrList | None = None
-    ubuntu_seed_kernel: str | None = None
+    ubuntu_bootstrap_pocket: str = "updates"
+    ubuntu_bootstrap_germinate: GerminateProperties
+    ubuntu_bootstrap_extra_snaps: UniqueStrList | None = None
+    ubuntu_bootstrap_extra_packages: UniqueStrList | None = None
+    ubuntu_bootstrap_kernel: str | None = None
 
     @classmethod
     def unmarshal(cls, data: dict[str, Any]) -> Self:
@@ -69,15 +69,15 @@ class UbuntuSeedPluginProperties(plugins.PluginProperties):
         :raise pydantic.ValidationError: If validation fails.
         """
         plugin_data = plugins.base.extract_plugin_properties(
-            data, plugin_name="ubuntu-seed",
+            data, plugin_name="ubuntu-bootstrap",
         )
         return cls(**plugin_data)
 
 
-class UbuntuSeedPlugin(plugins.Plugin):
+class UbuntuBootstrapPlugin(plugins.Plugin):
     """Builds a rootfs via ubuntu-image."""
 
-    properties_class = UbuntuSeedPluginProperties
+    properties_class = UbuntuBootstrapPluginProperties
 
     def get_build_snaps(self) -> set[str]:
         """Return a set of required snaps to install in the build environment."""
@@ -93,14 +93,14 @@ class UbuntuSeedPlugin(plugins.Plugin):
 
     def get_build_commands(self) -> list[str]:
         """Return a list of commands to run during the build step."""
-        options = cast(UbuntuSeedPluginProperties, self._options)
+        options = cast(UbuntuBootstrapPluginProperties, self._options)
 
         arch = self._part_info.target_arch
 
         series = self._part_info.project_info.series
 
         source_branch = series
-        branch = options.ubuntu_seed_germinate.branch
+        branch = options.ubuntu_bootstrap_germinate.branch
         if branch:
             source_branch = branch
 
@@ -120,16 +120,16 @@ class UbuntuSeedPlugin(plugins.Plugin):
             series,
             arch,
             main_repo.pocket.value,
-            options.ubuntu_seed_germinate.urls,
+            options.ubuntu_bootstrap_germinate.urls,
             source_branch,
-            options.ubuntu_seed_germinate.names,
+            options.ubuntu_bootstrap_germinate.names,
             main_repo.components,
             main_repo.flavor,
             main_repo.url,
-            options.ubuntu_seed_pocket,
-            options.ubuntu_seed_kernel,
-            options.ubuntu_seed_extra_snaps,
-            options.ubuntu_seed_extra_packages,
+            options.ubuntu_bootstrap_pocket,
+            options.ubuntu_bootstrap_kernel,
+            options.ubuntu_bootstrap_extra_snaps,
+            options.ubuntu_bootstrap_extra_packages,
             custom_components,
             custom_pocket,
             debug=debug,

--- a/tests/spread/amd64/classic/ubuntu_server_pc_amd64/imagecraft.yaml
+++ b/tests/spread/amd64/classic/ubuntu_server_pc_amd64/imagecraft.yaml
@@ -20,9 +20,9 @@ parts:
     source: https://github.com/snapcore/pc-gadget.git
     source-branch: classic
   rootfs:
-    plugin: ubuntu-seed
-    ubuntu-seed-pocket: updates
-    ubuntu-seed-germinate:
+    plugin: ubuntu-bootstrap
+    ubuntu-bootstrap-pocket: updates
+    ubuntu-bootstrap-germinate:
       urls:
         - "git://git.launchpad.net/~ubuntu-core-dev/ubuntu-seeds/+git/"
       branch: noble
@@ -32,8 +32,8 @@ parts:
         - minimal
         - standard
         - cloud-image
-    ubuntu-seed-kernel: linux-image-generic
-    ubuntu-seed-extra-snaps: [snapd]
+    ubuntu-bootstrap-kernel: linux-image-generic
+    ubuntu-bootstrap-extra-snaps: [snapd]
     stage:
       - -rootfs/etc/cloud/cloud.cfg.d/90_dpkg.cfg
       - -rootfs/dev/stderr  # workaround until u-i cleans it

--- a/tests/spread/amd64/classic/ubuntu_server_pc_arm64/imagecraft.yaml
+++ b/tests/spread/amd64/classic/ubuntu_server_pc_arm64/imagecraft.yaml
@@ -20,9 +20,9 @@ parts:
     source: https://github.com/snapcore/pc-gadget.git
     source-branch: classic
   rootfs:
-    plugin: ubuntu-seed
-    ubuntu-seed-pocket: updates
-    ubuntu-seed-germinate:
+    plugin: ubuntu-bootstrap
+    ubuntu-bootstrap-pocket: updates
+    ubuntu-bootstrap-germinate:
       urls:
         - "git://git.launchpad.net/~ubuntu-core-dev/ubuntu-seeds/+git/"
       branch: noble
@@ -32,9 +32,9 @@ parts:
         - minimal
         - standard
         - cloud-image
-    ubuntu-seed-kernel: linux-image-generic
-    ubuntu-seed-extra-snaps: [snapd]
-    ubuntu-seed-extra-packages: [grub-efi-arm64-signed, shim-signed, grub2-common]
+    ubuntu-bootstrap-kernel: linux-image-generic
+    ubuntu-bootstrap-extra-snaps: [snapd]
+    ubuntu-bootstrap-extra-packages: [grub-efi-arm64-signed, shim-signed, grub2-common]
     stage:
       - -rootfs/etc/cloud/cloud.cfg.d/90_dpkg.cfg
       - -rootfs/dev/stderr  # workaround until u-i cleans it

--- a/tests/unit/models/test_project.py
+++ b/tests/unit/models/test_project.py
@@ -60,8 +60,8 @@ parts:
     source: https://github.com/snapcore/pc-gadget.git
     source-branch: classic
   rootfs:
-    plugin: ubuntu-seed
-    ubuntu-seed-germinate:
+    plugin: ubuntu-bootstrap
+    ubuntu-bootstrap-germinate:
       urls:
         - "git://git.launchpad.net/~ubuntu-core-dev/ubuntu-seeds/+git/"
       branch: jammy
@@ -70,9 +70,9 @@ parts:
         - minimal
         - standard
         - cloud-image
-    ubuntu-seed-pocket: updates
-    ubuntu-seed-extra-snaps: [core20, snapd]
-    ubuntu-seed-kernel: linux-generic
+    ubuntu-bootstrap-pocket: updates
+    ubuntu-bootstrap-extra-snaps: [core20, snapd]
+    ubuntu-bootstrap-kernel: linux-generic
     stage:
       - -etc/cloud/cloud.cfg.d/90_dpkg.cfg
 """

--- a/tests/unit/plugins/test_ubuntu_bootstrap.py
+++ b/tests/unit/plugins/test_ubuntu_bootstrap.py
@@ -26,15 +26,15 @@ from imagecraft.models.package_repository import (
     PackageRepositoryApt,
     UsedForEnum,
 )
-from imagecraft.plugins import ubuntu_seed
+from imagecraft.plugins import ubuntu_bootstrap
 
-UBUNTU_SEED_BASIC_SPEC = {
-    "plugin": "ubuntu-seed",
-    "ubuntu-seed-pocket": "updates",
-    "ubuntu-seed-extra-snaps": ["core20", "snapd"],
-    "ubuntu-seed-extra-packages": ["apt"],
-    "ubuntu-seed-kernel": "linux-generic",
-    "ubuntu-seed-germinate": {
+UBUNTU_BOOTSTRAP_BASIC_SPEC = {
+    "plugin": "ubuntu-bootstrap",
+    "ubuntu-bootstrap-pocket": "updates",
+    "ubuntu-bootstrap-extra-snaps": ["core20", "snapd"],
+    "ubuntu-bootstrap-extra-packages": ["apt"],
+    "ubuntu-bootstrap-kernel": "linux-generic",
+    "ubuntu-bootstrap-germinate": {
         "urls": ["git://git.launchpad.net/~ubuntu-core-dev/ubuntu-seeds/+git/"],
         "branch": "jammy",
         "names": ["server", "minimal", "standard", "cloud-image"],
@@ -42,13 +42,13 @@ UBUNTU_SEED_BASIC_SPEC = {
 }
 
 
-UBUNTU_SEED_NO_SOURCE_BRANCH = {
-    "plugin": "ubuntu-seed",
-    "ubuntu-seed-pocket": "updates",
-    "ubuntu-seed-extra-snaps": ["core20", "snapd"],
-    "ubuntu-seed-extra-packages": ["apt"],
-    "ubuntu-seed-kernel": "linux-generic",
-    "ubuntu-seed-germinate": {
+UBUNTU_BOOTSTRAP_NO_SOURCE_BRANCH = {
+    "plugin": "ubuntu-bootstrap",
+    "ubuntu-bootstrap-pocket": "updates",
+    "ubuntu-bootstrap-extra-snaps": ["core20", "snapd"],
+    "ubuntu-bootstrap-extra-packages": ["apt"],
+    "ubuntu-bootstrap-kernel": "linux-generic",
+    "ubuntu-bootstrap-germinate": {
         "urls": ["git://git.launchpad.net/~ubuntu-core-dev/ubuntu-seeds/+git/"],
         "names": ["server", "minimal", "standard", "cloud-image"],
     },
@@ -56,15 +56,15 @@ UBUNTU_SEED_NO_SOURCE_BRANCH = {
 
 
 @pytest.fixture()
-def ubuntu_seed_plugin():
-    def _ubuntu_seed_plugin(spec, tmp_path):
+def ubuntu_bootstrap_plugin():
+    def _ubuntu_bootstrap_plugin(spec, tmp_path):
         project_dirs = craft_parts.ProjectDirs(work_dir=tmp_path)
-        plugin_properties = ubuntu_seed.UbuntuSeedPluginProperties.unmarshal(
+        plugin_properties = ubuntu_bootstrap.UbuntuBootstrapPluginProperties.unmarshal(
             spec,
         )
         part_spec = plugins.extract_part_properties(
             spec,
-            plugin_name="ubuntu-seed",
+            plugin_name="ubuntu-bootstrap",
         )
         part = craft_parts.Part(
             "rootfs",
@@ -105,51 +105,51 @@ def ubuntu_seed_plugin():
             properties=plugin_properties,
         )
 
-    return _ubuntu_seed_plugin
+    return _ubuntu_bootstrap_plugin
 
 
 def test_invalid_properties():
-    spec = UBUNTU_SEED_BASIC_SPEC.copy()
-    spec.update({"ubuntu-seed-something-invalid": True})
+    spec = UBUNTU_BOOTSTRAP_BASIC_SPEC.copy()
+    spec.update({"ubuntu-bootstrap-something-invalid": True})
     with pytest.raises(pydantic.ValidationError) as raised:
-        ubuntu_seed.UbuntuSeedPlugin.properties_class.unmarshal(spec)
+        ubuntu_bootstrap.UbuntuBootstrapPlugin.properties_class.unmarshal(spec)
     err = raised.value.errors()
     assert len(err) == 1
-    assert err[0]["loc"] == ("ubuntu-seed-something-invalid",)
+    assert err[0]["loc"] == ("ubuntu-bootstrap-something-invalid",)
     assert err[0]["type"] == "value_error.extra"
 
 
 def test_missing_properties():
     with pytest.raises(pydantic.ValidationError) as raised:
-        ubuntu_seed.UbuntuSeedPlugin.properties_class.unmarshal(
+        ubuntu_bootstrap.UbuntuBootstrapPlugin.properties_class.unmarshal(
             {"gadget-something-invalid": True},
         )
     err = raised.value.errors()
     assert len(err) == 1
-    assert err[0]["loc"] == ("ubuntu-seed-germinate",)
+    assert err[0]["loc"] == ("ubuntu-bootstrap-germinate",)
     assert err[0]["type"] == "value_error.missing"
 
 
-def test_get_build_snaps(ubuntu_seed_plugin, tmp_path):
-    plugin = ubuntu_seed_plugin(UBUNTU_SEED_BASIC_SPEC, tmp_path)
+def test_get_build_snaps(ubuntu_bootstrap_plugin, tmp_path):
+    plugin = ubuntu_bootstrap_plugin(UBUNTU_BOOTSTRAP_BASIC_SPEC, tmp_path)
     assert plugin.get_build_snaps() == set("ubuntu-image")
 
 
-def test_get_build_packages(ubuntu_seed_plugin, tmp_path):
-    plugin = ubuntu_seed_plugin(UBUNTU_SEED_BASIC_SPEC, tmp_path)
+def test_get_build_packages(ubuntu_bootstrap_plugin, tmp_path):
+    plugin = ubuntu_bootstrap_plugin(UBUNTU_BOOTSTRAP_BASIC_SPEC, tmp_path)
     assert plugin.get_build_packages() == set()
 
 
-def test_get_build_environment(ubuntu_seed_plugin, tmp_path):
-    plugin = ubuntu_seed_plugin(UBUNTU_SEED_BASIC_SPEC, tmp_path)
+def test_get_build_environment(ubuntu_bootstrap_plugin, tmp_path):
+    plugin = ubuntu_bootstrap_plugin(UBUNTU_BOOTSTRAP_BASIC_SPEC, tmp_path)
     assert plugin.get_build_environment() == {}
 
 
-def test_get_build_commands(ubuntu_seed_plugin, mocker, tmp_path):
-    plugin = ubuntu_seed_plugin(UBUNTU_SEED_BASIC_SPEC, tmp_path)
+def test_get_build_commands(ubuntu_bootstrap_plugin, mocker, tmp_path):
+    plugin = ubuntu_bootstrap_plugin(UBUNTU_BOOTSTRAP_BASIC_SPEC, tmp_path)
 
     with patch(
-        "imagecraft.plugins.ubuntu_seed.ubuntu_image_cmds_build_rootfs",
+        "imagecraft.plugins.ubuntu_bootstrap.ubuntu_image_cmds_build_rootfs",
         return_value=["build_rootfs_cmd1", "build_rootfs_cmd2"],
     ) as build_rootfs_patcher:
         assert plugin.get_build_commands() == [
@@ -161,27 +161,27 @@ def test_get_build_commands(ubuntu_seed_plugin, mocker, tmp_path):
             "jammy",
             "amd64",
             "release",
-            UBUNTU_SEED_BASIC_SPEC["ubuntu-seed-germinate"].get("urls"),
-            UBUNTU_SEED_BASIC_SPEC["ubuntu-seed-germinate"].get("branch"),
-            UBUNTU_SEED_BASIC_SPEC["ubuntu-seed-germinate"].get("names"),
+            UBUNTU_BOOTSTRAP_BASIC_SPEC["ubuntu-bootstrap-germinate"].get("urls"),
+            UBUNTU_BOOTSTRAP_BASIC_SPEC["ubuntu-bootstrap-germinate"].get("branch"),
+            UBUNTU_BOOTSTRAP_BASIC_SPEC["ubuntu-bootstrap-germinate"].get("names"),
             ["main", "restricted"],
             "ubuntu",
             "http://archive.ubuntu.com/ubuntu/",
-            UBUNTU_SEED_BASIC_SPEC["ubuntu-seed-pocket"],
-            UBUNTU_SEED_BASIC_SPEC["ubuntu-seed-kernel"],
-            UBUNTU_SEED_BASIC_SPEC["ubuntu-seed-extra-snaps"],
-            UBUNTU_SEED_BASIC_SPEC["ubuntu-seed-extra-packages"],
+            UBUNTU_BOOTSTRAP_BASIC_SPEC["ubuntu-bootstrap-pocket"],
+            UBUNTU_BOOTSTRAP_BASIC_SPEC["ubuntu-bootstrap-kernel"],
+            UBUNTU_BOOTSTRAP_BASIC_SPEC["ubuntu-bootstrap-extra-snaps"],
+            UBUNTU_BOOTSTRAP_BASIC_SPEC["ubuntu-bootstrap-extra-packages"],
             None,
             None,
             debug=False,
         )
 
     with patch(
-        "imagecraft.plugins.ubuntu_seed.ubuntu_image_cmds_build_rootfs",
+        "imagecraft.plugins.ubuntu_bootstrap.ubuntu_image_cmds_build_rootfs",
         return_value=["build_rootfs_cmd1", "build_rootfs_cmd2"],
     ) as build_rootfs_patcher:
         # test without source_branch
-        plugin = ubuntu_seed_plugin(UBUNTU_SEED_NO_SOURCE_BRANCH, tmp_path)
+        plugin = ubuntu_bootstrap_plugin(UBUNTU_BOOTSTRAP_NO_SOURCE_BRANCH, tmp_path)
 
         assert plugin.get_build_commands() == [
             "build_rootfs_cmd1",
@@ -192,16 +192,18 @@ def test_get_build_commands(ubuntu_seed_plugin, mocker, tmp_path):
             "jammy",
             "amd64",
             "release",
-            UBUNTU_SEED_NO_SOURCE_BRANCH["ubuntu-seed-germinate"].get("urls"),
+            UBUNTU_BOOTSTRAP_NO_SOURCE_BRANCH["ubuntu-bootstrap-germinate"].get("urls"),
             "jammy",
-            UBUNTU_SEED_NO_SOURCE_BRANCH["ubuntu-seed-germinate"].get("names"),
+            UBUNTU_BOOTSTRAP_NO_SOURCE_BRANCH["ubuntu-bootstrap-germinate"].get(
+                "names",
+            ),
             ["main", "restricted"],
             "ubuntu",
             "http://archive.ubuntu.com/ubuntu/",
-            UBUNTU_SEED_NO_SOURCE_BRANCH["ubuntu-seed-pocket"],
-            UBUNTU_SEED_NO_SOURCE_BRANCH["ubuntu-seed-kernel"],
-            UBUNTU_SEED_NO_SOURCE_BRANCH["ubuntu-seed-extra-snaps"],
-            UBUNTU_SEED_NO_SOURCE_BRANCH["ubuntu-seed-extra-packages"],
+            UBUNTU_BOOTSTRAP_NO_SOURCE_BRANCH["ubuntu-bootstrap-pocket"],
+            UBUNTU_BOOTSTRAP_NO_SOURCE_BRANCH["ubuntu-bootstrap-kernel"],
+            UBUNTU_BOOTSTRAP_NO_SOURCE_BRANCH["ubuntu-bootstrap-extra-snaps"],
+            UBUNTU_BOOTSTRAP_NO_SOURCE_BRANCH["ubuntu-bootstrap-extra-packages"],
             None,
             None,
             debug=False,
@@ -209,7 +211,7 @@ def test_get_build_commands(ubuntu_seed_plugin, mocker, tmp_path):
 
     # Test with a customization package repository
     with patch(
-        "imagecraft.plugins.ubuntu_seed.ubuntu_image_cmds_build_rootfs",
+        "imagecraft.plugins.ubuntu_bootstrap.ubuntu_image_cmds_build_rootfs",
         return_value=["build_rootfs_cmd1", "build_rootfs_cmd2"],
     ) as build_rootfs_patcher:
         plugin._part_info.project_info.package_repositories_ = [
@@ -242,16 +244,16 @@ def test_get_build_commands(ubuntu_seed_plugin, mocker, tmp_path):
             "jammy",
             "amd64",
             "release",
-            UBUNTU_SEED_BASIC_SPEC["ubuntu-seed-germinate"].get("urls"),
-            UBUNTU_SEED_BASIC_SPEC["ubuntu-seed-germinate"].get("branch"),
-            UBUNTU_SEED_BASIC_SPEC["ubuntu-seed-germinate"].get("names"),
+            UBUNTU_BOOTSTRAP_BASIC_SPEC["ubuntu-bootstrap-germinate"].get("urls"),
+            UBUNTU_BOOTSTRAP_BASIC_SPEC["ubuntu-bootstrap-germinate"].get("branch"),
+            UBUNTU_BOOTSTRAP_BASIC_SPEC["ubuntu-bootstrap-germinate"].get("names"),
             ["main", "restricted"],
             "ubuntu",
             "http://archive.ubuntu.com/ubuntu/",
-            UBUNTU_SEED_BASIC_SPEC["ubuntu-seed-pocket"],
-            UBUNTU_SEED_BASIC_SPEC["ubuntu-seed-kernel"],
-            UBUNTU_SEED_BASIC_SPEC["ubuntu-seed-extra-snaps"],
-            UBUNTU_SEED_BASIC_SPEC["ubuntu-seed-extra-packages"],
+            UBUNTU_BOOTSTRAP_BASIC_SPEC["ubuntu-bootstrap-pocket"],
+            UBUNTU_BOOTSTRAP_BASIC_SPEC["ubuntu-bootstrap-kernel"],
+            UBUNTU_BOOTSTRAP_BASIC_SPEC["ubuntu-bootstrap-extra-snaps"],
+            UBUNTU_BOOTSTRAP_BASIC_SPEC["ubuntu-bootstrap-extra-packages"],
             ["universe", "restricted"],
             "proposed",
             debug=False,

--- a/tests/unit/test_application.py
+++ b/tests/unit/test_application.py
@@ -41,8 +41,8 @@ parts:
     source: https://github.com/snapcore/pc-gadget.git
     source-branch: classic
   rootfs:
-    plugin: ubuntu-seed
-    ubuntu-seed-germinate:
+    plugin: ubuntu-bootstrap
+    ubuntu-bootstrap-germinate:
       urls:
         - "git://git.launchpad.net/~ubuntu-core-dev/ubuntu-seeds/+git/"
       branch: jammy
@@ -51,9 +51,9 @@ parts:
         - minimal
         - standard
         - cloud-image
-    ubuntu-seed-pocket: updates
-    ubuntu-seed-extra-snaps: [core20, snapd]
-    ubuntu-seed-kernel: linux-generic
+    ubuntu-bootstrap-pocket: updates
+    ubuntu-bootstrap-extra-snaps: [core20, snapd]
+    ubuntu-bootstrap-kernel: linux-generic
     stage:
       - -etc/cloud/cloud.cfg.d/90_dpkg.cfg
 """
@@ -69,8 +69,8 @@ platforms:
     build-on: [amd64]
 parts:
   rootfs:
-    plugin: ubuntu-seed
-    ubuntu-seed-germinate:
+    plugin: ubuntu-bootstrap
+    ubuntu-bootstrap-germinate:
       names:
         - server
         - minimal
@@ -79,9 +79,9 @@ parts:
       urls:
         - "git://git.launchpad.net/~ubuntu-core-dev/ubuntu-seeds/+git/"
       branch: jammy
-    ubuntu-seed-pocket: updates
-    ubuntu-seed-extra-snaps: [core20, snapd]
-    ubuntu-seed-kernel: linux-generic
+    ubuntu-bootstrap-pocket: updates
+    ubuntu-bootstrap-extra-snaps: [core20, snapd]
+    ubuntu-bootstrap-kernel: linux-generic
 """
 
 
@@ -104,4 +104,7 @@ def test_application_no_gadget(new_dir, default_application):
 
     project = default_application.project
 
-    assert project.parts["rootfs"].get("ubuntu-seed-germinate").get("branch") == "jammy"
+    assert (
+        project.parts["rootfs"].get("ubuntu-bootstrap-germinate").get("branch")
+        == "jammy"
+    )


### PR DESCRIPTION
This should avoid some confusion because various users have a different understanding of "seeding".
UbuntuBootstrap also reflects better what the plugin is doing.

Since we are doing that early in the life of the project I am not sure we should keep compatibility with the old plugin name.