### PR TITLE
ci: add conditionals for docs-only checks

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -10,11 +10,33 @@ on:
   pull_request:
 
 jobs:
+  filter:
+    runs-on: ubuntu-slim
+    outputs:
+      source-files: ${{ steps.filter.outputs.source-files }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        id: filter
+        with:
+          # Combine multiple negation checks into a union (¬A ∧ ¬B ∧ ¬C), because individual entries are checked independently (A ∨ B ∨ C).
+          # If we ever need to filter only for docs, glob 'docs/**/*' and '**/*.md'
+          filters: |
+            source-files:
+              - '!({docs/**,*.md,**/*.md,.readthedocs.yaml})'
   lint:
     uses: canonical/starflow/.github/workflows/lint-python.yaml@main
+    needs: filter
+    with:
+      source-files: ${{ needs.filter.outputs.source-files }}
   test:
     uses: canonical/starflow/.github/workflows/test-python.yaml@main
+    needs: filter
     with:
+      source-files: ${{ needs.filter.outputs.source-files }}
       lowest-python-version: ""
       fast-test-platforms: '["ubuntu-24.04"]'
       fast-test-python-versions: '["3.12", "3.13"]'
@@ -22,7 +44,9 @@ jobs:
       slow-test-python-versions: '["3.12"]'
   test-requires-root:
     uses: canonical/starflow/.github/workflows/test-python.yaml@main
+    needs: filter
     with:
+      source-files: ${{ needs.filter.outputs.source-files }}
       fast-test-platforms: '["ubuntu-24.04", "ubuntu-24.04-arm"]'
       fast-test-python-versions: '["3.12"]'
       slow-test-platforms: '["ubuntu-24.04", "ubuntu-24.04-arm"]'

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -13,15 +13,33 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  filter:
+    runs-on: ubuntu-slim
+    outputs:
+      source-files: ${{ steps.filter.outputs.source-files }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        id: filter
+        with:
+          # Combine multiple negation checks into a union (¬A ∧ ¬B ∧ ¬C), because individual entries are checked independently (A ∨ B ∨ C).
+          # If we ever need to filter only for docs, glob 'docs/**/*' and '**/*.md'
+          filters: |
+            source-files:
+              - '!({docs/**,*.md,**/*.md,.readthedocs.yaml})'
   build:
     runs-on: ubuntu-latest
+    needs: filter
     steps:
       - name: Decision to Publish
         id: decisions
         run: |
           # Secrets cannot be used in conditionals, so this is our dance:
           # https://github.com/actions/runner/issues/520
-          if [[ -n "${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}" ]]; then
+          if [[ -n "${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}" && "${{ needs.filter.outputs.source-files }}" = "true" ]]; then
             echo PUBLISH=true >> $GITHUB_OUTPUT
           else
             echo PUBLISH= >> $GITHUB_OUTPUT

--- a/.github/workflows/spread-test.yaml
+++ b/.github/workflows/spread-test.yaml
@@ -7,11 +7,29 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  filter:
+    runs-on: ubuntu-slim
+    outputs:
+      source-files: ${{ steps.filter.outputs.source-files }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        id: filter
+        with:
+          # Combine multiple negation checks into a union (¬A ∧ ¬B ∧ ¬C), because individual entries are checked independently (A ∨ B ∨ C).
+          # If we ever need to filter only for docs, glob 'docs/**/*' and '**/*.md'
+          filters: |
+            source-files:
+              - '!({docs/**,*.md,**/*.md,.readthedocs.yaml})'
   snap-builds:
     runs-on: ubuntu-24.04
+    needs: filter
     # Only build the snap for pull requests, it's not needed on release branches
     # or on master since we have launchpad build recipes which do this already
-    if: ${{ github.event_name == 'pull_request' }}
+    if: ${{ github.event_name == 'pull_request' && needs.filter.outputs.source-files == 'true' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -30,7 +48,8 @@ jobs:
 
   spread:
     runs-on: [self-hosted, imagecraft]
-    needs: snap-builds
+    needs: [snap-builds, filter]
+    if: ${{ needs.filter.outputs.source-files == 'true' }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Add conditionals to skip required checks and unnecessary operations.

For CRAFT-5161.

Tested in my fork: https://github.com/medubelko/imagecraft/pull/2

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/imagecraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
