### PR TITLE
docs: rename 'about this doc' → 'contribute to this doc'

### DIFF
--- a/docs/contribute-to-this-documentation.rst
+++ b/docs/contribute-to-this-documentation.rst
@@ -1,7 +1,7 @@
-.. _about-this-documentation:
+.. _contribute-to-this-documentation:
 
-About this documentation
-========================
+Contribute to this documentation
+================================
 
 The documentation is Imagecraft's first-person account of itself to the world. It
 provides knowledge and guidance to people who use, study, and develop the project.
@@ -33,7 +33,7 @@ author the documentation, there are a few paths you can take:
   <https://github.com/canonical/imagecraft>`_.
 * Bring your experience and ideas to the `Starcraft Matrix space
   <https://matrix.to/#/#starcraft-development:ubuntu.com>`_.
-* Volunteer for a task in the :ref:`about-this-documentation-coda`.
+* Volunteer for a task in the :ref:`contribute-to-this-documentation-coda`.
 
 Your contributions to the project are valuable. The team sees authorship as being on
 equal footing with development.
@@ -45,7 +45,7 @@ Canonical employees in a public and visible way. Lastly, all contributors receiv
 recognition in the Imagecraft release that they work on.
 
 
-.. _about-this-documentation-coda:
+.. _contribute-to-this-documentation-coda:
 
 Canonical Open Documentation Academy
 ------------------------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,7 +10,7 @@ Imagecraft
    how-to-guides/index
    reference/index
    explanation/index
-   about-this-documentation
+   contribute-to-this-documentation
    release-notes/index
 
 ..   tutorials/index


### PR DESCRIPTION
The title is a stakeholder requirement. I didn't create a redirect, because the doc isn't public yet.

---
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint && make test`?
