### PR TITLE
fix(snap-prepare): make keys optional

### DIFF
--- a/imagecraft/plugins/snap_preseed_plugin.py
+++ b/imagecraft/plugins/snap_preseed_plugin.py
@@ -20,8 +20,8 @@ import shlex
 from typing import Literal, cast
 
 from craft_parts.plugins import Plugin, PluginProperties
-from pydantic import field_validator
-from typing_extensions import override
+from pydantic import field_validator, model_validator
+from typing_extensions import Self, override
 
 from ._utils import resolve_snap, validate_snap_refs
 
@@ -31,13 +31,22 @@ class SnapPreseedPluginProperties(PluginProperties, frozen=True):
 
     plugin: Literal["snap-preseed"] = "snap-preseed"
 
-    snap_preseed_snaps: list[str]
+    snap_preseed_snaps: list[str] = []
     snap_preseed_channel: str | None = None
     snap_preseed_model_assert: str = ""
     snap_preseed_validation: Literal["ignore", "enforce"] = "ignore"
     snap_preseed_assertions: list[str] = []
     snap_preseed_revisions: str | None = None
     snap_preseed_write_revisions: str | bool = False
+
+    @model_validator(mode="after")
+    def _snaps_or_model_assert(self) -> Self:
+        """snap-preseed-snaps or snap-preseed-model-assert must be set."""
+        if not (self.snap_preseed_snaps or self.snap_preseed_model_assert):
+            raise ValueError(
+                "One of snap-preseed-snaps or snap-preseed-model-assert must be set."
+            )
+        return self
 
     @field_validator("snap_preseed_snaps")
     @classmethod

--- a/imagecraft/plugins/snap_preseed_plugin.py
+++ b/imagecraft/plugins/snap_preseed_plugin.py
@@ -44,7 +44,7 @@ class SnapPreseedPluginProperties(PluginProperties, frozen=True):
         """snap-preseed-snaps or snap-preseed-model-assert must be set."""
         if not (self.snap_preseed_snaps or self.snap_preseed_model_assert):
             raise ValueError(
-                "One of snap-preseed-snaps or snap-preseed-model-assert must be set."
+                "At least one of snap-preseed-snaps or snap-preseed-model-assert must be set."
             )
         return self
 

--- a/imagecraft/plugins/snap_preseed_plugin.py
+++ b/imagecraft/plugins/snap_preseed_plugin.py
@@ -34,7 +34,7 @@ class SnapPreseedPluginProperties(PluginProperties, frozen=True):
     snap_preseed_snaps: list[str] = []
     snap_preseed_channel: str | None = None
     snap_preseed_model_assert: str = ""
-    snap_preseed_validation: Literal["ignore", "enforce"] | None = None
+    snap_preseed_validation: Literal["ignore", "enforce"] = "enforce"
     snap_preseed_assertions: list[str] = []
     snap_preseed_revisions: str | None = None
     snap_preseed_write_revisions: str | bool = False
@@ -83,10 +83,8 @@ class SnapPreseedPlugin(Plugin):
             "prepare-image",
             "--classic",
             f"--arch={self._part_info.target_arch}",
+            f"--validation={options.snap_preseed_validation}",
         ]
-
-        if options.snap_preseed_validation:
-            cmd.append(f"--validation={options.snap_preseed_validation}")
 
         if options.snap_preseed_channel:
             cmd.append(f"--channel={options.snap_preseed_channel}")

--- a/imagecraft/plugins/snap_preseed_plugin.py
+++ b/imagecraft/plugins/snap_preseed_plugin.py
@@ -34,7 +34,7 @@ class SnapPreseedPluginProperties(PluginProperties, frozen=True):
     snap_preseed_snaps: list[str] = []
     snap_preseed_channel: str | None = None
     snap_preseed_model_assert: str = ""
-    snap_preseed_validation: Literal["ignore", "enforce"] = "ignore"
+    snap_preseed_validation: Literal["ignore", "enforce"] | None = None
     snap_preseed_assertions: list[str] = []
     snap_preseed_revisions: str | None = None
     snap_preseed_write_revisions: str | bool = False
@@ -83,8 +83,11 @@ class SnapPreseedPlugin(Plugin):
             "prepare-image",
             "--classic",
             f"--arch={self._part_info.target_arch}",
-            f"--validation={options.snap_preseed_validation}",
         ]
