### PR TITLE
docs: incorporate tutorial feedback

### DIFF
--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -99,6 +99,7 @@ Starcraft
 subkey
 subproject
 subprojects
+sudo
 SVG
 sysfs
 tex

--- a/docs/tutorials/build-an-ubuntu-image.rst
+++ b/docs/tutorials/build-an-ubuntu-image.rst
@@ -71,7 +71,7 @@ We'll run our image with QEMU. Install it with:
     :end-at: sudo apt install qemu-system-x86
 
 Lastly, we'll need UEFI firmware to pass to QEMU. One of the most popular choices is
-OVMF.
+OVMF. Install it with:
 
 .. literalinclude:: code/build-an-ubuntu-image/task.yaml
     :language: bash
@@ -93,7 +93,7 @@ your software projects:
     :end-at: cd ubuntu-minimal
 
 Images are built and configured through an ``imagecraft.yaml`` file, called the *project
-file*. Let's create one in the new project directory with the ``init`` command.
+file*. Let's create one in the new project directory with the ``init`` command:
 
 .. literalinclude:: code/build-an-ubuntu-image/task.yaml
     :language: bash
@@ -377,7 +377,7 @@ Run and test the image
 ----------------------
 
 Before we run our image with QEMU, let's copy the UEFI variables from OVMF into a
-temporary directory so we don't compromise the originals.
+temporary directory so we don't compromise the originals:
 
 .. literalinclude:: code/build-an-ubuntu-image/task.yaml
     :language: bash
@@ -387,7 +387,7 @@ temporary directory so we don't compromise the originals.
 
 You'll need to repeat this step if you reboot your machine between runs.
 
-With no further ado, let's run the image with QEMU.
+With no further ado, let's run the image with QEMU:
 
 .. literalinclude:: code/build-an-ubuntu-image/task.yaml
     :language: bash

--- a/docs/tutorials/build-an-ubuntu-image.rst
+++ b/docs/tutorials/build-an-ubuntu-image.rst
@@ -308,7 +308,7 @@ partition's active mount options, whether we want to dump the partition's utilit
 backup, and the file system check order.
 
 Let's create a part that writes this to the ``/etc/fstab/`` directory in the overlay
-file system. Add the following ``fstab`` part:
+file system. Add a new part named ``fstab``, defined as follows:
 
 .. literalinclude:: code/build-an-ubuntu-image/imagecraft.yaml
     :language: yaml
@@ -333,7 +333,7 @@ For the purposes of this tutorial, we'll set up a ``login`` part that runs the
 built for production environments. In such cases, you should use a secure method that
 fits your image's application.
 
-Add the following ``login`` part:
+Add a new part named ``login``, defined as follows:
 
 .. literalinclude:: code/build-an-ubuntu-image/imagecraft.yaml
     :language: yaml
@@ -380,7 +380,7 @@ Run and test the image
 ----------------------
 
 Before we run our image with QEMU, let's copy the UEFI variables from OVMF into a
-temporary directory so we don't compromise the originals:
+temporary directory so we don't compromise the originals.
 
 .. literalinclude:: code/build-an-ubuntu-image/task.yaml
     :language: bash
@@ -390,7 +390,7 @@ temporary directory so we don't compromise the originals:
 
 You'll need to repeat this step if you reboot your machine between runs.
 
-With no further ado, let's run the image with QEMU:
+With no further ado, let's run the image with QEMU.
 
 .. literalinclude:: code/build-an-ubuntu-image/task.yaml
     :language: bash

--- a/docs/tutorials/build-an-ubuntu-image.rst
+++ b/docs/tutorials/build-an-ubuntu-image.rst
@@ -6,28 +6,12 @@
 Build an Ubuntu image
 =====================
 
-In this tutorial, we'll build a basic Ubuntu image. We'll set up the project, define the
-image's partitions and content, and run the image with QEMU.
+In this tutorial, we'll build a minimal Ubuntu image for AMD64 machines. We'll set up
+the project, define the image's partitions and content, and run the image with QEMU.
 
-You won't need to come prepared with an intimate understanding of software packaging or
-disk images, but familiarity with Linux paradigms and terminal operations is required.
-
-By the end of this tutorial, you'll have built a minimal, pre-installed Ubuntu image for
-AMD64 machines.
-
-
-Lesson plan
------------
-
-This tutorial takes about 25 minutes to complete and works through the process of
-building an image. You'll be shown how to:
-
-* Set up an image project from scratch
-* State the project's essential information
-* Set up the image's partitions and root file system
-* Add packages to the image
-* Set a default user and password
-* Package the image
+It takes about 25 minutes to complete and doesn't require an intimate understanding of
+software packaging or disk images. However, this tutorial does require some familiarity
+with Linux paradigms and terminal usage.
 
 
 What you'll need
@@ -48,11 +32,11 @@ To begin, we'll need to install the Imagecraft snap. Open a terminal and run:
 .. literalinclude:: code/build-an-ubuntu-image/task.yaml
     :language: bash
     :dedent: 2
-    :start-at: snap install imagecraft --channel=beta --classic
-    :end-at: snap install imagecraft --channel=beta --classic
+    :start-at: snap install imagecraft --beta --classic
+    :end-at: snap install imagecraft --beta --classic
 
 Let's also install Multipass, which will create the build environment when it comes
-time to package our image.
+time to package the image.
 
 .. literalinclude:: code/build-an-ubuntu-image/task.yaml
     :language: bash
@@ -60,19 +44,32 @@ time to package our image.
     :start-at: snap install multipass
     :end-at: snap install multipass
 
+We'll run our image with QEMU, a common choice for full-system emulation. In your
+terminal, install it by running:
+
+.. code-block:: bash
+
+    sudo apt install qemu-system-x86
+
+We'll also need UEFI firmware. One of the most popular choices for QEMU is OVMF. Install
+it with:
+
+.. code-block:: bash
+
+    sudo apt install ovmf
+
 
 Set up the project
 ------------------
 
-We'll need a directory to hold our project. Navigate to where you like to keep software
-projects and create the new directory with:
+We'll need a directory to hold the project. Create a directory wherever you like to keep
+your software projects with:
 
 .. literalinclude:: code/build-an-ubuntu-image/task.yaml
     :language: bash
     :dedent: 2
     :start-at: mkdir ubuntu-minimal
     :end-at: cd ubuntu-minimal
-
 
 Images are built and configured through an ``imagecraft.yaml`` file, called the *project
 file*. Let's create one in the new project directory with the ``init`` command.
@@ -83,8 +80,8 @@ file*. Let's create one in the new project directory with the ``init`` command.
     :start-at: imagecraft init
     :end-at: imagecraft init
 
