### PR TITLE
services/pack: build partitions as files, inject via dd

### DIFF
--- a/imagecraft/pack/__init__.py
+++ b/imagecraft/pack/__init__.py
@@ -20,7 +20,6 @@ from imagecraft.pack.diskutil import (
     bytes_to_sectors,
     create_zero_image,
     format_populate_partition,
-    inject_partition_into_image,
 )
 from imagecraft.pack.gptutil import (
     SUPPORTED_SECTOR_SIZES,
@@ -36,7 +35,6 @@ __all__ = [
     "bytes_to_sectors",
     "create_zero_image",
     "format_populate_partition",
-    "inject_partition_into_image",
     "SUPPORTED_SECTOR_SIZES",
     "create_empty_gpt_image",
     "get_partition_sector_offset",

--- a/imagecraft/pack/diskutil.py
+++ b/imagecraft/pack/diskutil.py
@@ -81,6 +81,25 @@ class DiskSize:
         return bytes_to_sectors(bytes_=self.bytesize, sector_size=self.sector_size)
 
 
+@dataclass
+class PartitionGeometry:
+    """Geometry of a partition within a disk image."""
+
+    sector_offset: int
+    """Start sector of the partition within the image."""
+
+    sector_count: int
+    """Number of sectors occupied by the partition."""
+
+    sector_size: int
+    """Sector size of the image, in bytes."""
+
+    @property
+    def size_bytes(self) -> int:
+        """Return the partition size in bytes."""
+        return self.sector_count * self.sector_size
+
+
 # Image file operations
 
 
@@ -104,6 +123,8 @@ def _format_populate_ext_partition(
     content_dir: Path | None,
     partitionpath: Path,
     label: str | None = None,
+    offset_bytes: int = 0,
+    size_bytes: int | None = None,
 ) -> None:
     """Format a partition/device as EXT3/4 and embed content.
 
@@ -111,6 +132,10 @@ def _format_populate_ext_partition(
     :param content_dir: Directory containing contents for partition, or None.
     :param partitionpath: Path to partition file or block device.
     :param label: Ext Filesystem label, empty if not supplied.
+    :param offset_bytes: Byte offset within ``partitionpath`` at which to create
+        the filesystem. 0 means the start of the file/device.
+    :param size_bytes: Size of the filesystem to create, in bytes. When None,
+        mke2fs uses the remainder of the device after ``offset_bytes``.
     :raises CalledProcessError: If mke2fs fails.
     """
     mke2fs_args: list[str | Path] = ["-t", fstype]
@@ -121,7 +146,16 @@ def _format_populate_ext_partition(
     if label is not None:
         mke2fs_args.extend(["-L", label])
 
+    if offset_bytes:
+        mke2fs_args.extend(["-E", f"offset={offset_bytes}"])
+
     mke2fs_args.append(partitionpath)
+
+    if size_bytes is not None:
+        # The fs-size argument with a 'k' suffix is an absolute size that does
+        # not depend on the block size mke2fs picks. Round down to whole KiB so
+        # the filesystem never extends past the partition's end.
+        mke2fs_args.append(f"{size_bytes // 1024}k")
 
     with emit.open_stream(f"Creating {fstype} partition (label: {label!r})") as stream:
         run("mke2fs", *mke2fs_args, stdout=stream, stderr=stream)
@@ -134,6 +168,9 @@ def _format_populate_fat_partition(  # pylint: disable=too-many-arguments
     content_dir: Path | None,
     partitionpath: Path,
     label: str | None = None,
+    offset_bytes: int = 0,
+    sector_size: int = 512,
+    size_bytes: int | None = None,
 ) -> None:
     """Format a partition/device as FAT and copy content.
 
@@ -142,6 +179,12 @@ def _format_populate_fat_partition(  # pylint: disable=too-many-arguments
     :param content_dir: Directory containing contents for partition, or None.
     :param partitionpath: Path to partition file or block device.
     :param label: Fat Filesystem label, empty if not supplied.
+    :param offset_bytes: Byte offset within ``partitionpath`` at which to create
+        the filesystem. 0 means the start of the file/device.
+    :param sector_size: Logical sector size, used to translate ``offset_bytes``
+        into the sector unit that ``mkfs.fat --offset`` expects.
+    :param size_bytes: Size of the filesystem to create, in bytes. When None,
+        mkfs.fat uses the remainder of the device after the offset.
     :raises CalledProcessError: If mkfs.xxx or mcopy fails.
     """
     mkdosfs_args: list[str | Path] = []
@@ -152,7 +195,15 @@ def _format_populate_fat_partition(  # pylint: disable=too-many-arguments
     if label is not None:
         mkdosfs_args.extend(["-n", label])
 
+    if offset_bytes:
+        mkdosfs_args.extend(["--offset", str(offset_bytes // sector_size)])
+
     mkdosfs_args.append(partitionpath)
+
+    if size_bytes is not None:
+        # block-count is in 1024-byte blocks; round down to whole KiB so the
+        # filesystem stays within the partition.
+        mkdosfs_args.append(str(size_bytes // 1024))
 
     with emit.open_stream(f"Creating {fattype} partition (label: {label!r})") as stream:
         run("mkfs." + fattype, *mkdosfs_args, stdout=stream, stderr=stream)
@@ -165,7 +216,12 @@ def _format_populate_fat_partition(  # pylint: disable=too-many-arguments
         # empty.
         # Note that the documentation for mcopy's -i flag can be hard to find - some is here:
         # https://www.gnu.org/software/mtools/manual/mtools.html#drive-letters
-        mcopy_cmd = f"mcopy -n -o -s -i{str(partitionpath)} {content_dir}/* ::"
+        # A '@@<byte-offset>' suffix tells mtools where the filesystem starts
+        # within the image, mirroring mkfs.fat's --offset.
+        image_arg = str(partitionpath)
+        if offset_bytes:
+            image_arg = f"{image_arg}@@{offset_bytes}"
+        mcopy_cmd = f"mcopy -n -o -s -i{image_arg} {content_dir}/* ::"
         with emit.open_stream("Copying files to partition") as stream:
             run("bash", "-c", mcopy_cmd, stdout=stream, stderr=stream)
 
@@ -229,21 +285,41 @@ def format_populate_partition(
     content_dir: Path,
     partitionpath: Path,
     label: str | None = None,
+    geometry: PartitionGeometry | None = None,
 ) -> None:
     """Format a partition and copy files.
 
+    When ``geometry`` is given, the filesystem is created in place at the
+    partition's offset within ``partitionpath`` (which is then the whole disk
+    image) and constrained to the partition's size. mke2fs, mkfs.fat and mcopy
+    all support writing at an offset, so this lets imagecraft build partitions
+    directly inside the image without loop devices or an intermediate copy.
+    When ``geometry`` is None, the whole of ``partitionpath`` is formatted.
+
     :param fstype: Type of FS - one of (vfat, fat16, ext3, ext4).
     :param content_dir: Directory containing contents for partition.
-    :param partitionpath: Path to partition file.
-    :param disk_size: Disk size attributes.
+    :param partitionpath: Path to the partition file, or the disk image when
+        ``geometry`` is supplied.
     :param label: Filesystem label, empty if not supplied.
+    :param geometry: Optional on-disk geometry of the partition within
+        ``partitionpath``.
     """
+    offset_bytes = 0
+    sector_size = 512
+    size_bytes: int | None = None
+    if geometry is not None:
+        offset_bytes = geometry.sector_offset * geometry.sector_size
+        sector_size = geometry.sector_size
+        size_bytes = geometry.size_bytes
+
     if fstype.value.startswith("ext"):
         _format_populate_ext_partition(
             fstype=cast(ExtT, fstype.value),
             content_dir=content_dir,
             partitionpath=partitionpath,
             label=label,
+            offset_bytes=offset_bytes,
+            size_bytes=size_bytes,
         )
         return
     if "fat" in fstype.value:
@@ -262,28 +338,12 @@ def format_populate_partition(
             content_dir=content_dir,
             partitionpath=partitionpath,
             label=label,
+            offset_bytes=offset_bytes,
+            sector_size=sector_size,
+            size_bytes=size_bytes,
         )
         return
     raise CraftError(f"Unsupported filesystem: {fstype}")
-
-
-@dataclass
-class PartitionGeometry:
-    """Geometry of a partition within a disk image."""
-
-    sector_offset: int
-    """Start sector of the partition within the image."""
-
-    sector_count: int
-    """Number of sectors occupied by the partition."""
-
-    sector_size: int
-    """Sector size of the image, in bytes."""
-
-    @property
-    def size_bytes(self) -> int:
-        """Return the partition size in bytes."""
-        return self.sector_count * self.sector_size
 
 
 def _read_sfdisk_partition_table(imagepath: Path) -> dict[str, Any]:
@@ -297,9 +357,7 @@ def _read_sfdisk_partition_table(imagepath: Path) -> dict[str, Any]:
     return cast(dict[str, Any], json.loads(result.stdout)["partitiontable"])
 
 
-def get_partition_geometry(
-    imagepath: Path, partition_number: int
-) -> PartitionGeometry:
+def get_partition_geometry(imagepath: Path, partition_number: int) -> PartitionGeometry:
     """Return the on-disk geometry of the given partition.
 
     Looks up the partition by node suffix (``<imagepath><partition_number>``),
@@ -324,50 +382,3 @@ def get_partition_geometry(
     raise CraftError(
         f"No partition numbered {partition_number} in {imagepath}",
     )
-
-
-def inject_partition_into_image(
-    *,
-    partition: Path,
-    imagepath: Path,
-    sector_offset: int,
-    disk_size: DiskSize,
-) -> None:
-    """Inject partition into image.
-
-    :param partition: Path to partition file.
-    :param imagepath: Path to image file.
-    :param sector_offset: Number of image sectors to skip before writing.
-    :param disk_size: Disk size attributes.
-    :raises CalledProcessError: If dd fails.
-    """
-    part_size = partition.stat().st_size
-    requested_size = disk_size.sector_size * disk_size.sector_count
-    if part_size != requested_size:
-        raise CraftError(
-            f"Partition {partition.name!r} not expected size "
-            f"(actual: {part_size} vs. expected: {requested_size})."
-        )
-
-    cmd = [
-        "dd",
-        f"if={str(partition)}",
-        f"of={str(imagepath)}",
-        f"bs={disk_size.sector_size}",
-        f"seek={sector_offset}",
-        "status=progress",
-        "conv=notrunc,sparse",
-    ]
-    with subprocess.Popen(
-        cmd,
-        text=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-    ) as dd_proc:
-        if not dd_proc.stdout:
-            return
-        for line in iter(dd_proc.stdout.readline, ""):
-            emit.trace(line)
-        ret = dd_proc.wait()
-    if ret:
-        raise subprocess.CalledProcessError(ret, cmd)

--- a/imagecraft/pack/diskutil.py
+++ b/imagecraft/pack/diskutil.py
@@ -14,10 +14,11 @@
 
 """Disk-related utility functions."""
 
+import json
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Literal, cast
+from typing import Any, Literal, cast
 
 from craft_cli import CraftError, emit
 
@@ -264,6 +265,65 @@ def format_populate_partition(
         )
         return
     raise CraftError(f"Unsupported filesystem: {fstype}")
+
+
+@dataclass
+class PartitionGeometry:
+    """Geometry of a partition within a disk image."""
+
+    sector_offset: int
+    """Start sector of the partition within the image."""
+
+    sector_count: int
+    """Number of sectors occupied by the partition."""
+
+    sector_size: int
+    """Sector size of the image, in bytes."""
+
+    @property
+    def size_bytes(self) -> int:
+        """Return the partition size in bytes."""
+        return self.sector_count * self.sector_size
+
+
+def _read_sfdisk_partition_table(imagepath: Path) -> dict[str, Any]:
+    """Return the parsed sfdisk --json partition table for a disk image.
+
+    Works for both GPT and MBR partition tables.
+
+    :raises CalledProcessError: If sfdisk fails.
+    """
+    result = run("sfdisk", "--json", imagepath, stderr=subprocess.PIPE)
+    return cast(dict[str, Any], json.loads(result.stdout)["partitiontable"])
+
+
+def get_partition_geometry(
+    imagepath: Path, partition_number: int
+) -> PartitionGeometry:
+    """Return the on-disk geometry of the given partition.
+
+    Looks up the partition by node suffix (``<imagepath><partition_number>``),
+    which works for both GPT and MBR images partitioned via sfdisk.
+
+    :param imagepath: Path to the disk image file.
+    :param partition_number: 1-based partition number as written in the
+        partition table (for MBR with an extended container, logical
+        partitions start at 5).
+    :raises CraftError: If the partition cannot be found in the table.
+    """
+    table = _read_sfdisk_partition_table(imagepath)
+    sector_size = int(table.get("sectorsize", 512))
+    target_node = f"{imagepath}{partition_number}"
+    for partition in table.get("partitions", []):
+        if partition.get("node") == target_node:
+            return PartitionGeometry(
+                sector_offset=int(partition["start"]),
+                sector_count=int(partition["size"]),
+                sector_size=sector_size,
+            )
+    raise CraftError(
+        f"No partition numbered {partition_number} in {imagepath}",
+    )
 
 
 def inject_partition_into_image(

--- a/imagecraft/services/pack.py
+++ b/imagecraft/services/pack.py
@@ -14,8 +14,6 @@
 
 """Imagecraft Package service."""
 
-import contextlib
-import tempfile
 from pathlib import Path
 from typing import cast
 
@@ -57,9 +55,7 @@ class ImagecraftPackService(PackageService):
         for structure_item in volume.structure:
             partition_name = get_partition_name(volume_name, structure_item)
             emit.progress(f"Preparing partition {partition_name}")
-            partition_prime_dir = project_dirs.get_prime_dir(
-                partition=partition_name
-            )
+            partition_prime_dir = project_dirs.get_prime_dir(partition=partition_name)
 
             partition_number = partition_numbers[structure_item.name]
             geometry = diskutil.get_partition_geometry(
@@ -78,41 +74,18 @@ class ImagecraftPackService(PackageService):
                     f"requested size ({expected_sectors} sectors).",
                 )
 
-            # Build the partition contents in a temp file, then dd it into
-            # the disk image at the partition's sector offset. This avoids
-            # losetup entirely, which is needed so imagecraft can run inside
-            # unprivileged LXD containers.
-            safe_prefix = partition_name.replace("/", "_")
-            with tempfile.NamedTemporaryFile(
-                prefix=f".{safe_prefix}.part.",
-                suffix=".tmp",
-                dir=image_path.parent,
-                delete=False,
-            ) as tf:
-                part_path = Path(tf.name)
-            try:
-                with part_path.open("wb") as fh:
-                    fh.truncate(geometry.size_bytes)
-
-                diskutil.format_populate_partition(
-                    fstype=structure_item.filesystem,
-                    content_dir=partition_prime_dir,
-                    partitionpath=part_path,
-                    label=structure_item.filesystem_label,
-                )
-
-                diskutil.inject_partition_into_image(
-                    partition=part_path,
-                    imagepath=image_path,
-                    sector_offset=geometry.sector_offset,
-                    disk_size=diskutil.DiskSize(
-                        bytesize=geometry.size_bytes,
-                        sector_size=geometry.sector_size,
-                    ),
-                )
-            finally:
-                with contextlib.suppress(FileNotFoundError):
-                    part_path.unlink()
+            # Build the partition's filesystem directly inside the disk image
+            # at the partition's offset. mke2fs/mkfs.fat/mcopy all support
+            # writing at an offset, so this avoids losetup (needed to run
+            # inside unprivileged LXD containers) as well as the intermediate
+            # per-partition copy that a temp file + dd would require.
+            diskutil.format_populate_partition(
+                fstype=structure_item.filesystem,
+                content_dir=partition_prime_dir,
+                partitionpath=image_path,
+                label=structure_item.filesystem_label,
+                geometry=geometry,
+            )
 
         image_service.verify_images()
 

--- a/imagecraft/services/pack.py
+++ b/imagecraft/services/pack.py
@@ -14,11 +14,13 @@
 
 """Imagecraft Package service."""
 
+import contextlib
+import tempfile
 from pathlib import Path
 from typing import cast
 
 from craft_application import PackageService, models
-from craft_cli import emit
+from craft_cli import CraftError, emit
 from typing_extensions import override
 
 from imagecraft.models import Project, get_partition_name
@@ -43,33 +45,76 @@ class ImagecraftPackService(PackageService):
         volume_name, volume = next(iter(project.volumes.items()))
 
         image_service = cast(ImageService, self._services.get("image"))
-        # Both calls are idempotent — the prologue hook will have run them
+        # create_images() is idempotent — the prologue hook will have run it
         # already during the lifecycle, but pack may be called standalone.
         image_service.create_images()
-        image_service.attach_images()
 
         project_dirs = self._services.get("lifecycle").project_info.dirs
-        loop_paths = image_service.get_loop_paths()
+        images = image_service.get_images()
+        image_path = images[volume_name]
+        partition_numbers = image_service._get_partition_numbers(volume)  # noqa: SLF001
 
-        try:
-            for structure_item in volume.structure:
-                partition_name = get_partition_name(volume_name, structure_item)
-                emit.progress(f"Preparing partition {partition_name}")
-                partition_prime_dir = project_dirs.get_prime_dir(
-                    partition=partition_name
+        for structure_item in volume.structure:
+            partition_name = get_partition_name(volume_name, structure_item)
+            emit.progress(f"Preparing partition {partition_name}")
+            partition_prime_dir = project_dirs.get_prime_dir(
+                partition=partition_name
+            )
+
+            partition_number = partition_numbers[structure_item.name]
+            geometry = diskutil.get_partition_geometry(
+                imagepath=image_path,
+                partition_number=partition_number,
+            )
+
+            # Sanity-check the on-disk size matches the structure spec.
+            expected_sectors = diskutil.bytes_to_sectors(
+                structure_item.size, geometry.sector_size
+            )
+            if geometry.sector_count != expected_sectors:
+                raise CraftError(
+                    f"Partition {partition_name!r} on-disk size "
+                    f"({geometry.sector_count} sectors) does not match the "
+                    f"requested size ({expected_sectors} sectors).",
                 )
-                loop_path = Path(loop_paths[f"{volume_name}/{structure_item.name}"])
 
-                diskutil.format_device(
-                    device_path=loop_path,
+            # Build the partition contents in a temp file, then dd it into
+            # the disk image at the partition's sector offset. This avoids
+            # losetup entirely, which is needed so imagecraft can run inside
+            # unprivileged LXD containers.
+            safe_prefix = partition_name.replace("/", "_")
+            with tempfile.NamedTemporaryFile(
+                prefix=f".{safe_prefix}.part.",
+                suffix=".tmp",
+                dir=image_path.parent,
+                delete=False,
+            ) as tf:
+                part_path = Path(tf.name)
+            try:
+                with part_path.open("wb") as fh:
+                    fh.truncate(geometry.size_bytes)
+
+                diskutil.format_populate_partition(
                     fstype=structure_item.filesystem,
-                    label=structure_item.filesystem_label,
                     content_dir=partition_prime_dir,
+                    partitionpath=part_path,
+                    label=structure_item.filesystem_label,
                 )
 
-            image_service.verify_images()
-        finally:
-            image_service.detach_images()
+                diskutil.inject_partition_into_image(
+                    partition=part_path,
+                    imagepath=image_path,
+                    sector_offset=geometry.sector_offset,
+                    disk_size=diskutil.DiskSize(
+                        bytesize=geometry.size_bytes,
+                        sector_size=geometry.sector_size,
+                    ),
+                )
+            finally:
+                with contextlib.suppress(FileNotFoundError):
+                    part_path.unlink()
+
+        image_service.verify_images()
 
         images = image_service.finalize_images(dest)
 

--- a/tests/unit/pack/test_diskutil.py
+++ b/tests/unit/pack/test_diskutil.py
@@ -12,6 +12,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from subprocess import CompletedProcess
 from unittest.mock import ANY, call
 
 import pytest
@@ -234,3 +235,94 @@ def test_format_device_fat_no_content(mocker, device):
 
     assert mocked_run.call_count == 1
     assert mocked_run.call_args[0][0] == "mkfs.fat"
+
+
+# ── get_partition_geometry ───────────────────────────────────────────────────
+
+
+_GPT_SFDISK_JSON = """
+{
+   "partitiontable": {
+      "label": "gpt",
+      "device": "%(image)s",
+      "unit": "sectors",
+      "sectorsize": 512,
+      "partitions": [
+         {
+            "node": "%(image)s1",
+            "start": 2048,
+            "size": 524288,
+            "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+            "name": "efi"
+         },
+         {
+            "node": "%(image)s2",
+            "start": 526336,
+            "size": 12582912,
+            "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+            "name": "rootfs"
+         }
+      ]
+   }
+}
+"""
+
+_MBR_SFDISK_JSON = """
+{
+   "partitiontable": {
+      "label": "dos",
+      "device": "%(image)s",
+      "unit": "sectors",
+      "sectorsize": 512,
+      "partitions": [
+         {"node": "%(image)s1", "start": 2048, "size": 524288, "type": "0c", "bootable": true},
+         {"node": "%(image)s2", "start": 526336, "size": 10485760, "type": "83"}
+      ]
+   }
+}
+"""
+
+
+@pytest.mark.parametrize(
+    ("template", "image_name"),
+    [
+        (_GPT_SFDISK_JSON, "pc.img"),
+        (_MBR_SFDISK_JSON, "pi.img"),
+    ],
+)
+def test_get_partition_geometry(mocker, tmp_path, template, image_name):
+    image_path = tmp_path / image_name
+    fake_result = CompletedProcess(
+        args=[],
+        returncode=0,
+        stdout=template % {"image": str(image_path)},
+    )
+    mocker.patch(
+        "imagecraft.pack.diskutil.run", autospec=True, return_value=fake_result
+    )
+
+    geom1 = diskutil.get_partition_geometry(image_path, 1)
+    geom2 = diskutil.get_partition_geometry(image_path, 2)
+
+    assert geom1.sector_offset == 2048
+    assert geom1.sector_count == 524288
+    assert geom1.sector_size == 512
+    assert geom1.size_bytes == 524288 * 512
+
+    assert geom2.sector_offset == 526336
+    assert geom2.sector_size == 512
+
+
+def test_get_partition_geometry_missing(mocker, tmp_path):
+    image_path = tmp_path / "pc.img"
+    fake_result = CompletedProcess(
+        args=[],
+        returncode=0,
+        stdout=_GPT_SFDISK_JSON % {"image": str(image_path)},
+    )
+    mocker.patch(
+        "imagecraft.pack.diskutil.run", autospec=True, return_value=fake_result
+    )
+
+    with pytest.raises(CraftError, match="No partition numbered 9"):
+        diskutil.get_partition_geometry(image_path, 9)

--- a/tests/unit/pack/test_diskutil.py
+++ b/tests/unit/pack/test_diskutil.py
@@ -154,6 +154,57 @@ def test_format_populate_partition(
     mocked_run.assert_has_calls(calls)
 
 
+def test_format_populate_partition_ext_with_offset(mocker, content, imagepath):
+    """An ext partition with geometry is written in place at its offset."""
+    mocked_run = mocker.patch("imagecraft.pack.diskutil.run", autospec=True)
+    geometry = diskutil.PartitionGeometry(
+        sector_offset=2048, sector_count=32768, sector_size=512
+    )
+
+    diskutil.format_populate_partition(
+        fstype=FileSystem.EXT4,
+        content_dir=content,
+        partitionpath=imagepath,
+        label="test",
+        geometry=geometry,
+    )
+
+    args = mocked_run.call_args_list[0].args
+    assert args[0] == "mke2fs"
+    # offset is in bytes; size is the partition size in KiB.
+    assert "-E" in args
+    assert f"offset={2048 * 512}" in args
+    assert f"{32768 * 512 // 1024}k" == args[-1]
+
+
+def test_format_populate_partition_fat_with_offset(mocker, content, imagepath):
+    """A FAT partition with geometry passes --offset to mkfs.fat and @@ to mcopy."""
+    mocked_run = mocker.patch("imagecraft.pack.diskutil.run", autospec=True)
+    geometry = diskutil.PartitionGeometry(
+        sector_offset=2048, sector_count=32768, sector_size=512
+    )
+
+    diskutil.format_populate_partition(
+        fstype=FileSystem.FAT16,
+        content_dir=content,
+        partitionpath=imagepath,
+        label="test",
+        geometry=geometry,
+    )
+
+    mkfs_args = mocked_run.call_args_list[0].args
+    assert mkfs_args[0] == "mkfs.fat"
+    # mkfs.fat --offset is in sectors; block-count is in KiB.
+    assert "--offset" in mkfs_args
+    assert str(2048) in mkfs_args
+    assert str(32768 * 512 // 1024) == mkfs_args[-1]
+
+    # mcopy targets the image at the partition's byte offset.
+    mcopy_args = mocked_run.call_args_list[1].args
+    assert mcopy_args[0] == "bash"
+    assert f"-i{imagepath}@@{2048 * 512}" in mcopy_args[2]
+
+
 # ── format_device ────────────────────────────────────────────────────────────
 
 

--- a/tests/unit/services/test_pack.py
+++ b/tests/unit/services/test_pack.py
@@ -15,20 +15,36 @@ from typing import cast
 
 import pytest
 from craft_application import ServiceFactory
+from craft_cli import CraftError
+from imagecraft.pack import diskutil
 from imagecraft.services.image import ImageService
 from imagecraft.services.pack import ImagecraftPackService
 
 
 @pytest.fixture
 def mock_image_service(default_factory: ServiceFactory, tmp_path):
-    """ImageService with losetup operations mocked out."""
+    """ImageService with image state pre-populated.
+
+    The default project (see tests/conftest.py) has two partitions: efi
+    (256M aligned to 524288 sectors -- but spec says 500M) and rootfs
+    (6G). We expose stub partition geometry below so pack() can run
+    without invoking sfdisk on a real image.
+    """
     svc = cast(ImageService, default_factory.get("image"))
-    # Pre-populate state so pack() doesn't need to call losetup
+    # Pre-populate image state so pack() doesn't need to call create_images().
     svc._images = {"pc": tmp_path / ".pc.img.tmp"}
-    svc._loop_devices = {"pc": "/dev/loop8"}
-    svc._atexit_registered = True
-    yield svc
-    svc._loop_devices.clear()
+    return svc
+
+
+def _geometry_for(structure_item, partition_number, start_sector=2048):
+    """Build a PartitionGeometry that matches the structure's requested size."""
+    sector_size = 512
+    sectors = diskutil.bytes_to_sectors(structure_item.size, sector_size)
+    return diskutil.PartitionGeometry(
+        sector_offset=start_sector + partition_number * 10_000,
+        sector_count=sectors,
+        sector_size=sector_size,
+    )
 
 
 def test_pack(
@@ -42,43 +58,89 @@ def test_pack(
     prime_dir = tmp_path / "prime"
     dest_path = tmp_path / "dest"
 
-    # Mock out all system calls
-    mocker.patch.object(mock_image_service, "create_images")
-    mocker.patch.object(mock_image_service, "attach_images")
+    project = default_factory.get("project").get()
+    volume = project.volumes["pc"]
+
+    # Mock image service methods so we don't actually touch loop devices/files.
+    mock_create = mocker.patch.object(mock_image_service, "create_images")
     mock_verify = mocker.patch.object(mock_image_service, "verify_images")
-    mock_detach = mocker.patch.object(mock_image_service, "detach_images")
     mock_finalize = mocker.patch.object(
         mock_image_service,
         "finalize_images",
         return_value={"pc": tmp_path / "dest" / "pc.img"},
     )
-    mock_diskutil = mocker.patch("imagecraft.services.pack.diskutil", autospec=True)
+
+    # Provide geometry that matches each partition's structure size.
+    geometries = {
+        item.name: _geometry_for(item, idx)
+        for idx, item in enumerate(volume.structure, start=1)
+    }
+
+    def fake_geometry(*, imagepath, partition_number):
+        # partition_number is 1-based; structure positions are 1-based.
+        item = volume.structure[partition_number - 1]
+        return geometries[item.name]
+
+    mock_get_geometry = mocker.patch(
+        "imagecraft.services.pack.diskutil.get_partition_geometry",
+        side_effect=fake_geometry,
+    )
+    mock_format_populate = mocker.patch(
+        "imagecraft.services.pack.diskutil.format_populate_partition",
+    )
+    mock_inject = mocker.patch(
+        "imagecraft.services.pack.diskutil.inject_partition_into_image",
+    )
     mock_grubutil = mocker.patch("imagecraft.services.pack.grubutil", autospec=True)
     mock_image_cls = mocker.patch("imagecraft.services.pack.Image", autospec=True)
 
+    # losetup-style methods must NOT be reached from the build path.
+    mock_attach = mocker.patch.object(mock_image_service, "attach_images")
+    mock_detach = mocker.patch.object(mock_image_service, "detach_images")
+
     result = pack_service.pack(prime_dir=prime_dir, dest=dest_path)
 
-    # format_device called for each partition (efi + rootfs), populate_device is not a separate call
-    assert mock_diskutil.format_device.call_count == 2
+    # create_images is still called (it's idempotent).
+    mock_create.assert_called_once()
 
-    # Verify called before detach
+    # One format + one inject per partition (efi + rootfs).
+    assert mock_format_populate.call_count == len(volume.structure)
+    assert mock_inject.call_count == len(volume.structure)
+    assert mock_get_geometry.call_count == len(volume.structure)
+
+    # Each format_populate call must use the structure's fstype/label.
+    for call_args, structure_item in zip(
+        mock_format_populate.call_args_list, volume.structure, strict=True
+    ):
+        kwargs = call_args.kwargs
+        assert kwargs["fstype"] == structure_item.filesystem
+        assert kwargs["label"] == structure_item.filesystem_label
+        # partitionpath is a temp file under the image dir.
+        assert kwargs["partitionpath"].parent == (tmp_path / ".pc.img.tmp").parent
+
+    # Each inject must use the matching sector offset.
+    for call_args, structure_item in zip(
+        mock_inject.call_args_list, volume.structure, strict=True
+    ):
+        kwargs = call_args.kwargs
+        assert kwargs["imagepath"] == tmp_path / ".pc.img.tmp"
+        assert kwargs["sector_offset"] == geometries[structure_item.name].sector_offset
+
     mock_verify.assert_called_once()
-    mock_detach.assert_called_once()
     mock_finalize.assert_called_once_with(dest_path)
 
-    # grubutil called on the final image
+    # grubutil called on the final image.
     mock_grubutil.setup_grub.assert_called_once()
     mock_image_cls.assert_called_once()
 
-    # Old functions must NOT be called
-    mock_diskutil.create_zero_image.assert_not_called()
-    mock_diskutil.inject_partition_into_image.assert_not_called()
-    mock_diskutil.format_populate_partition.assert_not_called()
+    # losetup-style methods must NOT have been called from pack().
+    mock_attach.assert_not_called()
+    mock_detach.assert_not_called()
 
     assert result == [dest_path / "pc.img"]
 
 
-def test_pack_detaches_on_error(
+def test_pack_size_mismatch_raises(
     tmp_path,
     enable_features,
     default_factory: ServiceFactory,
@@ -86,22 +148,74 @@ def test_pack_detaches_on_error(
     mock_image_service: ImageService,
     mocker,
 ):
-    """detach_images() must be called even if format_device raises."""
+    """If sfdisk reports a partition size that disagrees with the structure
+    spec, pack() must raise instead of silently truncating data."""
     dest_path = tmp_path / "dest"
 
     mocker.patch.object(mock_image_service, "create_images")
-    mocker.patch.object(mock_image_service, "attach_images")
-    mock_detach = mocker.patch.object(mock_image_service, "detach_images")
     mocker.patch.object(mock_image_service, "verify_images")
     mocker.patch.object(mock_image_service, "finalize_images")
-    mocker.patch(
-        "imagecraft.services.pack.diskutil.format_device",
-        side_effect=RuntimeError("disk full"),
-    )
     mocker.patch("imagecraft.services.pack.grubutil", autospec=True)
     mocker.patch("imagecraft.services.pack.Image", autospec=True)
+
+    # Return geometry with a wrong sector count.
+    bogus_geometry = diskutil.PartitionGeometry(
+        sector_offset=2048,
+        sector_count=1,  # deliberately wrong
+        sector_size=512,
+    )
+    mocker.patch(
+        "imagecraft.services.pack.diskutil.get_partition_geometry",
+        return_value=bogus_geometry,
+    )
+    mocker.patch("imagecraft.services.pack.diskutil.format_populate_partition")
+    mocker.patch("imagecraft.services.pack.diskutil.inject_partition_into_image")
+
+    with pytest.raises(CraftError, match="does not match the requested size"):
+        pack_service.pack(prime_dir=tmp_path / "prime", dest=dest_path)
+
+
+def test_pack_cleans_temp_partition_files_on_error(
+    tmp_path,
+    enable_features,
+    default_factory: ServiceFactory,
+    pack_service: ImagecraftPackService,
+    mock_image_service: ImageService,
+    mocker,
+):
+    """The per-partition temp file must be removed even if formatting raises."""
+    dest_path = tmp_path / "dest"
+
+    project = default_factory.get("project").get()
+    volume = project.volumes["pc"]
+    first_item = volume.structure[0]
+
+    mocker.patch.object(mock_image_service, "create_images")
+    mocker.patch.object(mock_image_service, "verify_images")
+    mocker.patch.object(mock_image_service, "finalize_images")
+    mocker.patch("imagecraft.services.pack.grubutil", autospec=True)
+    mocker.patch("imagecraft.services.pack.Image", autospec=True)
+
+    mocker.patch(
+        "imagecraft.services.pack.diskutil.get_partition_geometry",
+        return_value=_geometry_for(first_item, 1),
+    )
+    captured_paths: list = []
+
+    def fail_format(*, partitionpath, **kwargs):
+        captured_paths.append(partitionpath)
+        raise RuntimeError("disk full")
+
+    mocker.patch(
+        "imagecraft.services.pack.diskutil.format_populate_partition",
+        side_effect=fail_format,
+    )
+    mocker.patch("imagecraft.services.pack.diskutil.inject_partition_into_image")
 
     with pytest.raises(RuntimeError, match="disk full"):
         pack_service.pack(prime_dir=tmp_path / "prime", dest=dest_path)
 
-    mock_detach.assert_called_once()
+    # The temp file used for the partition must have been cleaned up.
+    assert captured_paths
+    for path in captured_paths:
+        assert not path.exists()

--- a/tests/unit/services/test_pack.py
+++ b/tests/unit/services/test_pack.py
@@ -88,9 +88,6 @@ def test_pack(
     mock_format_populate = mocker.patch(
         "imagecraft.services.pack.diskutil.format_populate_partition",
     )
-    mock_inject = mocker.patch(
-        "imagecraft.services.pack.diskutil.inject_partition_into_image",
-    )
     mock_grubutil = mocker.patch("imagecraft.services.pack.grubutil", autospec=True)
     mock_image_cls = mocker.patch("imagecraft.services.pack.Image", autospec=True)
 
@@ -103,28 +100,21 @@ def test_pack(
     # create_images is still called (it's idempotent).
     mock_create.assert_called_once()
 
-    # One format + one inject per partition (efi + rootfs).
+    # One format-and-populate per partition (efi + rootfs).
     assert mock_format_populate.call_count == len(volume.structure)
-    assert mock_inject.call_count == len(volume.structure)
     assert mock_get_geometry.call_count == len(volume.structure)
 
-    # Each format_populate call must use the structure's fstype/label.
+    # Each format_populate call writes directly into the disk image at the
+    # partition's geometry, using the structure's fstype/label.
     for call_args, structure_item in zip(
         mock_format_populate.call_args_list, volume.structure, strict=True
     ):
         kwargs = call_args.kwargs
         assert kwargs["fstype"] == structure_item.filesystem
         assert kwargs["label"] == structure_item.filesystem_label
-        # partitionpath is a temp file under the image dir.
-        assert kwargs["partitionpath"].parent == (tmp_path / ".pc.img.tmp").parent
-
-    # Each inject must use the matching sector offset.
-    for call_args, structure_item in zip(
-        mock_inject.call_args_list, volume.structure, strict=True
-    ):
-        kwargs = call_args.kwargs
-        assert kwargs["imagepath"] == tmp_path / ".pc.img.tmp"
-        assert kwargs["sector_offset"] == geometries[structure_item.name].sector_offset
+        # partitionpath is the disk image itself (no intermediate temp file).
+        assert kwargs["partitionpath"] == tmp_path / ".pc.img.tmp"
+        assert kwargs["geometry"] == geometries[structure_item.name]
 
     mock_verify.assert_called_once()
     mock_finalize.assert_called_once_with(dest_path)
@@ -169,53 +159,6 @@ def test_pack_size_mismatch_raises(
         return_value=bogus_geometry,
     )
     mocker.patch("imagecraft.services.pack.diskutil.format_populate_partition")
-    mocker.patch("imagecraft.services.pack.diskutil.inject_partition_into_image")
 
     with pytest.raises(CraftError, match="does not match the requested size"):
         pack_service.pack(prime_dir=tmp_path / "prime", dest=dest_path)
-
-
-def test_pack_cleans_temp_partition_files_on_error(
-    tmp_path,
-    enable_features,
-    default_factory: ServiceFactory,
-    pack_service: ImagecraftPackService,
-    mock_image_service: ImageService,
-    mocker,
-):
-    """The per-partition temp file must be removed even if formatting raises."""
-    dest_path = tmp_path / "dest"
-
-    project = default_factory.get("project").get()
-    volume = project.volumes["pc"]
-    first_item = volume.structure[0]
-
-    mocker.patch.object(mock_image_service, "create_images")
-    mocker.patch.object(mock_image_service, "verify_images")
-    mocker.patch.object(mock_image_service, "finalize_images")
-    mocker.patch("imagecraft.services.pack.grubutil", autospec=True)
-    mocker.patch("imagecraft.services.pack.Image", autospec=True)
-
-    mocker.patch(
-        "imagecraft.services.pack.diskutil.get_partition_geometry",
-        return_value=_geometry_for(first_item, 1),
-    )
-    captured_paths: list = []
-
-    def fail_format(*, partitionpath, **kwargs):
-        captured_paths.append(partitionpath)
-        raise RuntimeError("disk full")
-
-    mocker.patch(
-        "imagecraft.services.pack.diskutil.format_populate_partition",
-        side_effect=fail_format,
-    )
-    mocker.patch("imagecraft.services.pack.diskutil.inject_partition_into_image")
-
-    with pytest.raises(RuntimeError, match="disk full"):
-        pack_service.pack(prime_dir=tmp_path / "prime", dest=dest_path)
-
-    # The temp file used for the partition must have been cleaned up.
-    assert captured_paths
-    for path in captured_paths:
-        assert not path.exists()


### PR DESCRIPTION
This is 100% vibe coded, but I think it might be possible to have imagecraft not require access to loop devices at all which would be a great step towards having it be able to run in unprivileged containers (I have another vibe-coded branch that removes it in the grub case). Happy to talk about all this at some point!

Replace the losetup-based build path with a loop-free flow. For each partition in a volume, pack() now:

1. Reads the partition's sector offset and size from sfdisk --json on the disk file (via the new diskutil.get_partition_geometry helper, which works for both GPT and MBR images).
2. Sanity-checks the on-disk size against the structure spec.
3. Creates a temp file sized to match the partition.
4. Calls diskutil.format_populate_partition to mkfs/copy content into the temp file.
5. dd's the temp file into the disk image at the right sector offset via diskutil.inject_partition_into_image.
6. Deletes the temp file.

attach_images/detach_images/get_loop_paths and the atexit handler in ImageService are no longer called from the build path, removing the losetup requirement. The methods themselves are kept in place for now because pack/grubutil.py still uses image.attach_loopdev() for grub install; that is being addressed in a parallel Phase B effort.

This is required so imagecraft can build images inside unprivileged LXD containers, where /dev/loop-control is gated on init_user_ns CAP_SYS_ADMIN.


---

- [ ] I've followed the [contribution guidelines](https://github.com/canonical/imagecraft/blob/main/CONTRIBUTING.md).
- [ ] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [ ] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
