### PR TITLE
feat(Lifecycle)!: use craft-application's new plugin groups

### DIFF
--- a/imagecraft/application.py
+++ b/imagecraft/application.py
@@ -19,6 +19,7 @@
 from craft_application import Application, AppMetadata
 from typing_extensions import override
 
+from imagecraft import plugins
 from imagecraft.models import project
 
 APP_METADATA = AppMetadata(
@@ -39,6 +40,7 @@ class Imagecraft(Application):
         from craft_parts.features import Features  # noqa: PLC0415
 
         Features(enable_partitions=True, enable_overlay=True)
+        plugins.setup_plugins()
 
     @override
     def _configure_services(self, provider_name: str | None) -> None:

--- a/imagecraft/application.py
+++ b/imagecraft/application.py
@@ -17,10 +17,8 @@
 """Main Imagecraft Application."""
 
 from craft_application import Application, AppMetadata
-from craft_parts.plugins.plugins import PluginType
 from typing_extensions import override
 
-from imagecraft import plugins
 from imagecraft.models import project
 
 APP_METADATA = AppMetadata(
@@ -34,10 +32,6 @@ APP_METADATA = AppMetadata(
 
 class Imagecraft(Application):
     """Imagecraft application definition."""
-
-    @override
-    def _get_app_plugins(self) -> dict[str, PluginType]:
-        return plugins.get_app_plugins()
 
     @override
     def _enable_craft_parts_features(self) -> None:

--- a/imagecraft/services/lifecycle.py
+++ b/imagecraft/services/lifecycle.py
@@ -20,19 +20,29 @@ import hashlib
 from pathlib import Path
 from typing import cast
 
+import craft_platforms
 from craft_application import LifecycleService
 from craft_cli import CraftError
 from craft_parts import Action, callbacks
 from craft_parts.executor.errors import EnvironmentChangedError
 from craft_parts.infos import ProjectInfo
+from craft_parts.plugins import Plugin
+from craft_parts.plugins.plugins import PluginGroup
 from typing_extensions import override
 
-from imagecraft import models
+from imagecraft import models, plugins
 from imagecraft.services.image import ImageService
 
 
 class ImagecraftLifecycleService(LifecycleService):
     """Imagecraft-specific lifecycle service."""
+
+    @staticmethod
+    @override
+    def get_plugin_group(
+        build_info: craft_platforms.BuildInfo,
+    ) -> dict[str, type[Plugin]] | None:
+        return {**PluginGroup.MINIMAL.value, **plugins.get_app_plugins()}
 
     @override
     def setup(self) -> None:

--- a/imagecraft/services/lifecycle.py
+++ b/imagecraft/services/lifecycle.py
@@ -42,7 +42,7 @@ class ImagecraftLifecycleService(LifecycleService):
     def get_plugin_group(
         build_info: craft_platforms.BuildInfo,
     ) -> dict[str, type[Plugin]] | None:
-        return {**PluginGroup.MINIMAL.value, **plugins.get_app_plugins()}
+        return {**PluginGroup.MINIMAL.value, **plugins.get_app_plugins()}  # pyright: ignore[reportUnknownMemberType]
 
     @override
     def setup(self) -> None:


### PR DESCRIPTION
Breaking change: We're extending the MINIMAL plugin group rather than the DEFAULT plugin group so that we can pick upstream plugins as needed, ensuring they work with imagecraft.

Fixes #314 
IMAGECRAFT-121

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/imagecraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [x] I've added or updated any relevant documentation.
- [x] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