+
+        if options.snap_preseed_validation:
+            cmd.append(f"--validation={options.snap_preseed_validation}")
+
         if options.snap_preseed_channel:
             cmd.append(f"--channel={options.snap_preseed_channel}")
 

--- a/imagecraft/plugins/uc_prepare_plugin.py
+++ b/imagecraft/plugins/uc_prepare_plugin.py
@@ -33,7 +33,7 @@ class UcPreparePluginProperties(PluginProperties, frozen=True):
     uc_prepare_model_assert: str
     uc_prepare_snaps: list[str] = []
     uc_prepare_channel: str | None = None
-    uc_prepare_validation: Literal["ignore", "enforce"] = "ignore"
+    uc_prepare_validation: Literal["ignore", "enforce"] | None = None
     uc_prepare_assertions: list[str] = []
     uc_prepare_revisions: str | None = None
     uc_prepare_write_revisions: str | bool = False
@@ -113,7 +113,8 @@ class UcPreparePlugin(Plugin):
         if options.uc_prepare_sysfs_overlay:
             cmd.append(f"--sysfs-overlay={options.uc_prepare_sysfs_overlay}")
 
-        cmd.append(f"--validation={options.uc_prepare_validation}")
+        if options.uc_prepare_validation:
+            cmd.append(f"--validation={options.uc_prepare_validation}")
 
         if options.uc_prepare_channel:
             cmd.append(f"--channel={options.uc_prepare_channel}")

--- a/imagecraft/plugins/uc_prepare_plugin.py
+++ b/imagecraft/plugins/uc_prepare_plugin.py
@@ -33,7 +33,7 @@ class UcPreparePluginProperties(PluginProperties, frozen=True):
     uc_prepare_model_assert: str
     uc_prepare_snaps: list[str] = []
     uc_prepare_channel: str | None = None
-    uc_prepare_validation: Literal["ignore", "enforce"] | None = None
+    uc_prepare_validation: Literal["ignore", "enforce"] = "enforce"
     uc_prepare_assertions: list[str] = []
     uc_prepare_revisions: str | None = None
     uc_prepare_write_revisions: str | bool = False
@@ -97,7 +97,7 @@ class UcPreparePlugin(Plugin):
         """Return a list of commands to run during the build step."""
         options = cast(UcPreparePluginProperties, self._options)
 
-        cmd = ["snap", "prepare-image"]
+        cmd = ["snap", "prepare-image", f"--validation={options.uc_prepare_validation}"]
 
         if options.uc_prepare_preseed:
             cmd.append("--preseed")
@@ -112,9 +112,6 @@ class UcPreparePlugin(Plugin):
 
         if options.uc_prepare_sysfs_overlay:
             cmd.append(f"--sysfs-overlay={options.uc_prepare_sysfs_overlay}")
-
-        if options.uc_prepare_validation:
-            cmd.append(f"--validation={options.uc_prepare_validation}")
 
         if options.uc_prepare_channel:
             cmd.append(f"--channel={options.uc_prepare_channel}")

--- a/tests/unit/plugins/test_snap_preseed_plugin.py
+++ b/tests/unit/plugins/test_snap_preseed_plugin.py
@@ -40,7 +40,7 @@ def test_missing_snaps_or_model_assert_key():
 
 @pytest.fixture
 def cmd_prefix(part_info):
-    return f"snap prepare-image --classic --arch={part_info.target_arch} --validation=ignore"
+    return f"snap prepare-image --classic --arch={part_info.target_arch}"
 
 
 def test_snap_preseed_snaps_validation():

--- a/tests/unit/plugins/test_snap_preseed_plugin.py
+++ b/tests/unit/plugins/test_snap_preseed_plugin.py
@@ -40,7 +40,7 @@ def test_missing_snaps_or_model_assert_key():
 
 @pytest.fixture
 def cmd_prefix(part_info):
-    return f"snap prepare-image --classic --arch={part_info.target_arch}"
+    return f"snap prepare-image --classic --arch={part_info.target_arch} --validation=enforce"
 
 
 def test_snap_preseed_snaps_validation():

