### PR TITLE
fix: clear ty diagnostics for partition-number helpers

### DIFF
--- a/imagecraft/pack/grubutil.py
+++ b/imagecraft/pack/grubutil.py
@@ -231,8 +231,9 @@ def _part_num(name: str, structure: StructureList) -> int | None:
     )
     for i, structure_item in enumerate(structure):
         if structure_item.name == name:
-            if getattr(structure_item, "partition_number", None) is not None:
-                return structure_item.partition_number  # type: ignore[union-attr]
+            explicit = getattr(structure_item, "partition_number", None)
+            if explicit is not None:
+                return explicit
             pos = i + 1  # 1-based
             if needs_extended and pos > mbrutil.PRIMARY_SLOTS_WITH_EXTENDED:
                 return pos + 1  # skip slot 4 (extended container)

--- a/imagecraft/services/image.py
+++ b/imagecraft/services/image.py
@@ -28,7 +28,12 @@ from craft_application import AppMetadata, AppService, ServiceFactory
 from craft_cli import CraftError, emit
 
 from imagecraft.models import Project
-from imagecraft.models.volume import GPTVolume, MBRVolume, PartitionSchema
+from imagecraft.models.volume import (
+    GPTVolume,
+    HybridVolume,
+    MBRVolume,
+    PartitionSchema,
+)
 from imagecraft.pack import gptutil, mbrutil
 from imagecraft.subprocesses import run
 
@@ -196,7 +201,9 @@ class ImageService(AppService):
                         f"Failed to detach loop device {device} after 10 seconds."
                     )
 
-    def _get_partition_numbers(self, volume: GPTVolume | MBRVolume) -> dict[str, int]:
+    def _get_partition_numbers(
+        self, volume: GPTVolume | MBRVolume | HybridVolume
+    ) -> dict[str, int]:
         """Return a mapping of partition name to disk partition number for a volume.
 
         For GPT and plain MBR (≤4 partitions), numbers are 1-based positions,

--- a/tests/unit/pack/test_grubutil.py
+++ b/tests/unit/pack/test_grubutil.py
@@ -14,6 +14,7 @@
 
 import contextlib
 from pathlib import Path
+from typing import cast
 from unittest.mock import MagicMock
 
 import pytest
@@ -23,8 +24,10 @@ from imagecraft.errors import ImageError
 from imagecraft.models import Volume
 from imagecraft.models.volume import (
     GPTStructureItem,
+    GPTStructureList,
     GPTVolume,
     MBRStructureItem,
+    MBRStructureList,
     MBRVolume,
 )
 from imagecraft.pack.chroot import Mount
@@ -472,20 +475,22 @@ def test_image_mounts_errors(
     ],
 )
 def test_part_num_gpt(name, structure_spec, expected):
-    structure = []
+    items = []
     for spec in structure_spec:
         item = MagicMock(spec=GPTStructureItem)
         item.name = spec["name"]
         item.partition_number = spec["partition_number"]
-        structure.append(item)
+        items.append(item)
+    structure = cast(GPTStructureList, items)
 
     assert _part_num(name, structure) == expected
 
 
 def test_part_num_mbr_plain():
-    structure = [
-        MagicMock(spec=MBRStructureItem, partition_number=None) for _ in range(3)
-    ]
+    structure = cast(
+        MBRStructureList,
+        [MagicMock(spec=MBRStructureItem, partition_number=None) for _ in range(3)],
+    )
     for i, name in enumerate(["boot", "data", "rootfs"]):
         structure[i].name = name
 
@@ -495,9 +500,10 @@ def test_part_num_mbr_plain():
 
 
 def test_part_num_mbr_extended():
-    structure = [
-        MagicMock(spec=MBRStructureItem, partition_number=None) for _ in range(5)
-    ]
+    structure = cast(
+        MBRStructureList,
+        [MagicMock(spec=MBRStructureItem, partition_number=None) for _ in range(5)],
+    )
     for i, name in enumerate(["boot", "p2", "p3", "logical1", "logical2"]):
         structure[i].name = name
 


### PR DESCRIPTION
ty (the static type checker run by `make lint-ty`) flagged three genuine issues in code introduced by the MBR support PR:

- grubutil._part_num used `# type: ignore[union-attr]` (mypy syntax) to reach `partition_number` on a union containing variants that don't define it. Capture the result of getattr() in a local instead, removing the need for any ignore.
- ImageService._get_partition_numbers was annotated with `GPTVolume | MBRVolume`, but its only caller passes `GPTVolume | MBRVolume | HybridVolume`. The implementation already handles HybridVolume correctly (volume_schema is HYBRID, so the MBR-extended path is skipped); widen the parameter type to match.
- test_part_num_{mbr_plain,mbr_extended,gpt} build their structure list from MagicMock instances. ty doesn't see through `spec=MBRStructureItem`, so the call to _part_num looked ill-typed. Cast to MBRStructureList / GPTStructureList at construction so the rest of the test reads naturally.

`make lint-ty` and `make lint-ruff` both pass clean afterwards.