### PR TITLE
fix: respect constraints on unit of structure size from original spec

### DIFF
--- a/docs/how-to-guides/code/basic_imagecraft.yaml
+++ b/docs/how-to-guides/code/basic_imagecraft.yaml
@@ -15,13 +15,13 @@ volumes:
         filesystem: vfat
         role: system-boot
         filesystem-label: UEFI
-        size: 256MiB
+        size: 256M
       - name: rootfs
         type: 0FC63DAF-8483-4772-8E79-3D69D8477DE4
         filesystem: ext4
         filesystem-label: writable
         role: system-data
-        size: 5GiB
+        size: 5G
 
 parts:
   # build a simple rootfs

--- a/docs/reference/code/example/imagecraft.yaml
+++ b/docs/reference/code/example/imagecraft.yaml
@@ -60,10 +60,10 @@ volumes:
         filesystem: vfat
         role: system-boot
         filesystem-label: EFI System
-        size: 256MiB
+        size: 256M
       - name: rootfs
         type: 0FC63DAF-8483-4772-8E79-3D69D8477DE4
         filesystem: ext4
         filesystem-label: writable
         role: system-data
-        size: 6GiB
+        size: 6G

--- a/docs/reference/imagecraft-yaml-file.rst
+++ b/docs/reference/imagecraft-yaml-file.rst
@@ -240,7 +240,7 @@ Size for structure item. Conforms to the IEC 80000-13 Standard.
 
     .. code-block:: yaml
 
-        size: "6GiB"
+        size: "6G"
 
 volumes.<volume>.structure.<item>.filesystem
 --------------------------------------------

--- a/imagecraft/templates/simple/imagecraft.yaml.j2
+++ b/imagecraft/templates/simple/imagecraft.yaml.j2
@@ -24,4 +24,4 @@ volumes:
               type: 0FC63DAF-8483-4772-8E79-3D69D8477DE4
               filesystem: ext4
               filesystem-label: writable
-              size: 3 GiB
+              size: 3 G

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -114,7 +114,7 @@ volumes:
         role: system-boot
         type: C12A7328-F81F-11D2-BA4B-00A0C93EC93B
         filesystem: vfat
-        size: 500MiB
+        size: 500M
 """
 
 

--- a/tests/integration/test_application.py
+++ b/tests/integration/test_application.py
@@ -59,14 +59,14 @@ volumes:
         type: C12A7328-F81F-11D2-BA4B-00A0C93EC93B
         filesystem: vfat
         filesystem-label: system-boot
-        size: 512MiB
+        size: 512M
         role: system-boot
       - name: rootfs
         type: 0FC63DAF-8483-4772-8E79-3D69D8477DE4
         filesystem: ext4
         filesystem-label: writable
         role: system-data
-        size: 512MiB
+        size: 512M
 
 """
 

--- a/tests/spread/pack/complex/imagecraft.yaml
+++ b/tests/spread/pack/complex/imagecraft.yaml
@@ -27,19 +27,19 @@ volumes:
         filesystem: vfat
         role: system-boot
         filesystem-label: EFI System
-        size: 256MiB
+        size: 256M
       - name: rootfs
         type: 0FC63DAF-8483-4772-8E79-3D69D8477DE4
         filesystem: ext4
         filesystem-label: writable
         role: system-data
-        size: 1GiB
+        size: 1G
       - name: data1
         type: 0FC63DAF-8483-4772-8E79-3D69D8477DE4
         filesystem: ext4
         filesystem-label: 1
         role: system-data
-        size: 200MB
+        size: 200M
       - name: data2
         type: 0FC63DAF-8483-4772-8E79-3D69D8477DE4
         filesystem: ext4
@@ -51,4 +51,4 @@ volumes:
         filesystem: ext3
         filesystem-label: 3
         role: system-data
-        size: 25 MiB
+        size: 25 M

--- a/tests/spread/pack/grub/imagecraft.yaml
+++ b/tests/spread/pack/grub/imagecraft.yaml
@@ -63,10 +63,10 @@ volumes:
         filesystem: vfat
         role: system-boot
         filesystem-label: EFI System
-        size: 256MiB
+        size: 256M
       - name: rootfs
         type: 0FC63DAF-8483-4772-8E79-3D69D8477DE4
         filesystem: ext4
         filesystem-label: writable
         role: system-data