-The generated project file will be our focus for most of this tutorial. Open it in your
-preferred text editor.
+Open the generated project file in your preferred text editor. This is where most of the
+tutorial will take place.
 
 
 .. _tutorial-describe-the-image:
@@ -92,29 +89,28 @@ preferred text editor.
 Describe the image
 ------------------
 
-An image's project file starts with its most essential descriptors, such as its name,
-version, and build environment. The comments in the template describe each of the keys.
-
-The ``init`` command filled out these top-level keys but left out some project-specific
-details. Let's update the ``summary`` and ``description`` keys to better reflect our new
-project. Replace the first six keys with:
+An image's project file starts with details like its name, version, and build
+environment. The ``init`` command declared these keys with some generic values. Let's
+update the ``summary`` and ``description`` keys to better reflect the new project.
+Replace the first six keys with:
 
 .. literalinclude:: code/build-an-ubuntu-image/imagecraft.yaml
     :language: yaml
     :start-at: name: ubuntu-minimal
     :end-at: Ubuntu 24.04 LTS, and it's booted with GRUB
 
-The ``base`` key defines the foundation for the image's contents. In Imagecraft, this is
-always an empty directory, known as the *bare* base.
+The ``base`` key defines the files that make up the foundation of the image. In
+Imagecraft, this is always an empty directory, known as the *bare* base, that must be
+built up manually.
 
-The ``build-base`` key defines the system that's used to assemble the image. It does
-*not* have any influence on the image's contents. It's best to build with the latest
-Ubuntu LTS release in most cases, so we left this unchanged.
+The ``build-base`` key defines the operating system that's used to assemble the image.
+It does *not* have any influence on the image's contents. It's best to build with the
+latest Ubuntu LTS release in most cases, so we left this unchanged.
 
-The ``summary`` and ``description`` keys tell consumers of our image a little more
+The ``summary`` and ``description`` keys tell consumers of the image a little more
 about it. The summary is a one-line description, limited at 79 characters, while the
 description is more open-ended and can span multiple lines. These were both placeholders
-in the template project file, so we made them meaningful for our project.
+in the template project file, so we made them meaningful for this project.
 
 
 .. _tutorial-define-the-partitions:
@@ -122,17 +118,17 @@ in the template project file, so we made them meaningful for our project.
 Define the partitions
 ---------------------
 
-Now that we've described our image and declared its essential build details, we need to
-define its disk partitions. To do so, we'll customize the ``volumes`` key.
+Now that we've described the image and declared its build details, we need to define its
+disk partitions. To do so, we'll customize the ``volumes`` key.
 
-Our project file contains a single volume, named ``disk``. The ``schema`` key tells us
-that the volume is partitioned with GPT, the only schema currently supported by
+The ``volumes`` key contains a single entry, named ``disk``. The ``schema`` key tells us
+that this volume is partitioned with GPT, the only schema currently supported by
 Imagecraft. We'll define individual partitions in the volume's ``structure`` key.
 
-Our image will have two partitions: a root file system and an EFI system partition. The
-first was created for us automatically. Before we go over its contents, let's also
-define an EFI system partition for our image to boot from. Add the following highlighted
-lines after the ``rootfs`` partition:
+The image will have two partitions: a root file system and an EFI system partition. The
+first was defined for us automatically. Before we go over its contents, let's define the
+EFI system partition the image will boot from. Add the following highlighted lines after
+the ``rootfs`` partition:
 
 .. literalinclude:: code/build-an-ubuntu-image/imagecraft.yaml
     :language: yaml
@@ -150,11 +146,11 @@ which tells Imagecraft that it contains the operating system.
 
 We set the ``type`` key to the identifier for EFI system partitions in a GUID partition
 table. The ``rootfs`` partition was generated with the identifier for Linux file
-systems. The identifiers themselves come from the UEFI specification—don't worry about
+systems. The identifiers themselves come from the UEFI specification--don't worry about
 memorizing them.
 
 We set the ``filesystem`` key to ``vfat``, the most common file system for EFI system
-partitions. Since the ``rootfs`` partition will be for general usage, it's using the
+partitions. Since the ``rootfs`` partition will be for general usage, it uses the
 ext4 filesystem instead.
 
 In both partitions, the ``filesystem-label`` key is set to a unique, human-readable
@@ -164,12 +160,12 @@ name. We'll use these labels when we set up the file system table later on.
 Mount the partitions
 --------------------
 
-Our image's partitions are ready, but we haven't told Imagecraft where to mount them in
+The image's partitions are ready, but we haven't told Imagecraft where to mount them in
 the image's file system. Let's shift our focus to the ``filesystems`` key.
 
 The ``filesystems`` key maps the image's partitions to their mount points. It expects a
 single file system, named ``default``, that mounts a partition to the root of the image.
-The ``filesystems`` key in our project file already mounts the ``rootfs`` partition to the
+The ``filesystems`` key in the project file already mounts the ``rootfs`` partition to the
 image's root, but we'll still need to mount the EFI system partition.
 
 Add the following highlighted lines to the end of the ``filesystems`` key:
@@ -182,8 +178,8 @@ Add the following highlighted lines to the end of the ``filesystems`` key:
     :emphasize-lines: 5, 6
 
 With this entry, we mounted the EFI system partition to the /boot/efi/ directory in the
-final image. Keep in mind that we'll need to create this directory ourselves when we set
-up the image's root file system.
+final image. Keep in mind that we'll need to create this directory when we set up the
+image's root file system.
 
 
 .. _tutorial-set-up-the-root-file-system:
@@ -191,14 +187,14 @@ up the image's root file system.
 Set up the root file system
 ---------------------------
 
-Because we're building our image on the bare base, its file system is currently an empty
-directory. Let's start building our Ubuntu file system with the ``parts`` key.
+Because we're building the image on the bare base, its file system is currently an empty
+directory. Let's start building it up with the ``parts`` key.
 
-*Parts* are the means by which we source packages for and manipulate the files in our
+*Parts* are the means by which we source packages for and manipulate the files in the
 image. More importantly, they give us access to the *overlay file system*, which is
-where we'll manipulate our image's contents.
+where we'll manipulate the image's contents.
 
-We'll create a Debian root file system with a part that uses the mmdebstrap plugin.
+We'll create the file system with a part that uses the mmdebstrap plugin.
 
 In the ``parts`` key, replace the template part with the following ``rootfs`` part:
 
@@ -207,7 +203,7 @@ In the ``parts`` key, replace the template part with the following ``rootfs`` pa
     :start-at: parts:
     :end-at: noble
 
