### PR TITLE
chore: remove references to tox

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,5 @@
 - [ ] Have you followed the guidelines for contributing?
 - [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
-- [ ] Have you successfully run `tox`?
+- [ ] Have you successfully run `make lint && make format`?
 
 ---

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,5 @@
 - [ ] Have you followed the guidelines for contributing?
 - [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
-- [ ] Have you successfully run `make lint && make format`?
+- [ ] Have you successfully run `make lint && make test`?
 
 ---

--- a/.gitignore
+++ b/.gitignore
@@ -40,7 +40,6 @@ pip-delete-this-directory.txt
 
 # Unit test / coverage reports
 htmlcov/
-.tox/
 .nox/
 .coverage
 .coverage.*

--- a/HACKING.rst
+++ b/HACKING.rst
@@ -360,4 +360,3 @@ it includes the changes from 2.9.1.
 .. _`Renovate bot`: https://github.com/renovatebot/renovate
 .. _ruff: https://github.com/charliermarsh/ruff
 .. _ShellCheck: https://www.shellcheck.net/
-.. _tox: https://tox.wiki

--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -414,7 +414,6 @@ TimedWriter
 toml
 toolchain
 toplevel
-Tox
 txt
 TypeError
 ubuntu


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

---

I noticed tox still had some vestiges left around Imagecraft, so this is just a drive-by PR to clean up any mentions of it.