### PR TITLE
feat: rely on `filesystems` to prepare chroot when calling update-grub

### DIFF
--- a/imagecraft/pack/chroot.py
+++ b/imagecraft/pack/chroot.py
@@ -53,6 +53,17 @@ class Mount:
         if options:
             self._options = options
 
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Mount):
+            return False
+        return (
+            self._fstype == other._fstype
+            and self._src == other._src
+            and self._relative_mountpoint == other._relative_mountpoint
+            and self._options == other._options
+            and self._mountpoint == other._mountpoint
+        )
+
     def mount(self, base_path: Path) -> None:
         """Mount the mountpoint.
 

--- a/imagecraft/pack/image.py
+++ b/imagecraft/pack/image.py
@@ -68,19 +68,13 @@ class Image:
 
     @property
     def has_data_partition(self) -> bool:
-        """The partition number associated to the data partition of the image."""
-        for _, structure_item in enumerate(self.volume.structure):
-            if structure_item.role == Role.SYSTEM_DATA:
-                return True
-        return False
+        """Check if a data partition is present in the image."""
+        return any(s.role == Role.SYSTEM_DATA for s in self.volume.structure)
 
     @property
     def has_boot_partition(self) -> bool:
-        """The partition number associated to the boot partition of the image."""
-        for _, structure_item in enumerate(self.volume.structure):
-            if structure_item.role == Role.SYSTEM_BOOT:
-                return True
-        return False
+        """Check if a boot partition is present in the image."""
+        return any(s.role == Role.SYSTEM_BOOT for s in self.volume.structure)
 
     @contextlib.contextmanager
     def attach_loopdev(self) -> Iterator[str]:

--- a/imagecraft/pack/image.py
+++ b/imagecraft/pack/image.py
@@ -67,22 +67,20 @@ class Image:
             )
 
     @property
-    def data_partition_number(self) -> int | None:
+    def has_data_partition(self) -> bool:
         """The partition number associated to the data partition of the image."""
-        for i, structure_item in enumerate(self.volume.structure):
+        for _, structure_item in enumerate(self.volume.structure):
             if structure_item.role == Role.SYSTEM_DATA:
-                # Partition numbers start at 1, so offset the index
-                return i + 1
-        return None
+                return True
+        return False
 
     @property
-    def boot_partition_number(self) -> int | None:
+    def has_boot_partition(self) -> bool:
         """The partition number associated to the boot partition of the image."""
-        for i, structure_item in enumerate(self.volume.structure):
+        for _, structure_item in enumerate(self.volume.structure):
             if structure_item.role == Role.SYSTEM_BOOT:
-                # Partition numbers start at 1, so offset the index
-                return i + 1
-        return None
+                return True
+        return False
 
     @contextlib.contextmanager
     def attach_loopdev(self) -> Iterator[str]:

--- a/imagecraft/services/pack.py
+++ b/imagecraft/services/pack.py
@@ -92,9 +92,17 @@ class ImagecraftPackService(PackageService):
                 )
         gptutil.verify_partition_tables(disk_image_file)
 
+        filesystem_mount = self._services.get(
+            "lifecycle"
+        ).project_info.default_filesystem_mount
         image = Image(volume=volume, disk_path=disk_image_file)
         arch = self._services.get("lifecycle").project_info.target_arch
-        grubutil.setup_grub(image=image, workdir=project_dirs.work_dir, arch=arch)
+        grubutil.setup_grub(
+            image=image,
+            workdir=project_dirs.work_dir,
+            arch=arch,
+            filesystem_mount=filesystem_mount,
+        )
 
         return [disk_image_file]
 

--- a/tests/spread/pack/grub-boot-partition/imagecraft.yaml
+++ b/tests/spread/pack/grub-boot-partition/imagecraft.yaml
@@ -1,0 +1,86 @@
+name: minimal-with-grub
+version: "0.1"
+base: bare
+build-base: ubuntu@24.04
+
+platforms:
+  amd64:
+
+filesystems:
+  default:
+    - mount: /
+      device: (volume/pc/rootfs)
+    - mount: /boot/
+      device: (volume/pc/boot)
+    - mount: /boot/efi/
+      device: (volume/pc/efi)
+
+parts:
+  # build a simple rootfs
+  rootfs:
+    plugin: nil
+    build-packages: ["mmdebstrap"]
+    overlay-script: |
+      mmdebstrap --arch amd64 --mode=sudo --format=dir --variant=minbase --include=apt noble $CRAFT_OVERLAY/ http://archive.ubuntu.com/ubuntu/
+      mkdir $CRAFT_OVERLAY/boot/efi
+
+  # add packages using chroot and apt to have maintainer scripts run
+  packages:
+    plugin: nil
+    after: [rootfs]
+    overlay-script: |
+      mkdir -p $CRAFT_OVERLAY/dev $CRAFT_OVERLAY/sys $CRAFT_OVERLAY/proc
+      mount -t devtmpfs devtmpfs-build $CRAFT_OVERLAY/dev
+      mount -t devpts devpts-build -o nodev,nosuid $CRAFT_OVERLAY/dev/pts
+      mount -t sysfs sysfs-build $CRAFT_OVERLAY/sys
+      mount -t proc proc-build $CRAFT_OVERLAY/proc
+      mount --bind /run $CRAFT_OVERLAY/run
+
+      DEBIAN_FRONTEND=noninteractive chroot $CRAFT_OVERLAY apt update
+      DEBIAN_FRONTEND=noninteractive chroot $CRAFT_OVERLAY apt install --assume-yes --quiet \
+        --option=Dpkg::options::=--force-unsafe-io --option=Dpkg::Options::=--force-confold \
+        ubuntu-server-minimal grub2-common grub-pc shim-signed linux-image-generic
+
+      mount --make-rprivate $CRAFT_OVERLAY/run
+      umount --recursive $CRAFT_OVERLAY/run
+      mount --make-rprivate $CRAFT_OVERLAY/sys
+      umount --recursive $CRAFT_OVERLAY/sys
+      mount --make-rprivate $CRAFT_OVERLAY/proc
+      umount --recursive $CRAFT_OVERLAY/proc
+      mount --make-rprivate $CRAFT_OVERLAY/dev/pts
+      umount --recursive $CRAFT_OVERLAY/dev/pts
+      mount --make-rprivate $CRAFT_OVERLAY/dev
+      umount --recursive $CRAFT_OVERLAY/dev
+
+  # Define a fstab
+  fstab:
+    plugin: nil
+    after: [packages]
+    overlay-script: |
+      cat << EOF > $CRAFT_OVERLAY/etc/fstab
+      LABEL=writable	/	ext4	discard,errors=remount-ro	0	1
+      LABEL=UEFI	/boot/efi	vfat	umask=0077	0 1
+      EOF
+
+volumes:
+  pc:
+    schema: gpt
+    structure:
+      - name: efi
+        type: C12A7328-F81F-11D2-BA4B-00A0C93EC93B
+        filesystem: vfat
+        role: system-boot
+        filesystem-label: EFI System
+        size: 256M
+      - name: boot
+        type: 0FC63DAF-8483-4772-8E79-3D69D8477DE4
+        size: 750M
+        role: system-boot
+        filesystem: ext4
+        filesystem-label: BOOT
+      - name: rootfs
+        type: 0FC63DAF-8483-4772-8E79-3D69D8477DE4
+        filesystem: ext4
+        filesystem-label: writable
+        role: system-data
+        size: 5G

--- a/tests/spread/pack/grub-boot-partition/task.yaml
+++ b/tests/spread/pack/grub-boot-partition/task.yaml
@@ -1,0 +1,66 @@
+summary: Pack an image with GRUB and a dedicated boot partition
+
+systems: [ubuntu-24.04-64]
+
+execute: |
+  TMPDIR="$(mktemp -d)"
+  TMP_MOUNT=${TMPDIR}/mount
+  mkdir -p ${TMP_MOUNT}
+  echo ${TMP_MOUNT} >> tmpmount.txt
+
+  GRUB_INSTALL_LOG="Setting up GRUB in the image"
+
+  imagecraft pack --verbose --destructive-mode 2>&1 >/dev/null | MATCH "$GRUB_INSTALL_LOG"
+
+  # Check that the message was actually written to the logfile.
+  imagecraft_log_file=$(find /root/.local/state/imagecraft/log/ -name 'imagecraft*.log' | sort -n | tail -n1)
+  MATCH "$GRUB_INSTALL_LOG" "$imagecraft_log_file"
+  # Also check detailed of the installation were logged
+  MATCH "Generating grub configuration file" "$imagecraft_log_file"
+  MATCH "Adding boot menu entry for UEFI Firmware Settings" "$imagecraft_log_file"
+
+  IMG_NAME=pc.img
+  test -f ${IMG_NAME}
+
+  losetup --find --show --partscan ${IMG_NAME}
+  losetup -a | grep ${IMG_NAME} | cut -f1 -d: >> loop.txt
+  LOOP="$(cat loop.txt)"
+
+  for l in `ls -d "$LOOP"p*`
+  do
+      p=${l#"$LOOP"}
+      mkdir ${TMP_MOUNT}/$p
+      mount $l ${TMP_MOUNT}/$p || true
+  done
+
+restore: |
+  if [ -f loop.txt -a -f tmpmount.txt ]; then
+      LOOP="$(cat loop.txt)"
+      TMP_MOUNT="$(cat tmpmount.txt)"
+
+      for l in `ls -d "$LOOP"p*`
+      do
+          p=${l#"$LOOP"}
+          mount --make-rprivate ${TMP_MOUNT}/$p || true
+          umount --recursive ${TMP_MOUNT}/$p || true
+      done
+
+      losetup -d "$LOOP"
+      sync
+      losetup -l | NOMATCH "$LOOP"
+      rm loop.txt
+  fi
+  imagecraft clean --destructive-mode
+  rm -rf pc.img || true
+
+debug: |
+  df -h
+  du -h -d 1 /tmp/
+  mount  -l
+  if [ -f loop.txt ]; then
+      cat loop.txt
+  fi
+  if [ -f tmpmount.txt ]; then
+      cat loop.txt
+  fi
+  losetup -l

--- a/tests/spread/pack/grub-boot-partition/task.yaml
+++ b/tests/spread/pack/grub-boot-partition/task.yaml
@@ -3,11 +3,6 @@ summary: Pack an image with GRUB and a dedicated boot partition
 systems: [ubuntu-24.04-64]
 
 execute: |
-  TMPDIR="$(mktemp -d)"
-  TMP_MOUNT=${TMPDIR}/mount
-  mkdir -p ${TMP_MOUNT}
-  echo ${TMP_MOUNT} >> tmpmount.txt
-
   GRUB_INSTALL_LOG="Setting up GRUB in the image"
 
   imagecraft pack --verbose --destructive-mode 2>&1 >/dev/null | MATCH "$GRUB_INSTALL_LOG"
@@ -19,48 +14,11 @@ execute: |
   MATCH "Generating grub configuration file" "$imagecraft_log_file"
   MATCH "Adding boot menu entry for UEFI Firmware Settings" "$imagecraft_log_file"
 
-  IMG_NAME=pc.img
-  test -f ${IMG_NAME}
-
-  losetup --find --show --partscan ${IMG_NAME}
-  losetup -a | grep ${IMG_NAME} | cut -f1 -d: >> loop.txt
-  LOOP="$(cat loop.txt)"
-
-  for l in `ls -d "$LOOP"p*`
-  do
-      p=${l#"$LOOP"}
-      mkdir ${TMP_MOUNT}/$p
-      mount $l ${TMP_MOUNT}/$p || true
-  done
-
 restore: |
-  if [ -f loop.txt -a -f tmpmount.txt ]; then
-      LOOP="$(cat loop.txt)"
-      TMP_MOUNT="$(cat tmpmount.txt)"
-
-      for l in `ls -d "$LOOP"p*`
-      do
-          p=${l#"$LOOP"}
-          mount --make-rprivate ${TMP_MOUNT}/$p || true
-          umount --recursive ${TMP_MOUNT}/$p || true
-      done
-
-      losetup -d "$LOOP"
-      sync
-      losetup -l | NOMATCH "$LOOP"
-      rm loop.txt
-  fi
   imagecraft clean --destructive-mode
   rm -rf pc.img || true
 
 debug: |
   df -h
   du -h -d 1 /tmp/
-  mount  -l
-  if [ -f loop.txt ]; then
-      cat loop.txt
-  fi
-  if [ -f tmpmount.txt ]; then
-      cat loop.txt
-  fi
-  losetup -l
+  mount -l

--- a/tests/unit/pack/test_grubutil.py
+++ b/tests/unit/pack/test_grubutil.py
@@ -18,8 +18,10 @@ from pathlib import Path
 import pytest
 from craft_parts.filesystem_mounts import FilesystemMount
 from craft_platforms import DebianArchitecture
+from imagecraft.errors import ImageError
 from imagecraft.models import Volume
-from imagecraft.pack.grubutil import setup_grub
+from imagecraft.pack.chroot import Mount
+from imagecraft.pack.grubutil import _image_mounts, setup_grub
 from imagecraft.pack.image import Image
 
 
@@ -198,3 +200,136 @@ def test_setup_grub_partitions(mocker, new_dir, volume, arch, emitter, message):
     mock_chroot.return_value.execute.assert_not_called()
 
     emitter.assert_progress(message, permanent=True)
+
+
+@pytest.mark.parametrize(
+    ("loop_dev", "volume", "filesystem_mount", "mounts"),
+    [
+        (
+            "/dev/loop99",
+            Volume.unmarshal(
+                {
+                    "schema": "gpt",
+                    "structure": [
+                        {
+                            "name": "efi",
+                            "role": "system-boot",
+                            "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                            "filesystem": "vfat",
+                            "size": "3G",
+                            "filesystem-label": "",
+                        },
+                        {
+                            "name": "rootfs",
+                            "role": "system-data",
+                            "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                            "filesystem": "ext4",
+                            "size": "0",
+                            "filesystem-label": "writable",
+                        },
+                    ],
+                }
+            ),
+            FilesystemMount.unmarshal(
+                [
+                    {"mount": "/", "device": "(volume/pc/rootfs)"},
+                    {"mount": "/boot/efi", "device": "(volume/pc/efi)"},
+                ]
+            ),
+            [
+                Mount(
+                    fstype=None,
+                    src="/dev/loop99p2",
+                    relative_mountpoint="/",
+                ),
+                Mount(
+                    fstype=None,
+                    src="/dev/loop99p1",
+                    relative_mountpoint="/boot/efi",
+                ),
+            ],
+        ),
+        (
+            "/dev/loop99",
+            Volume.unmarshal(
+                {
+                    "schema": "gpt",
+                    "structure": [
+                        {
+                            "name": "efi",
+                            "role": "system-boot",
+                            "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                            "filesystem": "vfat",
+                            "size": "3G",
+                            "filesystem-label": "",
+                        },
+                        {
+                            "name": "rootfs",
+                            "role": "system-data",
+                            "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                            "filesystem": "ext4",
+                            "size": "0",
+                            "filesystem-label": "writable",
+                        },
+                    ],
+                }
+            ),
+            FilesystemMount.unmarshal(
+                [
+                    {"mount": "/", "device": "(volume/pc/rootfs)"},
+                ]
+            ),
+            [
+                Mount(
+                    fstype=None,
+                    src="/dev/loop99p2",
+                    relative_mountpoint="/",
+                ),
+            ],
+        ),
+    ],
+)
+def test_image_mounts(
+    loop_dev: str,
+    volume: Volume,
+    filesystem_mount: FilesystemMount,
+    mounts: list[Mount],
+):
+    assert _image_mounts(loop_dev, volume.structure, filesystem_mount) == mounts
+
+
+@pytest.mark.parametrize(
+    ("loop_dev", "volume", "filesystem_mount"),
+    [
+        (
+            "/dev/loop99",
+            Volume.unmarshal(
+                {
+                    "schema": "gpt",
+                    "structure": [
+                        {
+                            "name": "rootfs",
+                            "role": "system-data",
+                            "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                            "filesystem": "ext4",
+                            "size": "0",
+                            "filesystem-label": "writable",
+                        },
+                    ],
+                }
+            ),
+            FilesystemMount.unmarshal(
+                [
+                    {"mount": "/", "device": "(volume/pc/not-matching)"},
+                ]
+            ),
+        ),
+    ],
+)
+def test_image_mounts_errors(
+    loop_dev: str,
+    volume: Volume,
+    filesystem_mount: FilesystemMount,
+):
+    with pytest.raises(ImageError, match="Cannot find a partition named"):
+        _image_mounts(loop_dev, volume.structure, filesystem_mount)

--- a/tests/unit/pack/test_image.py
+++ b/tests/unit/pack/test_image.py
@@ -78,3 +78,173 @@ class TestImage:
             call("losetup", "--json"),
             call("losetup", "-d", "/dev/loop99"),
         ]
+
+    @pytest.mark.parametrize(
+        ("volume_data", "has_data_partition"),
+        [
+            (
+                {
+                    "schema": "gpt",
+                    "structure": [
+                        {
+                            "name": "efi",
+                            "role": "system-boot",
+                            "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                            "filesystem": "vfat",
+                            "size": "3G",
+                            "filesystem-label": "",
+                        },
+                    ],
+                },
+                False,
+            ),
+            (
+                {
+                    "schema": "gpt",
+                    "structure": [
+                        {
+                            "name": "efi",
+                            "role": "system-boot",
+                            "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                            "filesystem": "vfat",
+                            "size": "3G",
+                            "filesystem-label": "",
+                        },
+                        {
+                            "name": "rootfs",
+                            "role": "system-data",
+                            "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                            "filesystem": "ext4",
+                            "size": "0",
+                            "filesystem-label": "writable",
+                        },
+                    ],
+                },
+                True,
+            ),
+            (
+                {
+                    "schema": "gpt",
+                    "structure": [
+                        {
+                            "name": "rootfs",
+                            "role": "system-data",
+                            "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                            "filesystem": "ext4",
+                            "size": "0",
+                            "filesystem-label": "writable",
+                        },
+                        {
+                            "name": "rootfs2",
+                            "role": "system-data",
+                            "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                            "filesystem": "ext4",
+                            "size": "0",
+                            "filesystem-label": "rootfs2",
+                        },
+                    ],
+                },
+                True,
+            ),
+        ],
+    )
+    def test_has_data_partition(
+        self,
+        volume_data: dict,
+        new_dir: Path,
+        has_data_partition: bool,  # noqa: FBT001
+    ):
+        volume = Volume.unmarshal(volume_data)
+        disk_path = Path(new_dir, "pc.img")
+        disk_path.touch(exist_ok=True)
+        image = Image(
+            volume=volume,
+            disk_path=disk_path,
+        )
+
+        assert image.has_data_partition == has_data_partition
+
+    @pytest.mark.parametrize(
+        ("volume_data", "has_boot_partition"),
+        [
+            (
+                {
+                    "schema": "gpt",
+                    "structure": [
+                        {
+                            "name": "efi",
+                            "role": "system-boot",
+                            "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                            "filesystem": "vfat",
+                            "size": "3G",
+                            "filesystem-label": "",
+                        },
+                    ],
+                },
+                True,
+            ),
+            (
+                {
+                    "schema": "gpt",
+                    "structure": [
+                        {
+                            "name": "efi",
+                            "role": "system-boot",
+                            "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                            "filesystem": "vfat",
+                            "size": "3G",
+                            "filesystem-label": "",
+                        },
+                        {
+                            "name": "rootfs",
+                            "role": "system-data",
+                            "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                            "filesystem": "ext4",
+                            "size": "0",
+                            "filesystem-label": "writable",
+                        },
+                        {
+                            "name": "efi2",
+                            "role": "system-boot",
+                            "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                            "filesystem": "vfat",
+                            "size": "3G",
+                            "filesystem-label": "",
+                        },
+                    ],
+                },
+                True,
+            ),
+            (
+                {
+                    "schema": "gpt",
+                    "structure": [
+                        {
+                            "name": "rootfs",
+                            "role": "system-data",
+                            "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                            "filesystem": "ext4",
+                            "size": "0",
+                            "filesystem-label": "writable",
+                        },
+                    ],
+                },
+                False,
+            ),
+        ],
+    )
+    def test_has_boot_partition(
+        self,
+        volume_data: dict,
+        new_dir: Path,
+        has_boot_partition: bool,  # noqa: FBT001
+    ):
+        volume = Volume.unmarshal(volume_data)
+        disk_path = Path(new_dir, "pc.img")
+        disk_path.touch(exist_ok=True)
+        image = Image(
+            volume=volume,
+            disk_path=disk_path,
+        )
+
+        assert image.has_boot_partition == has_boot_partition


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint && make test`?

---

Rely on the `default` entry in the `filesystems` section to mount the needed partitions to prepare the chroot where `update-grub` is called in.

Fixes #209
IMAGECRAFT-55