-The ``mmdebstrap-suite`` key is specific to the ``mmdebstrap`` plugin and specifies the
+The ``mmdebstrap-suite`` key is specific to the mmdebstrap plugin and specifies the
 package suite to bootstrap. To get the packages that are shipped with Ubuntu 24.04 LTS,
 we set the suite to ``noble``.
 
@@ -224,11 +220,11 @@ Add the following ``override-build`` key to the part:
     :lines: 39-52
     :emphasize-lines: 4-14
 
-The ``override-build`` key replaces the plugin's default behaviour. Since we want to
+The ``override-build`` key replaces the plugin's default behavior. Since we want to
 extend the part's build instead of overriding it, we started the script with ``craftctl
 default``, which runs the plugin's default commands.
 
-Now, when we install packages into our image, we'll be able to access the other
+Now, when we install packages into the image, we'll be able to access the other
 components in the ``noble`` suite.
 
 At this point, the file system only exists in the ``rootfs`` part. To get it into the
@@ -241,7 +237,7 @@ the ``rootfs`` key:
     :class: no-copybutton
     :start-at: rootfs:
     :end-at: '*': (overlay)/
-    :emphasize-lines: 15, 16
+    :emphasize-lines: 14, 15
 
 This copies the result of the part's build step to the root of the overlay file system,
 thereby securing its place in the final image.
@@ -252,9 +248,9 @@ thereby securing its place in the final image.
 Add essential packages
 ----------------------
 
-We'll need some additional packages for our image to be bootable. Let's define a new
-part to source them. In this case, we don't need any special behaviour, so we'll set
-the ``plugin`` key to ``nil``. Add the following ``packages`` part:
+We'll need some additional packages for the image to be bootable. Let's define a new
+part to source them. In this case, we don't need any special behavior, so we'll set the
+``plugin`` key to ``nil``. Add the following ``packages`` part:
 
 .. literalinclude:: code/build-an-ubuntu-image/imagecraft.yaml
     :language: yaml
@@ -265,18 +261,18 @@ as the kernel, core utilities, and boot loader.
 
 We added the ``sl`` package to ensure that we can source packages from the extra
 components of the ``noble`` suite we added in the ``rootfs`` part. This isn't essential,
-but it's a fun way to test our image later.
+but it's a fun way to test the image later.
 
 
 Create the file system table
 ----------------------------
 
-If we tried to boot our image, its partitions wouldn't be mounted. This is because
+If we tried to boot the image now, its partitions wouldn't be mounted. This is because
 Imagecraft requires that we create our file system table manually. The content of this
 table is similar to what we declared in the ``filesystems`` key, with some additional
 configuration.
 
-With how we set up our partitions and mount points, the table should read:
+With how we set up the partitions and mount points, the table will read:
 
 .. code-block:: text
     :class: no-copybutton
@@ -322,8 +318,8 @@ Add the following ``login`` part:
     :start-at: login:
     :end-at: echo "root:password" | chpasswd --root "${CRAFT_OVERLAY}"
 
-When we run our image later, this will allow us to log in with the username ``root`` and
-the password ``password``.
+When we run our image later, we'll log in with the username ``root`` and the password
+``password``.
 
 Our project file now contains everything we need to pack a complete, bootable image.
 Save and close the ``imagecraft.yaml`` file.
@@ -361,26 +357,8 @@ the image to make sure everything is working as expected.
 Run and test the image
 ----------------------
 
-We'll run our image with QEMU, a common choice for full-system emulation. In your
-terminal, install it by running:
-
-.. literalinclude:: code/build-an-ubuntu-image/task.yaml
-    :language: bash
-    :dedent: 2
-    :start-at: apt install qemu-system-x86
-    :end-at: apt install qemu-system-x86
-
-We'll also need UEFI firmware. One of the most popular choices for QEMU is OVMF. Install
-it with:
-
-.. literalinclude:: code/build-an-ubuntu-image/task.yaml
-    :language: bash
-    :dedent: 2
-    :start-at: apt install ovmf
-    :end-at: apt install ovmf
-
-Before we run our image, let's copy the UEFI variables into a temporary directory so we
-don't compromise the originals:
+Before we run our image with QEMU, let's copy the UEFI variables from OVMF into a
+temporary directory so we don't compromise the originals:
 
 .. literalinclude:: code/build-an-ubuntu-image/task.yaml
     :language: bash
@@ -430,8 +408,7 @@ command in the QEMU shell.
 Review the project file
 -----------------------
 
-Here's the complete project file for the ubuntu-minimal image. Yours should look similar
-to it.
+Here's the complete project file for the image. Yours should look similar to it.
 
 .. dropdown:: imagecraft.yaml for ubuntu-minimal
 

--- a/docs/tutorials/build-an-ubuntu-image.rst
+++ b/docs/tutorials/build-an-ubuntu-image.rst
@@ -21,9 +21,9 @@ What we'll build
 After installing the necessary tools, we'll start building a custom Ubuntu image from
 the ground up.
 
-You'll be guided through the process of defining the image's structure and content step
-by step. The image will be based on the suite of packages from Ubuntu 24.04 LTS, with
-some additional software that caters it to the tutorial.
+We'll define the image's structure and content step by step. The image will be based on
+the suite of packages from Ubuntu 24.04 LTS, with some additional software that caters
+it to the tutorial.
 
 We'll end the tutorial by packaging the complete image and running it with QEMU, a
 popular machine emulator.

--- a/docs/tutorials/build-an-ubuntu-image.rst
+++ b/docs/tutorials/build-an-ubuntu-image.rst
@@ -1,17 +1,32 @@
 .. meta::
-    :description: Learn how to build a basic Ubuntu image with Imagecraft.
+    :description: Learn how to build a custom Ubuntu image with Imagecraft.
+
 
 .. _tutorial-build-an-ubuntu-image:
 
 Build an Ubuntu image
 =====================
 
-In this tutorial, we'll build a minimal Ubuntu image for AMD64 machines. We'll set up
-the project, define the image's partitions and content, and run the image with QEMU.
+In this tutorial, we'll build a custom Ubuntu image for AMD64 machines. We'll work
+through everything from the initial project setup to the image's first boot.
 
-It takes about 25 minutes to complete and doesn't require an intimate understanding of
-software packaging or disk images. However, this tutorial does require some familiarity
-with Linux paradigms and terminal usage.
+The tutorial takes about 25 minutes to complete. It doesn't require an intimate
+understanding of software packaging or disk images, but you'll need to be familiar with
+Linux paradigms and terminal usage.
+
+
+What you'll build
+-----------------
+
+After installing the necessary tools, you'll start building a custom Ubuntu image from
+the ground up.
+
+You'll define the image's structure and content step by step. The image will be based on
+the suite of packages from Ubuntu 24.04 LTS, with some additional software to cater it
+to the tutorial.
+
+Once you've completed the tutorial, you'll have practical experience with Imagecraft and
+a custom image you can add software to or model your next image from.
 
 
 What you'll need