-        size: 5GiB
+        size: 5G

--- a/tests/spread/pack/overlay/imagecraft.yaml
+++ b/tests/spread/pack/overlay/imagecraft.yaml
@@ -32,10 +32,10 @@ volumes:
         filesystem: vfat
         role: system-boot
         filesystem-label: EFI System
-        size: 256MiB
+        size: 256M
       - name: rootfs
         type: 0FC63DAF-8483-4772-8E79-3D69D8477DE4
         filesystem: ext4
         filesystem-label: writable
         role: system-data
-        size: 3GiB
+        size: 3G

--- a/tests/spread/pack/simple/imagecraft.yaml
+++ b/tests/spread/pack/simple/imagecraft.yaml
@@ -19,4 +19,4 @@ volumes:
         type: 0FC63DAF-8483-4772-8E79-3D69D8477DE4
         filesystem: ext4
         filesystem-label: writable
-        size: 200 MiB
+        size: 200 M

--- a/tests/unit/models/test_grammar.py
+++ b/tests/unit/models/test_grammar.py
@@ -41,7 +41,7 @@ def test_get_grammar_aware_volume_keywords():
                         "filesystem": "ext4",
                         "filesystem-label": "writable",
                         "role": "system-data",
-                        "size": "6GiB",
+                        "size": "6G",
                     },
                     {
                         "name": "rootfs",
@@ -49,7 +49,7 @@ def test_get_grammar_aware_volume_keywords():
                         "filesystem": "ext4",
                         "filesystem-label": "writable",
                         "role": "system-data",
-                        "size": "6GiB",
+                        "size": "6G",
                     },
                 ],
             }

--- a/tests/unit/models/test_project.py
+++ b/tests/unit/models/test_project.py
@@ -46,7 +46,7 @@ volumes:
         role: system-boot
         type: C12A7328-F81F-11D2-BA4B-00A0C93EC93B
         filesystem: vfat
-        size: 500 MiB
+        size: 500 M
 """
 
 IMAGECRAFT_YAML_SIMPLE_PLATFORM = """
@@ -70,7 +70,7 @@ volumes:
         role: system-boot
         type: C12A7328-F81F-11D2-BA4B-00A0C93EC93B
         filesystem: vfat
-        size: 500 MiB
+        size: 500 M
 """
 
 IMAGECRAFT_YAML_MINIMAL_PLATFORM = """
@@ -92,7 +92,7 @@ volumes:
         role: system-boot
         type: C12A7328-F81F-11D2-BA4B-00A0C93EC93B
         filesystem: vfat
-        size: 500 MiB
+        size: 500 M
 """
 
 IMAGECRAFT_YAML_NO_BUILD_FOR_PLATFORM = """
@@ -115,7 +115,7 @@ volumes:
         role: system-boot
         type: C12A7328-F81F-11D2-BA4B-00A0C93EC93B
         filesystem: vfat
-        size: 500 MiB
+        size: 500 M
 """
 
 IMAGECRAFT_YAML_INVALID_BASE = """
@@ -138,7 +138,7 @@ volumes:
         role: system-boot
         type: C12A7328-F81F-11D2-BA4B-00A0C93EC93B
         filesystem: vfat
-        size: 500 MiB
+        size: 500 M
 """
 
 IMAGECRAFT_YAML_MISSING_BUILD_BASE = """
@@ -160,7 +160,7 @@ volumes:
         role: system-boot
         type: C12A7328-F81F-11D2-BA4B-00A0C93EC93B
         filesystem: vfat
-        size: 500 MiB
+        size: 500 M
 """
 
 pytestmark = [pytest.mark.usefixtures("enable_features")]
@@ -313,7 +313,7 @@ volumes:
         role: system-boot
         type: C12A7328-F81F-11D2-BA4B-00A0C93EC93B
         filesystem: vfat
-        size: 500MiB
+        size: 500M
   pc2:
     schema: gpt
     structure:
@@ -321,7 +321,7 @@ volumes:
         role: system-boot
         type: C12A7328-F81F-11D2-BA4B-00A0C93EC93B
         filesystem: vfat
-        size: 500MiB
+        size: 500M
 """
 
 IMAGECRAFT_YAML_INVALID_VOLUME_NAME = """
@@ -345,7 +345,7 @@ volumes:
         role: system-boot
         type: C12A7328-F81F-11D2-BA4B-00A0C93EC93B
         filesystem: vfat
-        size: 500MiB
+        size: 500M
 """
 
 