--- a/tests/unit/plugins/test_snap_preseed_plugin.py
+++ b/tests/unit/plugins/test_snap_preseed_plugin.py
@@ -33,7 +33,8 @@ def part_info(new_dir):
 
 def test_missing_snaps_or_model_assert_key():
     with pytest.raises(
-        ValidationError, match="At least one of snap-preseed-snaps or snap-preseed-model-assert"
+        ValidationError,
+        match="At least one of snap-preseed-snaps or snap-preseed-model-assert",
     ):
         SnapPreseedPluginProperties.unmarshal({})
 

--- a/tests/unit/plugins/test_snap_preseed_plugin.py
+++ b/tests/unit/plugins/test_snap_preseed_plugin.py
@@ -31,8 +31,10 @@ def part_info(new_dir):
     return PartInfo(project_info=project_info, part=Part("my-part", {}))
 
 
-def test_missing_snaps_key():
-    with pytest.raises(ValidationError, match="snap-preseed-snaps"):
+def test_missing_snaps_or_model_assert_key():
+    with pytest.raises(
+        ValidationError, match="One of snap-preseed-snaps or snap-preseed-model-assert"
+    ):
         SnapPreseedPluginProperties.unmarshal({})
 
 
@@ -66,7 +68,6 @@ def test_get_build_commands(part_info, cmd_prefix):
 def test_get_build_commands_with_model_assertion(part_info, cmd_prefix):
     properties = SnapPreseedPluginProperties.unmarshal(
         {
-            "snap-preseed-snaps": ["core24"],
             "snap-preseed-model-assert": "model.assert",
         }
     )
@@ -75,7 +76,7 @@ def test_get_build_commands_with_model_assertion(part_info, cmd_prefix):
 
     assert (
         plugin.get_build_commands()[0]
-        == f"{cmd_prefix} --snap=core24 model.assert {part_info.part_install_dir}"
+        == f"{cmd_prefix} model.assert {part_info.part_install_dir}"
     )
 
 

--- a/tests/unit/plugins/test_snap_preseed_plugin.py
+++ b/tests/unit/plugins/test_snap_preseed_plugin.py
@@ -33,7 +33,7 @@ def part_info(new_dir):
 
 def test_missing_snaps_or_model_assert_key():
     with pytest.raises(
-        ValidationError, match="One of snap-preseed-snaps or snap-preseed-model-assert"
+        ValidationError, match="At least one of snap-preseed-snaps or snap-preseed-model-assert"
     ):
         SnapPreseedPluginProperties.unmarshal({})
 

--- a/tests/unit/plugins/test_uc_prepare_plugin.py
+++ b/tests/unit/plugins/test_uc_prepare_plugin.py
@@ -105,7 +105,7 @@ def test_get_build_commands(part_info):
 
     assert (
         plugin.get_build_commands()[0]
-        == f"snap prepare-image --validation=ignore model.assert {part_info.part_install_dir}"
+        == f"snap prepare-image model.assert {part_info.part_install_dir}"
     )
 
 
@@ -120,7 +120,7 @@ def test_get_build_commands_with_preseed(part_info):
 
     assert (
         plugin.get_build_commands()[0]
-        == f"snap prepare-image --preseed --validation=ignore model.assert {part_info.part_install_dir}"
+        == f"snap prepare-image --preseed model.assert {part_info.part_install_dir}"
     )
 
 
@@ -136,7 +136,7 @@ def test_get_build_commands_with_preseed_sign_key(part_info):
 
     assert (
         plugin.get_build_commands()[0]
-        == f"snap prepare-image --preseed --preseed-sign-key=sign-key --validation=ignore model.assert {part_info.part_install_dir}"
+        == f"snap prepare-image --preseed --preseed-sign-key=sign-key model.assert {part_info.part_install_dir}"
     )
 
 
@@ -153,7 +153,7 @@ def test_get_build_commands_with_apparmor_dir(part_info):
 
     assert (
         plugin.get_build_commands()[0]
-        == f"snap prepare-image --preseed --apparmor-features-dir={apparmor_features_dir} --validation=ignore model.assert {part_info.part_install_dir}"
+        == f"snap prepare-image --preseed --apparmor-features-dir={apparmor_features_dir} model.assert {part_info.part_install_dir}"
     )
 
 
@@ -170,7 +170,7 @@ def test_get_build_commands_with_sysfs_overlay(part_info):
 
     assert (
         plugin.get_build_commands()[0]
-        == f"snap prepare-image --preseed --sysfs-overlay={sysfs_overlay} --validation=ignore model.assert {part_info.part_install_dir}"
+        == f"snap prepare-image --preseed --sysfs-overlay={sysfs_overlay} model.assert {part_info.part_install_dir}"
     )
 
 