@@ -35,7 +50,7 @@ To begin, we'll need to install the Imagecraft snap. Open a terminal and run:
     :start-at: snap install imagecraft --beta --classic
     :end-at: snap install imagecraft --beta --classic
 
-Let's also install Multipass, which will create the build environment when it comes
+Next, let's install Multipass, which will create the build environment when it comes
 time to package the image.
 
 .. literalinclude:: code/build-an-ubuntu-image/task.yaml
@@ -44,15 +59,15 @@ time to package the image.
     :start-at: snap install multipass
     :end-at: snap install multipass
 
-We'll run our image with QEMU, a common choice for full-system emulation. In your
-terminal, install it by running:
+We'll run our image with QEMU, a common choice for full-system emulation. Install it
+with:
 
 .. code-block:: bash
 
     sudo apt install qemu-system-x86
 
-We'll also need UEFI firmware. One of the most popular choices for QEMU is OVMF. Install
-it with:
+Lastly, we'll need UEFI firmware to pass to QEMU. One of the most popular choices is
+OVMF.
 
 .. code-block:: bash
 
@@ -90,7 +105,7 @@ Describe the image
 ------------------
 
 An image's project file starts with details like its name, version, and build
-environment. The ``init`` command declared these keys with some generic values. Let's
+environment. The ``init`` command set these keys to some generic values. Let's
 update the ``summary`` and ``description`` keys to better reflect the new project.
 Replace the first six keys with:
 
@@ -99,13 +114,13 @@ Replace the first six keys with:
     :start-at: name: ubuntu-minimal
     :end-at: Ubuntu 24.04 LTS, and it's booted with GRUB
 
-The ``base`` key defines the files that make up the foundation of the image. In
-Imagecraft, this is always an empty directory, known as the *bare* base, that must be
-built up manually.
+The ``base`` key defines the files that make up the foundation of the image. We're
+starting with an empty directory, known as the *bare* base, and building it up from
+scratch.
 
 The ``build-base`` key defines the operating system that's used to assemble the image.
-It does *not* have any influence on the image's contents. It's best to build with the
-latest Ubuntu LTS release in most cases, so we left this unchanged.
+It does *not* affect the image's contents. It's best to build with the latest Ubuntu LTS
+release in most cases, so we left this unchanged.
 
 The ``summary`` and ``description`` keys tell consumers of the image a little more
 about it. The summary is a one-line description, limited at 79 characters, while the
@@ -217,8 +232,8 @@ Add the following ``override-build`` key to the part:
 .. literalinclude:: code/build-an-ubuntu-image/imagecraft.yaml
     :language: yaml
     :class: no-copybutton
-    :lines: 39-52
-    :emphasize-lines: 4-14
+    :lines: 39-51
+    :emphasize-lines: 4-13
 
 The ``override-build`` key replaces the plugin's default behavior. Since we want to
 extend the part's build instead of overriding it, we started the script with ``craftctl
@@ -256,12 +271,9 @@ part to source them. In this case, we don't need any special behavior, so we'll 
     :language: yaml
     :lines: 56-64
 
-With the exception of ``sl``, these packages add the system's essential components, such
-as the kernel, core utilities, and boot loader.
-
-We added the ``sl`` package to ensure that we can source packages from the extra
-components of the ``noble`` suite we added in the ``rootfs`` part. This isn't essential,
-but it's a fun way to test the image later.
+With the exception of ``sl``, these packages add system essentials such as the kernel,
+core utilities, and boot loader. You won't need to worry about ``sl`` until we run the
+image later on.
 
 
 Create the file system table
@@ -388,8 +400,8 @@ As you may recall from the ``login`` part, the default username is ``root`` and 
 is ``password``. Enter these into the QEMU shell now.
 
 By booting and logging in to the image, we've verified the presence of its essential
-packages. To show that the non-essential packages are in place, let's run the ``sl``
-command in the QEMU shell.
+packages. To ensure the packages from the extra components of the ``noble`` suite are in
+place, let's run the ``sl`` command in the QEMU shell.
 
 .. terminal::
     :output-only:
@@ -404,6 +416,7 @@ command in the QEMU shell.
     __/ =| o |=-~~\  /~~\  /~~\  /~~\ ____Y___________|__ |__________________________|_
      |/-=|___|=    ||    ||    ||    |_____/~\___/           |_D__D__D_|  |_D__D__D_|
       \_/      \O=====O=====O=====O_/      \_/                \_/   \_/    \_/   \_/
+
 
 Review the project file
 -----------------------

--- a/docs/tutorials/build-an-ubuntu-image.rst
+++ b/docs/tutorials/build-an-ubuntu-image.rst
@@ -11,8 +11,8 @@ In this tutorial, we'll build a custom Ubuntu image for AMD64 machines. We'll wo
 through everything from the initial project setup to the image's first boot.
 
 The tutorial takes about 25 minutes to complete. It doesn't require an intimate
-understanding of software packaging or disk images, but you'll need to be familiar with
-Linux paradigms and terminal usage.
+understanding of OS images, or disk images in general, but you'll need to be familiar
+with Linux paradigms and terminal usage.
 
 
 What you'll build
@@ -21,9 +21,12 @@ What you'll build
 After installing the necessary tools, you'll start building a custom Ubuntu image from
 the ground up.
 
-You'll define the image's structure and content step by step. The image will be based on
-the suite of packages from Ubuntu 24.04 LTS, with some additional software to cater it
-to the tutorial.
+The tutorial guides you through the process of defining the image's structure and
+content step by step. The image will be based on the suite of packages from Ubuntu 24.04
+LTS, with some additional software to cater it to the tutorial.
+
+You'll end the tutorial by packaging the complete image and running it with QEMU, a
+popular machine emulator.
 
 Once you've completed the tutorial, you'll have practical experience with Imagecraft and
 a custom image you can add software to or model your next image from.
@@ -42,7 +45,7 @@ For this tutorial, you'll need:
 Install prerequisites
 ---------------------
 
-To begin, we'll need to install the Imagecraft snap. Open a terminal and run:
+To begin, let's install the Imagecraft snap. Open a terminal and run:
 
 .. literalinclude:: code/build-an-ubuntu-image/task.yaml
     :language: bash
@@ -59,19 +62,22 @@ time to package the image.
     :start-at: snap install multipass
     :end-at: snap install multipass
 
