### PR TITLE
fix(lint): suppress ty

### DIFF
--- a/imagecraft/pack/grubutil.py
+++ b/imagecraft/pack/grubutil.py
@@ -200,10 +200,10 @@ def _part_num(name: str, structure: StructureList) -> int | None:
     """Get the partition number for a given name based on its position."""
     for i, structure_item in enumerate(structure):
         if structure_item.name == name:
-            if structure_item.partition_number is None:
+            if structure_item.partition_number is None:  # ty: ignore[unresolved-attribute]
                 # Partition numbers start at 1, so offset the index
                 return i + 1
-            return structure_item.partition_number
+            return structure_item.partition_number  # ty: ignore[unresolved-attribute]
     return None
 
 

--- a/imagecraft/services/image.py
+++ b/imagecraft/services/image.py
@@ -207,7 +207,7 @@ class ImageService(AppService):
             mapping[vol_name] = loop_dev
             volume = project.volumes[vol_name]
             for i, structure in enumerate(volume.structure, start=1):
-                part_num = structure.partition_number or i
+                part_num = structure.partition_number or i  # ty: ignore[unresolved-attribute]
                 mapping[f"{vol_name}/{structure.name}"] = f"{loop_dev}p{part_num}"
 
         return mapping


### PR DESCRIPTION
Suppresses ty rule to fix lint check

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/imagecraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
