### PR TITLE
feat(plugins): use @ channel separator

### DIFF
--- a/docs/reference/plugins/snap_preseed_plugin.rst
+++ b/docs/reference/plugins/snap_preseed_plugin.rst
@@ -38,7 +38,8 @@ snap-preseed-snaps
 The snaps to seed into the image. Valid entries are:
 
 - a snap name
-- a snap name and channel in the format ``<snap-name>@<channel>``
+- a snap name and channel in the format ``<snap-name> @ <channel>`` (spaces around ``@``
+  are optional)
 - a path to a local snap within the project directory
 
 If the model assertion has a grade of ``signed`` or ``secured``, only snaps declared in
@@ -127,6 +128,6 @@ the ``hello-world`` snap from the ``latest/edge`` channel into a classic image.
      plugin: snap-preseed
      snap-preseed-snaps:
        - core24
-       - hello-world@latest/edge
+       - hello-world @ latest/edge
      organize:
        "var/*": (overlay)/var/

--- a/docs/reference/plugins/snap_preseed_plugin.rst
+++ b/docs/reference/plugins/snap_preseed_plugin.rst
@@ -38,7 +38,7 @@ snap-preseed-snaps
 The snaps to seed into the image. Valid entries are:
 
 - a snap name
-- a snap name and channel in the format ``<snap-name>/<channel>``
+- a snap name and channel in the format ``<snap-name>@<channel>``
 - a path to a local snap within the project directory
 
 If the model assertion has a grade of ``signed`` or ``secured``, only snaps declared in
@@ -127,6 +127,6 @@ the ``hello-world`` snap from the ``latest/edge`` channel into a classic image.
      plugin: snap-preseed
      snap-preseed-snaps:
        - core24
-       - hello-world/latest/edge
+       - hello-world@latest/edge
      organize:
        "var/*": (overlay)/var/

--- a/docs/reference/plugins/uc_prepare_plugin.rst
+++ b/docs/reference/plugins/uc_prepare_plugin.rst
@@ -44,7 +44,8 @@ Snaps to seed into the image in addition to those required by the model assertio
 entries are:
 
 - a snap name
-- a snap name and channel in the format ``<snap-name>@<channel>``
+- a snap name and channel in the format ``<snap-name> @ <channel>`` (spaces around ``@``
+  are optional)
 - a path to a local snap within the project directory
 
 If the model assertion has a grade of ``signed`` or ``secured``, only snaps declared in

--- a/docs/reference/plugins/uc_prepare_plugin.rst
+++ b/docs/reference/plugins/uc_prepare_plugin.rst
@@ -44,7 +44,7 @@ Snaps to seed into the image in addition to those required by the model assertio
 entries are:
 
 - a snap name
-- a snap name and channel in the format ``<snap-name>/<channel>``
+- a snap name and channel in the format ``<snap-name>@<channel>``
 - a path to a local snap within the project directory
 
 If the model assertion has a grade of ``signed`` or ``secured``, only snaps declared in

--- a/imagecraft/plugins/_utils.py
+++ b/imagecraft/plugins/_utils.py
@@ -29,17 +29,19 @@ def validate_snap_refs(snaps: list[str]) -> list[str]:
         if snap.endswith(".snap"):
             continue
 
-        parts = snap.split("/")
+        name = snap
+        if "@" in snap:
+            name, channel = snap.split("@", 1)
+            name = name.strip()
+            channel = channel.strip()
+            if (channel_parts := channel.split("/")) and (
+                len(channel_parts) > 1
+                and not any(p in VALID_RISKS for p in channel_parts)
+                or len(channel_parts) > MAX_CHANNEL_PARTS
+            ):
+                raise ValueError(f"Invalid snap reference {snap}")
 
-        name = parts[0]
         if not (len(name) <= MAX_LEN and PROJECT_NAME_COMPILED_REGEX.match(name)):