--- a/tests/unit/models/test_volume.py
+++ b/tests/unit/models/test_volume.py
@@ -50,10 +50,10 @@ def test_volume_valid():
     )
     assert volume.volume_schema == "gpt"
     assert len(volume.structure) == 3
-    assert volume.structure[0].size == 3221225472
+    assert volume.structure[0].size == 3 * 1024**3
     assert volume.structure[0].role == Role.SYSTEM_BOOT
     assert volume.structure[0].filesystem_label == "efi"
-    assert volume.structure[1].size == 6442450944
+    assert volume.structure[1].size == 6 * 1024**3
     assert volume.structure[1].filesystem_label == "boot"
     assert volume.structure[2].role == Role.SYSTEM_DATA
     assert volume.structure[2].size == 0

--- a/tests/unit/models/test_volume.py
+++ b/tests/unit/models/test_volume.py
@@ -28,7 +28,7 @@ def test_volume_valid():
                 "role": "system-boot",
                 "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
                 "filesystem": "vfat",
-                "size": "6GiB",
+                "size": "3G",
                 "filesystem-label": "",
             },
             {
@@ -50,10 +50,10 @@ def test_volume_valid():
     )
     assert volume.volume_schema == "gpt"
     assert len(volume.structure) == 3
-    assert volume.structure[0].size == 6442450944
+    assert volume.structure[0].size == 3221225472
     assert volume.structure[0].role == Role.SYSTEM_BOOT
     assert volume.structure[0].filesystem_label == "efi"
-    assert volume.structure[1].size == 6000000000
+    assert volume.structure[1].size == 6442450944
     assert volume.structure[1].filesystem_label == "boot"
     assert volume.structure[2].role == Role.SYSTEM_DATA
     assert volume.structure[2].size == 0
@@ -254,7 +254,7 @@ def test_volume_valid():
             },
         ),
         (
-            "1 validation error for Volume\nstructure.0.size\n  could not parse value and unit from byte string",
+            "1 validation error for Volume\nstructure.0.size\n  Value error, size must be expressed in bytes, optionally with M or G unit.",
             ValidationError,
             {
                 "schema": "gpt",
@@ -265,6 +265,22 @@ def test_volume_valid():
                         "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
                         "filesystem": "ext4",
                         "size": "invalid",
+                    }
+                ],
+            },
+        ),
+        (
+            "1 validation error for Volume\nstructure.0.size\n  Value error, size must be expressed in bytes, optionally with M or G unit.",
+            ValidationError,
+            {
+                "schema": "gpt",
+                "structure": [
+                    {
+                        "name": "test",
+                        "role": "system-data",
+                        "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                        "filesystem": "ext4",
+                        "size": "6GiB",
                     }
                 ],
             },

--- a/tests/unit/pack/test_diskutil.py
+++ b/tests/unit/pack/test_diskutil.py
@@ -96,17 +96,19 @@ def test_format_populate_partition(
         "imagecraft.pack.gptutil.subprocess.run",
         autospec=True,
     )
+    sector_size = 512
+    disk_size = 512000000
     diskutil.format_populate_partition(
         fstype=fstype,
         content_dir=content,
         partitionpath=imagepath,
-        disk_size=diskutil.DiskSize(bytesize=512000000, sector_size=512),
+        disk_size=diskutil.DiskSize(bytesize=disk_size, sector_size=sector_size),
         label=label,
     )
 
     create_zero_image.assert_called_with(
         imagepath=imagepath,
-        disk_size=diskutil.DiskSize(bytesize=512000000, sector_size=512),
+        disk_size=diskutil.DiskSize(bytesize=disk_size, sector_size=sector_size),
     )
 
     calls = [call(e, text=True, check=True, stdout=-1) for e in expected_values]

--- a/tests/unit/pack/test_gptutil.py
+++ b/tests/unit/pack/test_gptutil.py
@@ -30,7 +30,7 @@ def volume():
                 "role": "system-boot",
                 "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
                 "filesystem": "vfat",
-                "size": "6GiB",
+                "size": "6G",
                 "filesystem-label": "",
             },
             {
@@ -120,7 +120,7 @@ def test_create_empty_gpt_image(mocker, volume, tmp_path):
     )
     create_zero_image.assert_called_with(
         imagepath=imagepath,
-        disk_size=diskutil.DiskSize(bytesize=6463517184, sector_size=512),
+        disk_size=diskutil.DiskSize(bytesize=6464488448, sector_size=512),
     )
 
 