-We'll run our image with QEMU, a common choice for full-system emulation. Install it
-with:
+We'll run our image with QEMU. Install it with:
 
-.. code-block:: bash
-
-    sudo apt install qemu-system-x86
+.. literalinclude:: code/build-an-ubuntu-image/task.yaml
+    :language: bash
+    :dedent: 2
+    :start-at: sudo apt install qemu-system-x86
+    :end-at: sudo apt install qemu-system-x86
 
 Lastly, we'll need UEFI firmware to pass to QEMU. One of the most popular choices is
 OVMF.
 
-.. code-block:: bash
-
-    sudo apt install ovmf
+.. literalinclude:: code/build-an-ubuntu-image/task.yaml
+    :language: bash
+    :dedent: 2
+    :start-at: sudo apt install ovmf
+    :end-at: sudo apt install ovmf
 
 
 Set up the project
@@ -112,7 +118,7 @@ Replace the first six keys with:
 .. literalinclude:: code/build-an-ubuntu-image/imagecraft.yaml
     :language: yaml
     :start-at: name: ubuntu-minimal
-    :end-at: Ubuntu 24.04 LTS, and it's booted with GRUB
+    :end-at: and it's booted with GRUB.
 
 The ``base`` key defines the files that make up the foundation of the image. We're
 starting with an empty directory, known as the *bare* base, and building it up from
@@ -134,16 +140,18 @@ Define the partitions
 ---------------------
 
 Now that we've described the image and declared its build details, we need to define its
-disk partitions. To do so, we'll customize the ``volumes`` key.
+partitions. To do so, we'll customize the ``volumes`` key.
 
 The ``volumes`` key contains a single entry, named ``disk``. The ``schema`` key tells us
-that this volume is partitioned with GPT, the only schema currently supported by
-Imagecraft. We'll define individual partitions in the volume's ``structure`` key.
+that ``disk`` is partitioned with GPT, the only schema currently supported by
+Imagecraft. We'll define individual partitions with entries in the entry's ``structure``
+key.
 
-The image will have two partitions: a root file system and an EFI system partition. The
-first was defined for us automatically. Before we go over its contents, let's define the
-EFI system partition the image will boot from. Add the following highlighted lines after
-the ``rootfs`` partition:
+The image will have two partitions: a root file system and an EFI system partition. Each
+will need their own entry in the ``structure`` key.The first was defined for us
+automatically. Before we go over its contents, let's define the EFI system partition the
+image will boot from. Add the following highlighted lines after the ``rootfs``
+partition:
 
 .. literalinclude:: code/build-an-ubuntu-image/imagecraft.yaml
     :language: yaml
@@ -164,12 +172,13 @@ table. The ``rootfs`` partition was generated with the identifier for Linux file
 systems. The identifiers themselves come from the UEFI specification--don't worry about
 memorizing them.
 
-We set the ``filesystem`` key to ``vfat``, the most common file system for EFI system
-partitions. Since the ``rootfs`` partition will be for general usage, it uses the
-ext4 filesystem instead.
+We set the ``filesystem`` key to ``vfat`` for its compatibility with EFI system
+partitions. Since the ``rootfs`` partition will be for general usage, it uses the ext4
+filesystem instead.
 
 In both partitions, the ``filesystem-label`` key is set to a unique, human-readable
-name. We'll use these labels when we set up the file system table later on.
+name. This is for the benefit of you and anyone else who might work with the packaged
+image later on.
 
 
 Mount the partitions
@@ -193,8 +202,7 @@ Add the following highlighted lines to the end of the ``filesystems`` key:
     :emphasize-lines: 5, 6
 
 With this entry, we mounted the EFI system partition to the /boot/efi/ directory in the
-final image. Keep in mind that we'll need to create this directory when we set up the
-image's root file system.
+final image. We'll create this directory shortly.
 
 
 .. _tutorial-set-up-the-root-file-system:
@@ -206,12 +214,13 @@ Because we're building the image on the bare base, its file system is currently 
 directory. Let's start building it up with the ``parts`` key.
 
 *Parts* are the means by which we source packages for and manipulate the files in the
-image. More importantly, they give us access to the *overlay file system*, which is
-where we'll manipulate the image's contents.
+image. They're the primary way we interact with the *overlay file system*, which is
+where we'll build up the image's content.
 
 We'll create the file system with a part that uses the mmdebstrap plugin.
 
-In the ``parts`` key, replace the template part with the following ``rootfs`` part:
+In the ``parts`` key, replace the template part with a new part named ``rootfs``,
+defined as follows:
 
 .. literalinclude:: code/build-an-ubuntu-image/imagecraft.yaml
     :language: yaml
@@ -225,7 +234,8 @@ we set the suite to ``noble``.
 The plugin removes the default sources configuration files, which limit us to the system
 packages from the ``noble`` suite's ``main`` component. If we want to install anything
 more than essential system packages, we'll need to add a new sources configuration file.
-We also still need to create the ``/boot/efi`` directory we mounted the ``efi`` partition to.
+We also still need to create the ``/boot/efi`` directory we mounted the ``efi``
+partition to.
 
 Add the following ``override-build`` key to the part:
 
@@ -265,11 +275,11 @@ Add essential packages
 
 We'll need some additional packages for the image to be bootable. Let's define a new
 part to source them. In this case, we don't need any special behavior, so we'll set the
-``plugin`` key to ``nil``. Add the following ``packages`` part:
+``plugin`` key to ``nil``. Add a new part named ``packages``, defined as follows:
 
 .. literalinclude:: code/build-an-ubuntu-image/imagecraft.yaml
     :language: yaml
-    :lines: 56-64
+    :lines: 55-64
 
 With the exception of ``sl``, these packages add system essentials such as the kernel,
 core utilities, and boot loader. You won't need to worry about ``sl`` until we run the
@@ -302,14 +312,14 @@ file system. Add the following ``fstab`` part:
 
 .. literalinclude:: code/build-an-ubuntu-image/imagecraft.yaml
     :language: yaml
-    :lines: 66-73
+    :lines: 65-72
 
 Here, we used the ``overlay-script`` key to write the table to the overlay file system,
 which is referenced through the ``$CRAFT_OVERLAY`` environment variable. Keep in mind
 that this environment variable is only available in parts that include, or depend on
 another part that includes, overlay keys.
 
-The partitions will now be mounted automatically every time the system boots.
+The partitions will now be mounted automatically when the system boots.
 
 
 Set the default user