-            raise ValueError(f"Invalid snap reference {snap}")
-
-        if (channel_parts := parts[1:]) and (
-            len(channel_parts) > 1
-            and not any(p in VALID_RISKS for p in channel_parts)
-            or len(channel_parts) > MAX_CHANNEL_PARTS
-        ):
             raise ValueError(f"Invalid snap reference {snap}")
 
     return snaps
@@ -54,7 +56,7 @@ def resolve_snap(snap: str) -> str:
     unchanged.
     """
     snap = snap.strip()
-    if "/" in snap and not snap.endswith(".snap"):
-        name, channel = snap.split("/", 1)
-        snap = f"{name}={channel}"
+    if "@" in snap:
+        name, channel = snap.split("@", 1)
+        snap = f"{name.strip()}={channel.strip()}"
     return snap

--- a/tests/spread/plugins/snap-preseed/imagecraft.yaml
+++ b/tests/spread/plugins/snap-preseed/imagecraft.yaml
@@ -30,6 +30,6 @@ parts:
   snaps:
     plugin: snap-preseed
     snap-preseed-snaps:
-      - hello-world/latest/stable
+      - hello-world@latest/stable
     organize:
       "var/*": (overlay)/var/

--- a/tests/unit/plugins/test_snap_preseed_plugin.py
+++ b/tests/unit/plugins/test_snap_preseed_plugin.py
@@ -55,7 +55,7 @@ def test_snap_preseed_snaps_validation():
 
 def test_get_build_commands(part_info, cmd_prefix):
     properties = SnapPreseedPluginProperties.unmarshal(
-        {"snap-preseed-snaps": ["core24", "hello-world/latest/stable"]}
+        {"snap-preseed-snaps": ["core24", "hello-world@latest/stable"]}
     )
 
     plugin = SnapPreseedPlugin(properties=properties, part_info=part_info)

--- a/tests/unit/plugins/test_uc_prepare_plugin.py
+++ b/tests/unit/plugins/test_uc_prepare_plugin.py
@@ -178,7 +178,7 @@ def test_get_build_commands_with_snaps(part_info):
     properties = UcPreparePluginProperties.unmarshal(
         {
             "uc-prepare-model-assert": "model.assert",
-            "uc-prepare-snaps": ["core24", "hello-world/latest/stable"],
+            "uc-prepare-snaps": ["core24", "hello-world@latest/stable"],
         }
     )
 

--- a/tests/unit/plugins/test_utils.py
+++ b/tests/unit/plugins/test_utils.py
@@ -24,9 +24,9 @@ from imagecraft.plugins._utils import resolve_snap, validate_snap_refs
         ("core24", "core24"),
         ("  core24  ", "core24"),
         ("./my-snap_1.0_amd64.snap", "./my-snap_1.0_amd64.snap"),
-        ("hello-world/latest/stable", "hello-world=latest/stable"),
-        ("core24/stable", "core24=stable"),
-        ("  hello-world/latest/stable  ", "hello-world=latest/stable"),
+        ("hello-world@latest/stable", "hello-world=latest/stable"),
+        ("core24@stable", "core24=stable"),
+        ("  hello-world @ latest/stable  ", "hello-world=latest/stable"),
     ],
 )
 def test_resolve_snap(snap, expected):
@@ -36,12 +36,15 @@ def test_resolve_snap(snap, expected):
 def test_validate_snap_ref_valid():
     valid_refs = [
         "hello-world",
-        "hello-world/edge",
-        "hello-world/24",
-        "hello-world/stable/hotfix",
-        "hello-world/24/beta/hotfix",
+        "hello-world@edge",
+        "hello-world @ edge",
+        "hello-world@24",
+        "hello-world@stable/hotfix",
+        "hello-world @ stable/hotfix",
+        "hello-world@24/beta/hotfix",
         "my-snap-123",
         "/path/to/local.snap",
+        "hello-world@latest/edge",
     ]
 
     assert validate_snap_refs(valid_refs) == valid_refs


### PR DESCRIPTION
Changes expected channel separator from "/" to "@" with optional surrounding whitespace.

Fixes #342 

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/imagecraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [x] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
