### PR TITLE
fix(mmdebstrap_plugin): unmount lingering mounts

### DIFF
--- a/imagecraft/plugins/mmdebstrap_plugin.py
+++ b/imagecraft/plugins/mmdebstrap_plugin.py
@@ -98,8 +98,11 @@ class MmdebstrapPlugin(Plugin):
 
         suite = options.mmdebstrap_suite or self._get_build_base_suite()
         cmd.append(f'{suite} "$CRAFT_PART_INSTALL" {self._get_default_mirror()}')
+        return [" ".join(cmd), *self._get_cleanup_commands()]
+
+    def _get_cleanup_commands(self) -> list[str]:
         return [
-            " ".join(cmd),
+            'for m in $(findmnt -rno TARGET | grep "^$CRAFT_PART_INSTALL/" | sort -r); do umount -lf "$m" 2>/dev/null || true; done',
             'rm -rf "$CRAFT_PART_INSTALL"/dev/*',
             'rm -rf "$CRAFT_PART_INSTALL"/etc/apt/sources.list.d/*',
             'rm -f "$CRAFT_PART_INSTALL"/etc/apt/sources.list',

--- a/imagecraft/plugins/mmdebstrap_plugin.py
+++ b/imagecraft/plugins/mmdebstrap_plugin.py
@@ -103,6 +103,8 @@ class MmdebstrapPlugin(Plugin):
     def _get_cleanup_commands(self) -> list[str]:
         return [
             'for m in $(findmnt -rno TARGET | grep "^$CRAFT_PART_INSTALL/" | sort -r); do umount -lf "$m" 2>/dev/null || true; done',
+            'mountpoint -q "$CRAFT_PART_INSTALL"/sys || rm -rf "$CRAFT_PART_INSTALL"/sys/*',
+            'mountpoint -q "$CRAFT_PART_INSTALL"/proc || rm -rf "$CRAFT_PART_INSTALL"/proc/*',
             'rm -rf "$CRAFT_PART_INSTALL"/dev/*',
             'rm -rf "$CRAFT_PART_INSTALL"/etc/apt/sources.list.d/*',
             'rm -f "$CRAFT_PART_INSTALL"/etc/apt/sources.list',

--- a/imagecraft/plugins/mmdebstrap_plugin.py
+++ b/imagecraft/plugins/mmdebstrap_plugin.py
@@ -101,11 +101,13 @@ class MmdebstrapPlugin(Plugin):
         return [" ".join(cmd), *self._get_cleanup_commands()]
 
     def _get_cleanup_commands(self) -> list[str]:
+        # unmount any leftover mounts
+        # skip content-removal if directory still mounted
         return [
             'for m in $(findmnt -rno TARGET | grep "^$CRAFT_PART_INSTALL/" | sort -r); do umount -lf "$m" 2>/dev/null || true; done',
             'mountpoint -q "$CRAFT_PART_INSTALL"/sys || rm -rf "$CRAFT_PART_INSTALL"/sys/*',
             'mountpoint -q "$CRAFT_PART_INSTALL"/proc || rm -rf "$CRAFT_PART_INSTALL"/proc/*',
-            'rm -rf "$CRAFT_PART_INSTALL"/dev/*',
+            'mountpoint -q "$CRAFT_PART_INSTALL"/dev || rm -rf "$CRAFT_PART_INSTALL"/dev/*',
             'rm -rf "$CRAFT_PART_INSTALL"/etc/apt/sources.list.d/*',
             'rm -f "$CRAFT_PART_INSTALL"/etc/apt/sources.list',
         ]

--- a/tests/integration/plugins/mmdebstrap/imagecraft.yaml
+++ b/tests/integration/plugins/mmdebstrap/imagecraft.yaml
@@ -1,0 +1,31 @@
+name: mmdebstrap-test
+version: "0.1"
+summary: Test mmdebstrap plugin
+description: Test mmdebstrap plugin
+base: bare
+build-base: ubuntu@24.04
+platforms:
+  amd64:
+  arm64:
+
+parts:
+  rootfs:
+    plugin: mmdebstrap
+    organize:
+      "*": (overlay)/
+
+volumes:
+  pc:
+    schema: gpt
+    structure:
+      - name: rootfs
+        type: 0FC63DAF-8483-4772-8E79-3D69D8477DE4
+        filesystem: ext4
+        filesystem-label: writable
+        role: system-data
+        size: 512M
+
+filesystems:
+  default:
+    - mount: /
+      device: (volume/pc/rootfs)

--- a/tests/integration/plugins/test_mmdebstrap_plugin.py
+++ b/tests/integration/plugins/test_mmdebstrap_plugin.py
@@ -1,0 +1,53 @@
+#  This file is part of imagecraft.
+#
+#  Copyright 2026 Canonical Ltd.
+#
+#  This program is free software: you can redistribute it and/or modify it
+#  under the terms of the GNU General Public License version 3, as
+#  published by the Free Software Foundation.
+#
+#  This program is distributed in the hope that it will be useful, but WITHOUT
+#  ANY WARRANTY; without even the implied warranties of MERCHANTABILITY,
+#  SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.
+#  See the GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Integration tests for the mmdebstrap plugin."""
+
+from pathlib import Path
+
+import pytest
+from imagecraft import application
+
+
+@pytest.fixture
+def custom_project_file(default_project_file: Path):
+    yaml_content = (Path(__file__).parent / "mmdebstrap/imagecraft.yaml").read_text()
+    default_project_file.write_text(yaml_content)
+    return default_project_file
+
+
+@pytest.mark.slow
+@pytest.mark.requires_root
+def test_mmdebstrap_cleanup(
+    project_path: Path,
+    custom_project_file: Path,
+    imagecraft_app: application.Imagecraft,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Test that mmdebstrap plugin cleans up /sys, /proc and /dev."""
+    monkeypatch.setattr(
+        "sys.argv",
+        ["imagecraft", "build", "--destructive-mode", "--verbosity", "debug"],
+    )
+    result = imagecraft_app.run()
+
+    assert result == 0
+
+    install_dir = project_path / "parts/rootfs/install"
+
+    for subdir in ["sys", "proc", "dev"]:
+        path = install_dir / subdir
+        if path.exists():
+            assert list(path.iterdir()) == []

--- a/tests/unit/plugins/test_mmdebstrap_plugin.py
+++ b/tests/unit/plugins/test_mmdebstrap_plugin.py
@@ -58,6 +58,9 @@ def test_get_build_snaps(plugin):
 def test_get_build_commands(plugin, arch, mirror):
     assert plugin.get_build_commands() == [
         f'mmdebstrap --arch={arch} --mode=root --variant=apt --format=dir noble "$CRAFT_PART_INSTALL" {mirror}',
+        'for m in $(findmnt -rno TARGET | grep "^$CRAFT_PART_INSTALL/" | sort -r); do umount -lf "$m" 2>/dev/null || true; done',
+        'mountpoint -q "$CRAFT_PART_INSTALL"/sys || rm -rf "$CRAFT_PART_INSTALL"/sys/*',
+        'mountpoint -q "$CRAFT_PART_INSTALL"/proc || rm -rf "$CRAFT_PART_INSTALL"/proc/*',
         'rm -rf "$CRAFT_PART_INSTALL"/dev/*',
         'rm -rf "$CRAFT_PART_INSTALL"/etc/apt/sources.list.d/*',
         'rm -f "$CRAFT_PART_INSTALL"/etc/apt/sources.list',

--- a/tests/unit/plugins/test_mmdebstrap_plugin.py
+++ b/tests/unit/plugins/test_mmdebstrap_plugin.py
@@ -61,7 +61,7 @@ def test_get_build_commands(plugin, arch, mirror):
         'for m in $(findmnt -rno TARGET | grep "^$CRAFT_PART_INSTALL/" | sort -r); do umount -lf "$m" 2>/dev/null || true; done',
         'mountpoint -q "$CRAFT_PART_INSTALL"/sys || rm -rf "$CRAFT_PART_INSTALL"/sys/*',
         'mountpoint -q "$CRAFT_PART_INSTALL"/proc || rm -rf "$CRAFT_PART_INSTALL"/proc/*',
-        'rm -rf "$CRAFT_PART_INSTALL"/dev/*',
+        'mountpoint -q "$CRAFT_PART_INSTALL"/dev || rm -rf "$CRAFT_PART_INSTALL"/dev/*',
         'rm -rf "$CRAFT_PART_INSTALL"/etc/apt/sources.list.d/*',
         'rm -f "$CRAFT_PART_INSTALL"/etc/apt/sources.list',
     ]

--- a/tests/unit/plugins/test_mmdebstrap_plugin.py
+++ b/tests/unit/plugins/test_mmdebstrap_plugin.py
@@ -58,12 +58,7 @@ def test_get_build_snaps(plugin):
 def test_get_build_commands(plugin, arch, mirror):
     assert plugin.get_build_commands() == [
         f'mmdebstrap --arch={arch} --mode=root --variant=apt --format=dir noble "$CRAFT_PART_INSTALL" {mirror}',
-        'for m in $(findmnt -rno TARGET | grep "^$CRAFT_PART_INSTALL/" | sort -r); do umount -lf "$m" 2>/dev/null || true; done',
-        'mountpoint -q "$CRAFT_PART_INSTALL"/sys || rm -rf "$CRAFT_PART_INSTALL"/sys/*',
-        'mountpoint -q "$CRAFT_PART_INSTALL"/proc || rm -rf "$CRAFT_PART_INSTALL"/proc/*',
-        'mountpoint -q "$CRAFT_PART_INSTALL"/dev || rm -rf "$CRAFT_PART_INSTALL"/dev/*',
-        'rm -rf "$CRAFT_PART_INSTALL"/etc/apt/sources.list.d/*',
-        'rm -f "$CRAFT_PART_INSTALL"/etc/apt/sources.list',
+        *plugin._get_cleanup_commands(),
     ]
 
 


### PR DESCRIPTION
Adds clean-up commands to the mmdebstrap plugin to unmount any remaining mounts and remove files inside sys/* and proc/* after unmounting

Fixes #337 

(IMAGECRAFT-142)

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/imagecraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
