### PR TITLE
docs: clean up 'imagecraft.yaml'

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -32,14 +32,6 @@ except ImportError:
 project_dir = pathlib.Path(__file__).parents[1].resolve()
 sys.path.insert(0, str(project_dir.absolute()))
 
-# Add directories to sys path to simplify kitbash arguments
-model_dir = (project_dir / "imagecraft/models").resolve()
-sys.path.append(str(model_dir.absolute()))
-
-library_dir = (project_dir / ".venv/lib/python3.12/site-packages").resolve()
-sys.path.append(str(library_dir.absolute()))
-
-
 project = "Imagecraft"
 author = "Canonical"
 

--- a/docs/reference/imagecraft-yaml-file.rst
+++ b/docs/reference/imagecraft-yaml-file.rst
@@ -16,30 +16,38 @@ essential details of how it builds.
 Top-level descriptors include the image's name, version, description, and license,
 alongside operational values such as its supported architectures and build environment.
 
-.. kitbash-field:: craft_application.models.Project name
+.. py:currentmodule:: craft_application.models.project
 
-.. kitbash-field:: craft_application.models.Project title
+.. kitbash-field:: Project name
 
-.. kitbash-field:: craft_application.models.Project version
+.. kitbash-field:: Project title
 
-.. kitbash-field:: craft_application.models.Project license
+.. kitbash-field:: Project version
 
-.. kitbash-field:: craft_application.models.Project summary
+.. kitbash-field:: Project license
 
-.. kitbash-field:: craft_application.models.Project description
+.. kitbash-field:: Project summary
 
-.. kitbash-field:: project.Project base
+.. kitbash-field:: Project description
 
-.. kitbash-field:: project.Project build_base
+.. py:currentmodule:: imagecraft.models.project
+
+.. kitbash-field:: Project base
+
+.. kitbash-field:: Project build_base
     :override-type: Literal['ubuntu@20.04', 'ubuntu@22.04', 'ubuntu@24.04']
 
-.. kitbash-field:: craft_application.models.Project platforms
+.. py:currentmodule:: craft_application.models.project
+
+.. kitbash-field:: Project platforms
     :override-type: dict[str, Platform]
 
-.. kitbash-field:: craft_application.models.Project parts
+.. kitbash-field:: Project parts
     :override-type: dict[str, Part]
 
-.. kitbash-field:: project.Project volumes
+.. py:currentmodule:: imagecraft.models.project
+
+.. kitbash-field:: Project volumes
     :override-type: dict[str, Volume]
 
 
@@ -49,72 +57,74 @@ Part keys
 The ``parts`` key and its values declare the image's :ref:`parts <explanation-parts>`
 and detail how they're built.
 
+.. py:currentmodule:: craft_parts.parts
+
 .. Main keys
 
-.. kitbash-field:: craft_parts.parts.PartSpec plugin
+.. kitbash-field:: PartSpec plugin
     :prepend-name: parts.<part-name>
 
-.. kitbash-field:: craft_parts.parts.PartSpec after
+.. kitbash-field:: PartSpec after
     :prepend-name: parts.<part-name>
 
-.. kitbash-field:: craft_parts.parts.PartSpec disable_parallel
+.. kitbash-field:: PartSpec disable_parallel
     :prepend-name: parts.<part-name>
 
 .. Pull step keys
 
-.. kitbash-field:: craft_parts.parts.PartSpec source
+.. kitbash-field:: PartSpec source
     :prepend-name: parts.<part-name>
 
-.. kitbash-field:: craft_parts.parts.PartSpec source_type
+.. kitbash-field:: PartSpec source_type
     :prepend-name: parts.<part-name>
 
-.. kitbash-field:: craft_parts.parts.PartSpec source_checksum
+.. kitbash-field:: PartSpec source_checksum
     :prepend-name: parts.<part-name>
 
-.. kitbash-field:: craft_parts.parts.PartSpec source_branch
+.. kitbash-field:: PartSpec source_branch
     :prepend-name: parts.<part-name>
 
-.. kitbash-field:: craft_parts.parts.PartSpec source_tag
+.. kitbash-field:: PartSpec source_tag
     :prepend-name: parts.<part-name>
 
-.. kitbash-field:: craft_parts.parts.PartSpec source_commit
+.. kitbash-field:: PartSpec source_commit
     :prepend-name: parts.<part-name>
 
-.. kitbash-field:: craft_parts.parts.PartSpec source_depth
+.. kitbash-field:: PartSpec source_depth
     :prepend-name: parts.<part-name>
 
-.. kitbash-field:: craft_parts.parts.PartSpec source_submodules
+.. kitbash-field:: PartSpec source_submodules
     :prepend-name: parts.<part-name>
 