--- a/docs/tutorials/build-an-ubuntu-image.rst
+++ b/docs/tutorials/build-an-ubuntu-image.rst
@@ -12,8 +12,8 @@ image's partitions and content, and run the image with QEMU.
 You won't need to come prepared with an intimate understanding of software packaging or
 disk images, but familiarity with Linux paradigms and terminal operations is required.
 
-By the end of this tutorial, you'll have crafted an image that can serve as the basis
-for future projects.
+By the end of this tutorial, you'll have built a minimal, pre-installed Ubuntu image for
+AMD64 machines.
 
 
 Lesson plan
@@ -28,16 +28,6 @@ building an image. You'll be shown how to:
 * Add packages to the image
 * Set a default user and password
 * Package the image
-
-
-What we'll work with
---------------------
-
-The object of this tutorial is to build a minimal, pre-installed Ubuntu image for AMD64
-machines.
-
-The final image will be named ``disk.img``, and we'll end the tutorial by running and
-testing it with QEMU.
 
 
 What you'll need
@@ -74,8 +64,8 @@ time to package our image.
 Set up the project
 ------------------
 
-We'll need a directory to hold our image project. Navigate to where you like to keep
-software projects and create the new directory with:
+We'll need a directory to hold our project. Navigate to where you like to keep software
+projects and create the new directory with:
 
 .. literalinclude:: code/build-an-ubuntu-image/task.yaml
     :language: bash
@@ -125,18 +115,6 @@ The ``summary`` and ``description`` keys tell consumers of our image a little mo
 about it. The summary is a one-line description, limited at 79 characters, while the
 description is more open-ended and can span multiple lines. These were both placeholders
 in the template project file, so we made them meaningful for our project.
-
-
-.. Define the target platform
-.. --------------------------
-
-.. We need to tell Imagecraft what CPU architecture our image builds and runs on. This is
-.. done with the ``platforms`` key.
-
-.. An image's target architecture influences its structure and contents, so its project
-.. file must be customized to each platform. Since we'll be building our image for AMD64
-.. machines, and our project file already targets the AMD64 architecture, we'll leave the
-.. ``platforms`` key as is.
 
 
 .. _tutorial-define-the-partitions:
@@ -220,7 +198,7 @@ directory. Let's start building our Ubuntu file system with the ``parts`` key.
 image. More importantly, they give us access to the *overlay file system*, which is
 where we'll manipulate our image's contents.
 
-We'll create a Debian root file system with a part that uses the ``mmdebstrap`` plugin.
+We'll create a Debian root file system with a part that uses the mmdebstrap plugin.
 
 In the ``parts`` key, replace the template part with the following ``rootfs`` part:
 

--- a/docs/tutorials/build-an-ubuntu-image.rst
+++ b/docs/tutorials/build-an-ubuntu-image.rst
@@ -11,8 +11,8 @@ In this tutorial, we'll build a custom Ubuntu image for AMD64 machines. We'll wo
 through everything from the initial project setup to the image's first boot.
 
 The tutorial takes about 25 minutes to complete. It doesn't require an intimate
-understanding of OS images, or disk images in general, but you'll need to be familiar
-with Linux paradigms and terminal usage.
+understanding of disk images, but you'll need to be familiar with Linux paradigms and
+terminal usage.
 
 
 What you'll build

--- a/docs/tutorials/build-an-ubuntu-image.rst
+++ b/docs/tutorials/build-an-ubuntu-image.rst
@@ -299,8 +299,8 @@ With how we set up the partitions and mount points, the table will read:
 .. code-block:: text
     :class: no-copybutton
 
-    LABEL=writable    /            ext4    discard,errors=remount-ro    0    1
-    LABEL=UEFI        /boot/efi    vfat    umask=0077                   0    1
+    LABEL=root        /            ext4    discard,errors=remount-ro    0    1
+    LABEL=uefi        /boot/efi    vfat    umask=0077                   0    1
 
 The first three columns should look familiar—these are the labels, mount points, and
 file system types we declared for our partitions. The last three columns declare each

--- a/docs/tutorials/build-an-ubuntu-image.rst
+++ b/docs/tutorials/build-an-ubuntu-image.rst
@@ -12,20 +12,20 @@ through everything from the initial project setup to the image's first boot.
 
 The tutorial takes about 25 minutes to complete. It doesn't require an intimate
 understanding of disk images, but you'll need to be familiar with Linux paradigms and
-terminal usage.
+using the terminal.
 
 
-What you'll build
------------------
+What we'll build
+----------------
 
-After installing the necessary tools, you'll start building a custom Ubuntu image from
+After installing the necessary tools, we'll start building a custom Ubuntu image from
 the ground up.
 
-The tutorial guides you through the process of defining the image's structure and
-content step by step. The image will be based on the suite of packages from Ubuntu 24.04
-LTS, with some additional software to cater it to the tutorial.
+You'll be guided through the process of defining the image's structure and content step
+by step. The image will be based on the suite of packages from Ubuntu 24.04 LTS, with
+some additional software that caters it to the tutorial.
 
-You'll end the tutorial by packaging the complete image and running it with QEMU, a
+We'll end the tutorial by packaging the complete image and running it with QEMU, a
 popular machine emulator.
 
 Once you've completed the tutorial, you'll have practical experience with Imagecraft and
@@ -54,7 +54,7 @@ To begin, let's install the Imagecraft snap. Open a terminal and run:
     :end-at: snap install imagecraft --beta --classic
 
 Next, let's install Multipass, which will create the build environment when it comes
-time to package the image.
+time to package the image:
 
 .. literalinclude:: code/build-an-ubuntu-image/task.yaml
     :language: bash
@@ -84,7 +84,7 @@ Set up the project
 ------------------
 
 We'll need a directory to hold the project. Create a directory wherever you like to keep
-your software projects with:
+your software projects:
 
 .. literalinclude:: code/build-an-ubuntu-image/task.yaml
     :language: bash
@@ -111,9 +111,9 @@ Describe the image
 ------------------
 
 An image's project file starts with details like its name, version, and build
-environment. The ``init`` command set these keys to some generic values. Let's
-update the ``summary`` and ``description`` keys to better reflect the new project.
-Replace the first six keys with:
+environment. Imagecraft initialized these keys with generic values. Let's update the
+``summary`` and ``description`` keys to better reflect the new project. Replace the
+first six keys with:
 
 .. literalinclude:: code/build-an-ubuntu-image/imagecraft.yaml
     :language: yaml
@@ -148,10 +148,9 @@ Imagecraft. We'll define individual partitions with entries in the entry's ``str
 key.
 
 The image will have two partitions: a root file system and an EFI system partition. Each
