### PR TITLE
build(snap): replace external symlinks to python

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -121,6 +121,10 @@ parts:
       version="$(PYTHONPATH=$CRAFT_PART_INSTALL/lib/python3.12/site-packages "${CRAFT_STAGE}/usr/bin/python3" -c "import imagecraft;print(imagecraft.__version__)")"
       ${SNAP}/libexec/snapcraft/craftctl set version="$version"
 
+      rm $CRAFT_PART_INSTALL/bin/python*
+      ln -s ../usr/bin/python3 $CRAFT_PART_INSTALL/bin/python3
+      ln -s python3 $CRAFT_PART_INSTALL/bin/python
+
   bash-completion:
     after: [imagecraft]
     plugin: nil


### PR DESCRIPTION
- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?

---

Fixes python symlinks detected by a failure in store upload 
`package contains external symlinks: bin/python -> /build/imagecraft/stage/usr/bin/python3, bin/python3.12 -> python`

See https://launchpad.net/~canonical-starcraft/+snap/imagecraft/+build/2749540