-.. kitbash-field:: craft_parts.parts.PartSpec source_subdir
+.. kitbash-field:: PartSpec source_subdir
     :prepend-name: parts.<part-name>
 
-.. kitbash-field:: craft_parts.parts.PartSpec override_pull
+.. kitbash-field:: PartSpec override_pull
     :prepend-name: parts.<part-name>
 
 .. Overlay step keys
 
-.. kitbash-field:: craft_parts.parts.PartSpec overlay_files
+.. kitbash-field:: PartSpec overlay_files
     :prepend-name: parts.<part-name>
 
-.. kitbash-field:: craft_parts.parts.PartSpec overlay_packages
+.. kitbash-field:: PartSpec overlay_packages
     :prepend-name: parts.<part-name>
 
-.. kitbash-field:: craft_parts.parts.PartSpec overlay_script
+.. kitbash-field:: PartSpec overlay_script
     :prepend-name: parts.<part-name>
 
 .. Build step keys
 
-.. kitbash-field:: craft_parts.parts.PartSpec build_environment
+.. kitbash-field:: PartSpec build_environment
     :prepend-name: parts.<part-name>
 
-.. kitbash-field:: craft_parts.parts.PartSpec build_packages
+.. kitbash-field:: PartSpec build_packages
     :prepend-name: parts.<part-name>
 
-.. kitbash-field:: craft_parts.parts.PartSpec build_snaps
+.. kitbash-field:: PartSpec build_snaps
     :prepend-name: parts.<part-name>
 
-.. kitbash-field:: craft_parts.parts.PartSpec organize_files
+.. kitbash-field:: PartSpec organize_files
     :prepend-name: parts.<part-name>
     :skip-examples:
 
@@ -134,48 +144,50 @@ Source paths always reference the default partition.
     organize:
       vmlinuz-6.2.0-39-generic: (boot)/vmlinuz
 
-.. kitbash-field:: craft_parts.parts.PartSpec override_build
+.. kitbash-field:: PartSpec override_build
     :prepend-name: parts.<part-name>
 
 .. Stage step keys
 
-.. kitbash-field:: craft_parts.parts.PartSpec stage_files
+.. kitbash-field:: PartSpec stage_files
     :prepend-name: parts.<part-name>
     :override-type: list[str]
 
-.. kitbash-field:: craft_parts.parts.PartSpec stage_packages
+.. kitbash-field:: PartSpec stage_packages
     :prepend-name: parts.<part-name>
 
-.. kitbash-field:: craft_parts.parts.PartSpec stage_snaps
+.. kitbash-field:: PartSpec stage_snaps
     :prepend-name: parts.<part-name>
 
-.. kitbash-field:: craft_parts.parts.PartSpec override_stage
+.. kitbash-field:: PartSpec override_stage
     :prepend-name: parts.<part-name>
 
 .. Prime step keys
 
-.. kitbash-field:: craft_parts.parts.PartSpec prime_files
+.. kitbash-field:: PartSpec prime_files
     :prepend-name: parts.<part-name>
     :override-type: list[str]
 
-.. kitbash-field:: craft_parts.parts.PartSpec override_prime
+.. kitbash-field:: PartSpec override_prime
     :prepend-name: parts.<part-name>
 
 .. Permission keys
 
-.. kitbash-field:: craft_parts.parts.PartSpec permissions
+.. kitbash-field:: PartSpec permissions
     :prepend-name: parts.<part-name>
 
-.. kitbash-field:: craft_parts.permissions.Permissions path
+.. py:currentmodule:: craft_parts.permissions
+
+.. kitbash-field:: Permissions path
     :prepend-name: parts.<part-name>.permissions.<permission>
 
-.. kitbash-field:: craft_parts.permissions.Permissions owner
+.. kitbash-field:: Permissions owner
     :prepend-name: parts.<part-name>.permissions.<permission>
 
-.. kitbash-field:: craft_parts.permissions.Permissions group
+.. kitbash-field:: Permissions group
     :prepend-name: parts.<part-name>.permissions.<permission>
 
-.. kitbash-field:: craft_parts.permissions.Permissions mode
+.. kitbash-field:: Permissions mode
     :prepend-name: parts.<part-name>.permissions.<permission>
 
 
@@ -185,10 +197,12 @@ Volume keys
 The ``volumes`` key and its values declare the schema and layout of the image's
 partitions.
 
-.. kitbash-field:: volume.Volume volume_schema
+.. py:currentmodule:: imagecraft.models.volume
+
+.. kitbash-field:: Volume volume_schema
     :prepend-name: volumes.<volume-name>
 
-.. kitbash-field:: volume.Volume structure
+.. kitbash-field:: Volume structure
     :prepend-name: volumes.<volume-name>
     :override-type: list[Partition]
 