@@ -186,7 +186,7 @@ def test_get_build_commands_with_snaps(part_info):
 
     assert (
         plugin.get_build_commands()[0]
-        == f"snap prepare-image --validation=ignore --snap=core24 --snap=hello-world=latest/stable model.assert {part_info.part_install_dir}"
+        == f"snap prepare-image --snap=core24 --snap=hello-world=latest/stable model.assert {part_info.part_install_dir}"
     )
 
 
@@ -202,7 +202,7 @@ def test_get_build_commands_with_assertions(part_info):
 
     assert (
         plugin.get_build_commands()[0]
-        == f"snap prepare-image --validation=ignore --assert=system-user.assert --assert=account.assert model.assert {part_info.part_install_dir}"
+        == f"snap prepare-image --assert=system-user.assert --assert=account.assert model.assert {part_info.part_install_dir}"
     )
 
 
@@ -218,7 +218,7 @@ def test_get_build_commands_with_channel(part_info):
 
     assert (
         plugin.get_build_commands()[0]
-        == f"snap prepare-image --validation=ignore --channel=latest/stable model.assert {part_info.part_install_dir}"
+        == f"snap prepare-image --channel=latest/stable model.assert {part_info.part_install_dir}"
     )
 
 
@@ -250,7 +250,7 @@ def test_get_build_commands_with_revisions(part_info):
 
     assert (
         plugin.get_build_commands()[0]
-        == f"snap prepare-image --validation=ignore --revisions=./revisions.txt model.assert {part_info.part_install_dir}"
+        == f"snap prepare-image --revisions=./revisions.txt model.assert {part_info.part_install_dir}"
     )
 
 
@@ -266,7 +266,7 @@ def test_get_build_commands_with_write_revisions(part_info):
 
     assert (
         plugin.get_build_commands()[0]
-        == f"snap prepare-image --validation=ignore --write-revisions={part_info.part_install_dir}/seed.manifest model.assert {part_info.part_install_dir}"
+        == f"snap prepare-image --write-revisions={part_info.part_install_dir}/seed.manifest model.assert {part_info.part_install_dir}"
     )
 
 
@@ -282,5 +282,5 @@ def test_get_build_commands_with_write_revisions_path(part_info):
 
     assert (
         plugin.get_build_commands()[0]
-        == f"snap prepare-image --validation=ignore --write-revisions={part_info.part_install_dir}/revisions.txt model.assert {part_info.part_install_dir}"
+        == f"snap prepare-image --write-revisions={part_info.part_install_dir}/revisions.txt model.assert {part_info.part_install_dir}"
     )

--- a/tests/unit/plugins/test_uc_prepare_plugin.py
+++ b/tests/unit/plugins/test_uc_prepare_plugin.py
@@ -105,7 +105,7 @@ def test_get_build_commands(part_info):
 
     assert (
         plugin.get_build_commands()[0]
-        == f"snap prepare-image model.assert {part_info.part_install_dir}"
+        == f"snap prepare-image --validation=enforce model.assert {part_info.part_install_dir}"
     )
 
 
@@ -120,7 +120,7 @@ def test_get_build_commands_with_preseed(part_info):
 
     assert (
         plugin.get_build_commands()[0]
-        == f"snap prepare-image --preseed model.assert {part_info.part_install_dir}"
+        == f"snap prepare-image --validation=enforce --preseed model.assert {part_info.part_install_dir}"
     )
 
 
@@ -136,7 +136,7 @@ def test_get_build_commands_with_preseed_sign_key(part_info):
 
     assert (
         plugin.get_build_commands()[0]
-        == f"snap prepare-image --preseed --preseed-sign-key=sign-key model.assert {part_info.part_install_dir}"
+        == f"snap prepare-image --validation=enforce --preseed --preseed-sign-key=sign-key model.assert {part_info.part_install_dir}"
     )
 
 
@@ -153,7 +153,7 @@ def test_get_build_commands_with_apparmor_dir(part_info):
 
     assert (
         plugin.get_build_commands()[0]
-        == f"snap prepare-image --preseed --apparmor-features-dir={apparmor_features_dir} model.assert {part_info.part_install_dir}"
+        == f"snap prepare-image --validation=enforce --preseed --apparmor-features-dir={apparmor_features_dir} model.assert {part_info.part_install_dir}"
     )
 
 
