### PR TITLE
fix: build latest fuse-overlayfs to fix warning message

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -79,7 +79,6 @@ parts:
       - python3.12-venv
       - python3.12-minimal
       - python3-minimal
-      - fuse-overlayfs
       - mtools
       - dosfstools
       - e2fsprogs
@@ -87,7 +86,6 @@ parts:
       - coreutils
       - util-linux
     organize:
-      "usr/bin/fuse-overlayfs": "libexec/imagecraft/fuse-overlayfs"
       "usr/lib/python3/dist-packages/apt*": "lib/python3.12/site-packages/"
       "usr/sbin/sfdisk": "libexec/imagecraft/sfdisk"
       "usr/bin/mcopy": "libexec/imagecraft/mcopy"
@@ -95,6 +93,19 @@ parts:
       "usr/bin/dd": "libexec/imagecraft/dd"
       "usr/bin/truncate": "libexec/imagecraft/truncate"
       "usr/sbin/mkfs*": "libexec/imagecraft/"
+  fuse-overlayfs:
+    after: [imagecraft-libs]
+    source: https://github.com/containers/fuse-overlayfs.git
+    source-tag: v1.15
+    plugin: autotools
+    build-attributes:
+      - enable-patchelf
+    build-packages:
+      - libfuse3-dev
+    stage-packages:
+      - libfuse3-3
+    organize:
+      "fuse-overlayfs": "libexec/imagecraft/fuse-overlayfs"
   imagecraft:
     after: [imagecraft-libs, libgit2]
     source: .


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?

---

Fixes a warning message from `fuse-overlayfs` as reported [in this upstream issue](https://github.com/containers/fuse-overlayfs/issues/429) by building the latest version from source.