@@ -198,23 +212,23 @@ Partition keys
 
 The following keys can be declared for each partition listed in the ``structure`` key.
 
-.. kitbash-field:: volume.StructureItem name
+.. kitbash-field:: StructureItem name
     :prepend-name: volumes.<volume-name>.structure.<partition>
 
-.. kitbash-field:: volume.StructureItem id
+.. kitbash-field:: StructureItem id
     :prepend-name: volumes.<volume-name>.structure.<partition>
 
-.. kitbash-field:: volume.StructureItem role
+.. kitbash-field:: StructureItem role
     :prepend-name: volumes.<volume-name>.structure.<partition>
 
-.. kitbash-field:: volume.StructureItem structure_type
+.. kitbash-field:: StructureItem structure_type
     :prepend-name: volumes.<volume-name>.structure.<partition>
 
-.. kitbash-field:: volume.StructureItem size
+.. kitbash-field:: StructureItem size
     :prepend-name: volumes.<volume-name>.structure.<partition>
 
-.. kitbash-field:: volume.StructureItem filesystem
+.. kitbash-field:: StructureItem filesystem
     :prepend-name: volumes.<volume-name>.structure.<partition>
 
-.. kitbash-field:: volume.StructureItem filesystem_label
+.. kitbash-field:: StructureItem filesystem_label
     :prepend-name: volumes.<volume-name>.structure.<partition>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ types = [
 ]
 docs = [
     "canonical-sphinx[full]~=0.5.1",
-    "pydantic-kitbash==0.0.6",
+    "pydantic-kitbash==0.0.7",
     "sphinx-autobuild~=2024.2",
     "sphinx-pydantic==0.1.1",
     # sphinx-sitemap is pinned to 2.6 because https://github.com/jdillard/sphinx-sitemap/pull/95

--- a/uv.lock
+++ b/uv.lock
@@ -927,7 +927,7 @@ dev-plucky = [{ name = "python-apt", marker = "sys_platform == 'linux'", specifi
 docs = [
     { name = "canonical-sphinx", extras = ["full"], specifier = "~=0.5.1" },
     { name = "matplotlib" },
-    { name = "pydantic-kitbash", specifier = "==0.0.6" },
+    { name = "pydantic-kitbash", specifier = "==0.0.7" },
     { name = "sphinx-autobuild", specifier = "~=2024.2" },
     { name = "sphinx-lint", specifier = "==1.0.0" },
     { name = "sphinx-pydantic", specifier = "==0.1.1" },
@@ -1758,7 +1758,7 @@ wheels = [
 
 [[package]]
 name = "pydantic-kitbash"
-version = "0.0.6"
+version = "0.0.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "docutils" },
@@ -1766,9 +1766,9 @@ dependencies = [
     { name = "pyyaml" },
     { name = "sphinx" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4a/c0/48066291bb9db968d42d6419fa666be077c893d17cdca0eac44cedb2e3d1/pydantic_kitbash-0.0.6.tar.gz", hash = "sha256:60b18ce727f06b6c5a3f8db5675bb6c423449bb59832c3e04cfef4b1568a84e9", size = 124406, upload-time = "2025-07-03T19:24:33.841Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c6/b9/630281fa690b2449e70d59ce221c91d9633571c4a7c2dcd8469a59a8c7cc/pydantic_kitbash-0.0.7.tar.gz", hash = "sha256:14eda8a87401b09d746e1ad4157248d8c0d1841803bf609600143e567a687551", size = 131893, upload-time = "2025-08-01T16:26:32.107Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/46/4e/4f492ee0d832eb9d8ebd9915e35bff6fd09d658bc6fdb1f31d70495492cf/pydantic_kitbash-0.0.6-py3-none-any.whl", hash = "sha256:e16fa65ebfebe7d295e9b476641e253e02b18686e52bedc2ec65c46421d9875d", size = 13156, upload-time = "2025-07-03T19:24:32.342Z" },
+    { url = "https://files.pythonhosted.org/packages/56/05/4a05fbb8f72ae86060430e55349e1d504ee73973e9a767aeb9ecaf85a447/pydantic_kitbash-0.0.7-py3-none-any.whl", hash = "sha256:4ab60369cb8b3cbf289724df295a514bb309d2cb669d1d0c6d1eafaacf530ec5", size = 13645, upload-time = "2025-08-01T16:26:29.879Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- [X] Have you followed the guidelines for contributing?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] Have you successfully run `make lint && make test`?

---

* Update `pydantic-kitbash` to v0.0.7
* Remove library modules from `sys.path`
* Clean up 'Part Properties' by declaring ..py:currentmodule::

Once Imagecraft is updated to the next Craft Parts release, this will get rid of the Kitbash warnings in docs builds.