### PR TITLE
docs: add a security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,41 +1,45 @@
 # Security policy
 
-## Release cycle
+## Imagecraft and images
 
-<!---
-The information under this header may not be strictly accurate for all applications.
-Review the wording carefully and only copy it if the support offered makes sense. If it
-seems wrong, speak with Canonical Security Engineering about refining a version for
-your application.
--->
+Imagecraft is a tool that generates system images. Images are typically composed of
+Ubuntu software and application code, and without regular maintenance and updates they
+can become vulnerable.
 
-Only the latest minor version of major versions supported in an Ubuntu LTS release
-receive security support. Backports to previous minor releases or other unsupported
-releases are made on a best-effort basis and will typically only be done for critical
-vulnerabilities.
+An image's author or maintainer is the sole party responsible for its security. Image
+authors should be diligent and keep the software inside their images up-to-date with the
+latest releases, security patches, and security measures.
 
-This support tracks the Ubuntu LTS release cycle. The most recent major version will
-always support Ubuntu LTS series still in their regular maintenance lifecycle. When a
-major imagecraft release drops support for an Ubuntu LTS series, the previous major
-release remains supported for only the dropped LTS series until the end of its extended
-support lifecycle.
+Any vulnerabilities found in an image should be reported to the image's author or
+maintainer.
 
-Once an LTS release of Ubuntu is sunset, new security fixes for this software will no
-longer be provided.
+## Build isolation
+
+In typical operation, Imagecraft makes use of tools like [LXD] and [Multipass] to create
+isolated build environments. Imagecraft itself provides no extra security, relying on
+these tools to provide secure sandboxing. The security of these build environments
+are the responsibility of these tools and should be reported to their respective
+project maintainers.
+
+Additionally, [destructive] builds are designed to give full access to the running host
+and are not isolated in any way.
+
+## Supported versions
+
+Imagecraft is still in development and has no long-term support releases. As such,
+only the latest released version is considered supported.
 
 ## Reporting a vulnerability
 
-<!---
-Replace the first link in this section with your repository's advisories board. See
-GitHub's documentation for enabling the security advisory tab on a repository:
-https://docs.github.com/en/code-security/security-advisories/working-with-repository-security-advisories/configuring-private-vulnerability-reporting-for-a-repository
--->
+To report a security issue, file a [Private Security Report] with a description of the
+issue, the steps you took to create the issue, affected versions, and, if known,
+mitigations for the issue.
 
-To report a security issue, file a [Private Security
-Report](https://github.com/canonical/imagecraft/security/advisories/new) with a
-description of the issue, the steps you took to create the issue, affected versions,
-and, if known, mitigations for the issue.
-
-The [Ubuntu Security disclosure and embargo
-policy](https://ubuntu.com/security/disclosure-policy) contains more information about
+The [Ubuntu Security disclosure and embargo policy] contains more information about
 what you can expect when you contact us and what we expect from you.
+
+[destructive]: https://documentation.ubuntu.com/imagecraft/en/stable/reference/commands/pack/#pack
+[Private Security Report]: https://github.com/canonical/imagecraft/security/advisories/new
+[LXD]: https://canonical.com/lxd
+[Multipass]: https://canonical.com/multipass
+[Ubuntu Security disclosure and embargo policy]: https://ubuntu.com/security/disclosure-policy


### PR DESCRIPTION
- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?

---

This is slightly adapted from Rockcraft's security policy. The section about release cycle was omitted on purpose and should be added once a first stable version of Imagecraft is released.

CRAFT-4277