-will need their own entry in the ``structure`` key.The first was defined for us
-automatically. Before we go over its contents, let's define the EFI system partition the
-image will boot from. Add the following highlighted lines after the ``rootfs``
-partition:
+will need their own entry in the ``structure`` key. The first was defined for us
+automatically. Before we go over it, let's define the EFI system partition the image
+will boot from. Add the following highlighted lines after the ``rootfs`` partition:
 
 .. literalinclude:: code/build-an-ubuntu-image/imagecraft.yaml
     :language: yaml
@@ -169,7 +168,7 @@ which tells Imagecraft that it contains the operating system.
 
 We set the ``type`` key to the identifier for EFI system partitions in a GUID partition
 table. The ``rootfs`` partition was generated with the identifier for Linux file
-systems. The identifiers themselves come from the UEFI specification--don't worry about
+systems. The identifiers themselves come from the UEFI specification---don't worry about
 memorizing them.
 
 We set the ``filesystem`` key to ``vfat`` for its compatibility with EFI system
@@ -198,7 +197,7 @@ Add the following highlighted lines to the end of the ``filesystems`` key:
     :language: yaml
     :class: no-copybutton
     :start-at: filesystems:
-    :end-at: mount: /boot/efi
+    :end-at: mount: /boot/efi/
     :emphasize-lines: 5, 6
 
 With this entry, we mounted the EFI system partition to the /boot/efi/ directory in the
@@ -215,7 +214,7 @@ directory. Let's start building it up with the ``parts`` key.
 
 *Parts* are the means by which we source packages for and manipulate the files in the
 image. They're the primary way we interact with the *overlay file system*, which is
-where we'll build up the image's content.
+where we'll build up the image.
 
 We'll create the file system with a part that uses the mmdebstrap plugin.
 
@@ -234,8 +233,8 @@ we set the suite to ``noble``.
 The plugin removes the default sources configuration files, which limit us to the system
 packages from the ``noble`` suite's ``main`` component. If we want to install anything
 more than essential system packages, we'll need to add a new sources configuration file.
-We also still need to create the ``/boot/efi`` directory we mounted the ``efi``
-partition to.
+We also still need to create the /boot/efi/ directory we mounted the ``efi`` partition
+to.
 
 Add the following ``override-build`` key to the part:
 
@@ -300,7 +299,7 @@ With how we set up the partitions and mount points, the table will read:
     :class: no-copybutton
 
     LABEL=root        /            ext4    discard,errors=remount-ro    0    1
-    LABEL=uefi        /boot/efi    vfat    umask=0077                   0    1
+    LABEL=uefi        /boot/efi/   vfat    umask=0077                   0    1
 
 The first three columns should look familiar—these are the labels, mount points, and
 file system types we declared for our partitions. The last three columns declare each
@@ -330,8 +329,7 @@ and password.
 
 For the purposes of this tutorial, we'll set up a ``login`` part that runs the
 ``chpasswd`` command in the overlay file system. This should *not* be done in images
-built for production environments. In such cases, you should use a secure method that
-fits your image's application.
+built for production environments.
 
 Add a new part named ``login``, defined as follows:
 
@@ -353,8 +351,7 @@ Pack the image
 --------------
 
 To isolate the image build from your machine, we'll pack the image in a Multipass VM.
-Once you're ready, open a new terminal in the ``ubuntu-minimal/`` project directory and
-run:
+Open a new terminal in the ``ubuntu-minimal/`` project directory and run:
 
 .. literalinclude:: code/build-an-ubuntu-image/task.yaml
     :language: bash
@@ -443,8 +440,7 @@ Conclusion
 ----------
 
 This marks the end of this image's journey. If you'd like to develop your crafting
-skills further, you can customize the ubuntu-minimal image or even build a new one
-from scratch.
+skills further, you can customize the image or even build a new one from scratch.
 
 If you create an image for a new system or architecture, we encourage you to share it
 with us on `Matrix <https://matrix.to/#/#starcraft-development:ubuntu.com>`__. We'd love

--- a/docs/tutorials/code/build-an-ubuntu-image/imagecraft.yaml
+++ b/docs/tutorials/code/build-an-ubuntu-image/imagecraft.yaml
@@ -67,7 +67,7 @@ parts:
     overlay-script: |
       cat << EOF > $CRAFT_OVERLAY/etc/fstab
       LABEL=root        /            ext4    discard,errors=remount-ro    0    1
-      LABEL=UEFI        /boot/efi    vfat    umask=0077                   0    1
+      LABEL=uefi        /boot/efi    vfat    umask=0077                   0    1
       EOF
 
   login:

--- a/docs/tutorials/code/build-an-ubuntu-image/imagecraft.yaml
+++ b/docs/tutorials/code/build-an-ubuntu-image/imagecraft.yaml
@@ -33,7 +33,7 @@ filesystems:
     - device: (volume/disk/rootfs)
       mount: /
     - device: (volume/disk/efi)
-      mount: /boot/efi
+      mount: /boot/efi/
 
 parts:
   rootfs:
@@ -41,7 +41,7 @@ parts:
     mmdebstrap-suite: noble
     override-build: |
       craftctl default
-      mkdir $CRAFT_PART_INSTALL/boot/efi
+      mkdir $CRAFT_PART_INSTALL/boot/efi/
       cat << EOF > $CRAFT_PART_INSTALL/etc/apt/sources.list.d/ubuntu.sources
       Types: deb deb-src
       URIs: http://archive.ubuntu.com/ubuntu
@@ -67,7 +67,7 @@ parts:
     overlay-script: |
       cat << EOF > $CRAFT_OVERLAY/etc/fstab
       LABEL=root        /            ext4    discard,errors=remount-ro    0    1
-      LABEL=uefi        /boot/efi    vfat    umask=0077                   0    1
+      LABEL=uefi        /boot/efi/    vfat    umask=0077                   0    1
       EOF
 
   login:

--- a/docs/tutorials/code/build-an-ubuntu-image/imagecraft.yaml
+++ b/docs/tutorials/code/build-an-ubuntu-image/imagecraft.yaml
@@ -2,11 +2,11 @@ name: ubuntu-minimal
 base: bare
 build-base: ubuntu@24.04
 version: '0.1'
-summary: A lightweight, pre-installed Ubuntu image for AMD64 machines.
+summary: A lightweight, unofficial Ubuntu image for AMD64 machines.
 description: |
-  The ubuntu-minimal image is a lightweight, pre-installed Ubuntu
-  image for AMD64 machines. Its root file system is based off of
-  Ubuntu 24.04 LTS, and it's booted with GRUB.
+  The ubuntu-minimal image is a lightweight, unofficial Ubuntu image for AMD64
+  machines. Its root file system and packages are based off of Ubuntu 24.04 LTS,
+  and it's booted with GRUB.
 
 platforms:
   amd64:
@@ -19,7 +19,7 @@ volumes:
         role: system-data
         type: 0FC63DAF-8483-4772-8E79-3D69D8477DE4
         filesystem: ext4
-        filesystem-label: writable
+        filesystem-label: root
         size: 3G
       - name: efi
         role: system-boot
@@ -66,7 +66,7 @@ parts:
     plugin: nil
     overlay-script: |
       cat << EOF > $CRAFT_OVERLAY/etc/fstab
-      LABEL=writable    /            ext4    discard,errors=remount-ro    0    1
+      LABEL=root        /            ext4    discard,errors=remount-ro    0    1
       LABEL=UEFI        /boot/efi    vfat    umask=0077                   0    1
       EOF
 

--- a/docs/tutorials/code/build-an-ubuntu-image/imagecraft.yaml
+++ b/docs/tutorials/code/build-an-ubuntu-image/imagecraft.yaml
@@ -22,9 +22,9 @@ volumes:
         filesystem-label: writable
         size: 3G
       - name: efi
+        role: system-boot
         type: C12A7328-F81F-11D2-BA4B-00A0C93EC93B
         filesystem: vfat
-        role: system-boot
         filesystem-label: UEFI
         size: 256M
 
@@ -42,7 +42,6 @@ parts:
     override-build: |
       craftctl default
       mkdir $CRAFT_PART_INSTALL/boot/efi
-
       cat << EOF > $CRAFT_PART_INSTALL/etc/apt/sources.list.d/ubuntu.sources
       Types: deb deb-src
       URIs: http://archive.ubuntu.com/ubuntu

--- a/docs/tutorials/code/build-an-ubuntu-image/task.yaml
+++ b/docs/tutorials/code/build-an-ubuntu-image/task.yaml
@@ -19,11 +19,11 @@ execute: |
   cp /usr/share/OVMF/OVMF_VARS_4M.fd /tmp/OVMF_VARS_4M.fd
 
   # This doesn't currently work in Spread
-  # qemu-system-x86_64 \
-  #   -accel kvm \
-  #   -m 4G \
-  #   -cpu host \
-  #   -smp 8 \
-  #   -drive if=pflash,format=raw,readonly=on,file=/usr/share/OVMF/OVMF_CODE_4M.fd \
-  #   -drive if=pflash,format=raw,file=/tmp/OVMF_VARS_4M.fd \
-  #   -drive file=disk.img,format=raw,index=0,media=disk
+  qemu-system-x86_64 \
+    -accel kvm \
+    -m 4G \
+    -cpu host \
+    -smp 8 \
+    -drive if=pflash,format=raw,readonly=on,file=/usr/share/OVMF/OVMF_CODE_4M.fd \
+    -drive if=pflash,format=raw,file=/tmp/OVMF_VARS_4M.fd \
+    -drive file=disk.img,format=raw,index=0,media=disk

--- a/docs/tutorials/code/build-an-ubuntu-image/task.yaml
+++ b/docs/tutorials/code/build-an-ubuntu-image/task.yaml
@@ -3,7 +3,13 @@ summary: Test the "Build an Ubuntu image" tutorial
 execute: |
   snap install imagecraft --beta --classic
   snap install multipass
-  apt install --yes qemu-system-x86 ovmf  # Differs from instructions
+
+  # This is what Spread runs
+  apt install --yes qemu-system-x86 ovmf
+  # This is what the user runs
+  sudo apt install qemu-system-x86
+  sudo apt install ovmf
+
   mkdir ubuntu-minimal
   cd ubuntu-minimal
   imagecraft init
@@ -12,7 +18,7 @@ execute: |
   imagecraft pack
   cp /usr/share/OVMF/OVMF_VARS_4M.fd /tmp/OVMF_VARS_4M.fd
 
-  # Note: This doesn't currently work in spread.
+  # This doesn't currently work in Spread
   # qemu-system-x86_64 \
   #   -accel kvm \
   #   -m 4G \

--- a/docs/tutorials/code/build-an-ubuntu-image/task.yaml
+++ b/docs/tutorials/code/build-an-ubuntu-image/task.yaml
@@ -1,28 +1,23 @@
 summary: Test the "Build an Ubuntu image" tutorial
 
 execute: |
-  snap install imagecraft --channel=beta --classic
+  snap install imagecraft --beta --classic
   snap install multipass
+  apt install --yes qemu-system-x86 ovmf  # Differs from instructions
   mkdir ubuntu-minimal
   cd ubuntu-minimal
   imagecraft init
   cp ../imagecraft.yaml imagecraft.yaml
   snap set imagecraft provider=multipass
   imagecraft pack
-  # What we run in spread
-  apt install --yes qemu-system-x86 ovmf
-  # What the user sees:
-  apt install qemu-system-x86
-  apt install ovmf
   cp /usr/share/OVMF/OVMF_VARS_4M.fd /tmp/OVMF_VARS_4M.fd
 
-  # Note: This doesn't currently work in spread. We'll need to figure out the correct
-  # command to use at a later date.
-  qemu-system-x86_64 \
-    -accel kvm \
-    -m 4G \
-    -cpu host \
-    -smp 8 \
-    -drive if=pflash,format=raw,readonly=on,file=/usr/share/OVMF/OVMF_CODE_4M.fd \
-    -drive if=pflash,format=raw,file=/tmp/OVMF_VARS_4M.fd \
-    -drive file=disk.img,format=raw,index=0,media=disk
+  # Note: This doesn't currently work in spread.
+  # qemu-system-x86_64 \
+  #   -accel kvm \
+  #   -m 4G \
+  #   -cpu host \
+  #   -smp 8 \
+  #   -drive if=pflash,format=raw,readonly=on,file=/usr/share/OVMF/OVMF_CODE_4M.fd \
+  #   -drive if=pflash,format=raw,file=/tmp/OVMF_VARS_4M.fd \
+  #   -drive file=disk.img,format=raw,index=0,media=disk


### PR DESCRIPTION
Address some of the feedback that was received shortly after the tutorial was written. This preempts some changes I'm making to the init template in https://github.com/canonical/imagecraft/pull/353.

[Rendered page](https://canonical-ubuntu-documentation-library--354.com.readthedocs.build/imagecraft/354/tutorials/build-an-ubuntu-image/)

---

- [X] I've followed the [contribution guidelines](https://github.com/canonical/imagecraft/blob/main/CONTRIBUTING.md).
- [X] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
~~I've successfully run `make lint && make test`.~~
- [X] I've added or updated any relevant documentation.
- [X] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