@@ -170,7 +170,7 @@ def test_get_build_commands_with_sysfs_overlay(part_info):
 
     assert (
         plugin.get_build_commands()[0]
-        == f"snap prepare-image --preseed --sysfs-overlay={sysfs_overlay} model.assert {part_info.part_install_dir}"
+        == f"snap prepare-image --validation=enforce --preseed --sysfs-overlay={sysfs_overlay} model.assert {part_info.part_install_dir}"
     )
 
 
@@ -186,7 +186,7 @@ def test_get_build_commands_with_snaps(part_info):
 
     assert (
         plugin.get_build_commands()[0]
-        == f"snap prepare-image --snap=core24 --snap=hello-world=latest/stable model.assert {part_info.part_install_dir}"
+        == f"snap prepare-image --validation=enforce --snap=core24 --snap=hello-world=latest/stable model.assert {part_info.part_install_dir}"
     )
 
 
@@ -202,7 +202,7 @@ def test_get_build_commands_with_assertions(part_info):
 
     assert (
         plugin.get_build_commands()[0]
-        == f"snap prepare-image --assert=system-user.assert --assert=account.assert model.assert {part_info.part_install_dir}"
+        == f"snap prepare-image --validation=enforce --assert=system-user.assert --assert=account.assert model.assert {part_info.part_install_dir}"
     )
 
 
@@ -218,7 +218,7 @@ def test_get_build_commands_with_channel(part_info):
 
     assert (
         plugin.get_build_commands()[0]
-        == f"snap prepare-image --channel=latest/stable model.assert {part_info.part_install_dir}"
+        == f"snap prepare-image --validation=enforce --channel=latest/stable model.assert {part_info.part_install_dir}"
     )
 
 
@@ -226,7 +226,7 @@ def test_get_build_commands_with_validation_enforce(part_info):
     properties = UcPreparePluginProperties.unmarshal(
         {
             "uc-prepare-model-assert": "model.assert",
-            "uc-prepare-validation": "enforce",
+            "uc-prepare-validation": "ignore",
         }
     )
 
@@ -234,7 +234,7 @@ def test_get_build_commands_with_validation_enforce(part_info):
 
     assert (
         plugin.get_build_commands()[0]
-        == f"snap prepare-image --validation=enforce model.assert {part_info.part_install_dir}"
+        == f"snap prepare-image --validation=ignore model.assert {part_info.part_install_dir}"
     )
 
 
@@ -250,7 +250,7 @@ def test_get_build_commands_with_revisions(part_info):
 
     assert (
         plugin.get_build_commands()[0]
-        == f"snap prepare-image --revisions=./revisions.txt model.assert {part_info.part_install_dir}"
+        == f"snap prepare-image --validation=enforce --revisions=./revisions.txt model.assert {part_info.part_install_dir}"
     )
 
 
@@ -266,7 +266,7 @@ def test_get_build_commands_with_write_revisions(part_info):
 
     assert (
         plugin.get_build_commands()[0]
-        == f"snap prepare-image --write-revisions={part_info.part_install_dir}/seed.manifest model.assert {part_info.part_install_dir}"
+        == f"snap prepare-image --validation=enforce --write-revisions={part_info.part_install_dir}/seed.manifest model.assert {part_info.part_install_dir}"
     )
 
 
@@ -282,5 +282,5 @@ def test_get_build_commands_with_write_revisions_path(part_info):
 
     assert (
         plugin.get_build_commands()[0]
-        == f"snap prepare-image --write-revisions={part_info.part_install_dir}/revisions.txt model.assert {part_info.part_install_dir}"
+        == f"snap prepare-image --validation=enforce --write-revisions={part_info.part_install_dir}/revisions.txt model.assert {part_info.part_install_dir}"
     )


### PR DESCRIPTION
This PR:
- makes only one of `snap-preseed-snaps` or `snap-preseed-model-assert` required
- changes default validation to "enforce"

Currently `snap-preseed-snaps` is required for the snap-preseed plugin but the user can provide a model assertion file which would contain a list of snaps.  

`snap prepare-image` sets the validation mode to `enforce` by default.

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/imagecraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