--- a/tests/unit/pack/test_gptutil.py
+++ b/tests/unit/pack/test_gptutil.py
@@ -118,9 +118,14 @@ def test_create_empty_gpt_image(mocker, volume, tmp_path):
         sector_size=512,
         layout=volume,
     )
+    bytesize = 2048 * 512 + 34 * 512 + 6 * 1024**3 + 20 * 1024**2
+    # partition reserved size +
+    # partition table size +
+    # partition 1 size +
+    # partition 2 size
     create_zero_image.assert_called_with(
         imagepath=imagepath,
-        disk_size=diskutil.DiskSize(bytesize=6464488448, sector_size=512),
+        disk_size=diskutil.DiskSize(bytesize=bytesize, sector_size=512),
     )
 
 

--- a/tests/unit/test_application.py
+++ b/tests/unit/test_application.py
@@ -39,7 +39,7 @@ volumes:
         role: system-boot
         type: C12A7328-F81F-11D2-BA4B-00A0C93EC93B
         filesystem: vfat
-        size: 500 MiB
+        size: 500 M
 """
 
 
@@ -84,19 +84,19 @@ volumes:
           role: system-boot
           type: C12A7328-F81F-11D2-BA4B-00A0C93EC93B
           filesystem: vfat
-          size: 500 MiB
+          size: 500 M
       - to riscv64:
         - name: uboot
           role: system-boot
           type: C12A7328-F81F-11D2-BA4B-00A0C93EC93B
           filesystem: vfat
-          size: 200 MiB
+          size: 200 M
       - name: rootfs
         type: 0FC63DAF-8483-4772-8E79-3D69D8477DE4
         filesystem: ext4
         filesystem-label: writable
         role: system-data
-        size: 6GiB
+        size: 6G
 """
 
 

--- a/tests/unit/test_grammar.py
+++ b/tests/unit/test_grammar.py
@@ -33,7 +33,7 @@ pc:
       filesystem: ext4
       filesystem-label: writable
       role: system-data
-      size: 6GiB
+      size: 6G
     """,
             "amd64",
             "amd64",
@@ -47,7 +47,7 @@ pc:
                             "filesystem": "ext4",
                             "filesystem-label": "writable",
                             "role": "system-data",
-                            "size": "6GiB",
+                            "size": "6G",
                         }
                     ],
                 },
@@ -63,13 +63,13 @@ pc:
         role: system-boot
         type: C12A7328-F81F-11D2-BA4B-00A0C93EC93B
         filesystem: vfat
-        size: 500 MiB
+        size: 500 M
     - name: rootfs
       type: 0FC63DAF-8483-4772-8E79-3D69D8477DE4
       filesystem: ext4
       filesystem-label: writable
       role: system-data
-      size: 6GiB
+      size: 6G
     """,
             "amd64",
             "arm64",
@@ -82,7 +82,7 @@ pc:
                             "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
                             "filesystem": "vfat",
                             "role": "system-boot",
-                            "size": "500 MiB",
+                            "size": "500 M",
                         },
                         {
                             "name": "rootfs",
@@ -90,7 +90,7 @@ pc:
                             "filesystem": "ext4",
                             "filesystem-label": "writable",
                             "role": "system-data",
-                            "size": "6GiB",
+                            "size": "6G",
                         },
                     ],
                 },
@@ -122,7 +122,7 @@ pc:
           filesystem: ext4
           filesystem-label: writable
           role: system-data
-          size: 6GiB
+          size: 6G
     - else:
     """,
             "amd64",


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint && make test`?

---

The Volumes section is a subset of the original Volumes specification. This must be respected strictly.
Keep using the ByteSize type but pre-validate the received value to enforce the stricter set of valid units and to convert it to bytes interpreted by the ByteSize type.

