### PR TITLE
Be stricter when mounting and safer when umounting

### DIFF
--- a/imagecraft/pack/chroot.py
+++ b/imagecraft/pack/chroot.py
@@ -127,14 +127,8 @@ class Chroot:
         self.path = path
         self.mounts = mounts
 
-    def _setup_chroot(self) -> None:
+    def _setup(self) -> None:
         """Chroot environment preparation."""
-        # Some images (such as cloudimgs) symlink ``/etc/resolv.conf`` to
-        # ``/run/systemd/resolve/stub-resolv.conf``. We want resolv.conf to be
-        # a regular file to bind-mount the host resolver configuration on.
-        #
-        # There's no need to restore the file to its original condition because
-        # this operation happens on a temporary filesystem layer.
         logger.debug("setup chroot: %r", self.path)
 
         for entry in self.mounts:
@@ -142,13 +136,13 @@ class Chroot:
 
         logger.debug("chroot setup complete")
 
-    def _cleanup_chroot(self) -> None:
+    def _cleanup(self) -> None:
         """Chroot environment cleanup."""
         logger.debug("cleanup chroot: %r", self.path)
         for entry in reversed(self.mounts):
             entry.umount()
 
-    def chroot(
+    def execute(
         self, target: Callable[..., str | None], *args: Any, **kwargs: Any
     ) -> Any:  # noqa: ANN401
         """Execute a callable in a chroot environment.
@@ -165,14 +159,14 @@ class Chroot:
             target=_runner, args=(self.path, child_conn, target, args, kwargs)
         )
         logger.debug("[pid=%d] set up chroot", os.getpid())
-        self._setup_chroot()
+        self._setup()
         try:
             child.start()
             res, err = parent_conn.recv()
             child.join()
         finally:
             logger.debug("[pid=%d] clean up chroot", os.getpid())
-            self._cleanup_chroot()
+            self._cleanup()
 
         if isinstance(err, str):
             raise errors.ChrootExecutionError(err)

--- a/imagecraft/pack/chroot.py
+++ b/imagecraft/pack/chroot.py
@@ -107,6 +107,7 @@ def _runner(
     logger.debug("[pid=%d] child process: target=%r", pid, target)
     try:
         logger.debug("[pid=%d] chroot to %r", pid, path)
+        os.chdir(path)
         os.chroot(path)
         res = target(*args, **kwargs)
     except Exception as exc:  # noqa: BLE001

--- a/imagecraft/pack/chroot.py
+++ b/imagecraft/pack/chroot.py
@@ -45,15 +45,12 @@ class Mount:
         relative_mountpoint: str,
         *,
         options: list[str] | None = None,
-        mountpoint: Path | None = None,
     ) -> None:
         self._fstype = fstype
         self._src = src
         self._relative_mountpoint = relative_mountpoint
         if options:
             self._options = options
-        if mountpoint:
-            self._mountpoint = mountpoint
 
     def mount(self, base_path: Path) -> None:
         """Mount the mountpoint.

--- a/imagecraft/pack/chroot.py
+++ b/imagecraft/pack/chroot.py
@@ -155,8 +155,8 @@ class Chroot:
             target=_runner, args=(self.path, child_conn, target, args, kwargs)
         )
         logger.debug("[pid=%d] set up chroot", os.getpid())
-        self._setup()
         try:
+            self._setup()
             child.start()
             res, err = parent_conn.recv()
             child.join()

--- a/imagecraft/pack/chroot.py
+++ b/imagecraft/pack/chroot.py
@@ -65,14 +65,13 @@ class Mount:
 
         self._mountpoint = base_path / self._relative_mountpoint.lstrip("/")
         pid = os.getpid()
-        # Only mount if mountpoint exists.
-        if self._mountpoint.exists():
-            logger.debug("[pid=%d] mount %r on chroot", pid, str(self._mountpoint))
-            os_utils.mount(self._src, str(self._mountpoint), *args)
-        else:
-            logger.debug(
-                "[pid=%d] mountpoint %r does not exist", pid, str(self._mountpoint)
+        if not self._mountpoint.exists():
+            raise errors.ChrootExecutionError(
+                f"mountpoint {str(self._mountpoint)} does not exist."
             )
+
+        logger.debug("[pid=%d] mount %r on chroot", pid, str(self._mountpoint))
+        os_utils.mount(self._src, str(self._mountpoint), *args)
 
     def umount(self, *, lazy: bool = False) -> None:
         """Umount the mountpoint."""

--- a/imagecraft/pack/grubutil.py
+++ b/imagecraft/pack/grubutil.py
@@ -147,7 +147,7 @@ def setup_grub(image: Image, workdir: Path, arch: str) -> None:
     chroot = Chroot(path=mount_dir, mounts=mounts)
 
     try:
-        chroot.chroot(
+        chroot.execute(
             target=_grub_install,
             grub_target=_ARCH_TO_GRUB_EFI_TARGET[arch],
             loop_dev=loop_dev,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,7 @@
 import os
 import types
 from pathlib import Path
+from unittest import mock
 
 import pytest
 from craft_application import ProjectService, ServiceFactory
@@ -86,6 +87,13 @@ def new_dir(tmpdir):
     yield tmpdir
 
     os.chdir(cwd)
+
+
+@pytest.fixture
+def mock_chroot(monkeypatch):
+    mock_fn = mock.Mock(spec=os.chroot)
+    monkeypatch.setattr(os, "chroot", mock_fn)
+    return mock_fn
 
 
 @pytest.fixture

--- a/tests/unit/pack/test_chroot.py
+++ b/tests/unit/pack/test_chroot.py
@@ -71,7 +71,7 @@ class TestChroot:
         mock_mount = mocker.patch("imagecraft.pack.chroot.os_utils.mount")
         mock_umount = mocker.patch("imagecraft.pack.chroot.os_utils.umount")
 
-        spy_process = mocker.spy(multiprocessing, "Process")
+        mock_process = mocker.patch("imagecraft.pack.chroot.multiprocessing.Process")
         new_root = Path(new_dir, "dir1")
 
         new_root.mkdir()
@@ -93,13 +93,13 @@ class TestChroot:
             str(raised.value) == f"mountpoint {new_dir}/dir1/inexistent does not exist."
         )
 
-        assert not (new_root / Path("foo.txt")).exists()
-        assert spy_process.mock_calls == [
+        assert mock_process.mock_calls == [
             call(
                 target=_runner,
                 args=(new_root, ANY, target_func, (), {"content": "content"}),
             )
         ]
+        mock_process.start.assert_not_called()
 
         assert mock_mount.mock_calls == [
             call("sys-build", f"{new_root}/existent", "-tsys"),

--- a/tests/unit/pack/test_chroot.py
+++ b/tests/unit/pack/test_chroot.py
@@ -1,0 +1,155 @@
+# Copyright 2025 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import multiprocessing
+from pathlib import Path
+from unittest.mock import ANY, call
+
+import pytest
+from imagecraft import errors
+from imagecraft.pack.chroot import Chroot, Mount, _runner
+
+
+def target_func(content: str) -> str:
+    Path("foo.txt").write_text(content)
+    return "1337"
+
+
+@pytest.mark.usefixtures("new_dir")
+class TestChroot:
+    """Fork process and execute in chroot."""
+
+    def test_chroot(self, mocker, new_dir, mock_chroot):
+        mock_mount = mocker.patch("imagecraft.pack.chroot.os_utils.mount")
+        mock_umount = mocker.patch("imagecraft.pack.chroot.os_utils.umount")
+
+        spy_process = mocker.spy(multiprocessing, "Process")
+        new_root = Path(new_dir, "dir1")
+
+        new_root.mkdir()
+        for subdir in ["etc", "proc", "sys", "dev"]:
+            Path(new_root, subdir).mkdir()
+
+        mounts: list[Mount] = [
+            Mount(fstype="proc", src="proc-build", relative_mountpoint="proc"),
+        ]
+
+        chroot = Chroot(path=new_root, mounts=mounts)
+
+        chroot.execute(
+            target=target_func,
+            content="content",
+        )
+
+        assert (new_root / Path("foo.txt")).read_text() == "content"
+        assert spy_process.mock_calls == [
+            call(
+                target=_runner,
+                args=(new_root, ANY, target_func, (), {"content": "content"}),
+            )
+        ]
+        assert mock_mount.mock_calls == [
+            call("proc-build", f"{new_root}/proc", "-tproc"),
+            call(f"{new_root}/proc", "--make-rprivate"),
+        ]
+        assert mock_umount.mock_calls == [
+            call(f"{new_root}/proc", "--recursive"),
+        ]
+
+
+@pytest.fixture
+def relative_path():
+    return "/relative"
+
+
+@pytest.fixture
+def mount_call_test1(request, new_dir, relative_path):
+    return (
+        Mount(
+            fstype=None,
+            src="/test",
+            relative_mountpoint=request.getfixturevalue("relative_path"),
+        ),
+        call(
+            "/test",
+            f"{request.getfixturevalue('new_dir')}{request.getfixturevalue('relative_path')}",
+        ),
+    )
+
+
+@pytest.fixture
+def mount_call_test2(request, new_dir, relative_path):
+    return (
+        Mount(
+            fstype="proc",
+            src="/test",
+            relative_mountpoint=request.getfixturevalue("relative_path"),
+        ),
+        call(
+            "/test",
+            f"{request.getfixturevalue('new_dir')}{request.getfixturevalue('relative_path')}",
+            "-tproc",
+        ),
+    )
+
+
+@pytest.fixture
+def mount_call_test3(request, new_dir, relative_path):
+    return (
+        Mount(
+            fstype="devpts",
+            src="devpts-build",
+            relative_mountpoint=request.getfixturevalue("relative_path"),
+            options=["-o", "nodev,nosuid"],
+        ),
+        call(
+            "devpts-build",
+            f"{request.getfixturevalue('new_dir')}{request.getfixturevalue('relative_path')}",
+            "-o",
+            "nodev,nosuid",
+            "-tdevpts",
+        ),
+    )
+
+
+@pytest.mark.usefixtures("new_dir")
+class TestMount:
+    """Handle a mounting/umounting of a directory."""
+
+    @pytest.mark.parametrize(
+        ("mount_call"),
+        [
+            "mount_call_test1",
+            "mount_call_test2",
+            "mount_call_test3",
+        ],
+    )
+    def test_mount(self, mocker, request, new_dir, relative_path, mount_call):
+        (new_dir / relative_path).mkdir()
+        mock_mount = mocker.patch("imagecraft.pack.chroot.os_utils.mount")
+        mount, received_call = request.getfixturevalue(mount_call)
+        mount.mount(base_path=new_dir)
+        assert mock_mount.mock_calls == [received_call]
+
+    def test_mount_missing_dir(self, mocker, new_dir):
+        mocker.patch("imagecraft.pack.chroot.os_utils.mount")
+
+        mount = Mount(fstype=None, src="source", relative_mountpoint="/destination")
+
+        with pytest.raises(errors.ChrootExecutionError) as raised:
+            mount.mount(base_path=new_dir / "inexistent")
+        assert (
+            str(raised.value)
+            == f"mountpoint {new_dir}/inexistent/destination does not exist."
+        )


### PR DESCRIPTION
- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?

---

- Raise an exception when the mountpoint does not exist in Mount.mount()
- Catch exceptions when calling Mount.umount() in `_cleanup` to umount as many dirs as possible from the given list.

Fixes #118 
CRAFT-4402