### PR TITLE
docs: configure for ubuntu.com proxy

### DIFF
--- a/docs/_static/js/overwrite-links.js
+++ b/docs/_static/js/overwrite-links.js
@@ -1,0 +1,38 @@
+// Replace oldDomain with newDomain
+const oldDomain = 'canonical-imagecraft-proxy.readthedocs-hosted.com';
+const newDomain = 'ubuntu.com/docs/imagecraft';
+
+function escapeRegExp(value) {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function overwriteMatchingAnchorUrls(container) {
+    if (!container) return;
+
+    const anchors = container.querySelectorAll('a[href], link[href]');
+    const oldDomainRegex = new RegExp(escapeRegExp(oldDomain), 'g');
+
+    anchors.forEach(anchor => {
+        anchor.href = anchor.href.replace(oldDomainRegex, newDomain);
+    });
+}
+
+overwriteMatchingAnchorUrls(document.querySelector('header'));
+
+// Use a MutationObserver to wait for the RTD flyout element to appear in the DOM
+const observer = new MutationObserver(function(mutations, obs) {
+
+    const rtdFlyout = document.querySelector('readthedocs-flyout');
+    if (!rtdFlyout) return;
+
+    obs.disconnect();
+
+    rtdFlyout.addEventListener('click', function() {
+        const shadowRoot = rtdFlyout.shadowRoot;
+        if (!shadowRoot) return;
+
+        overwriteMatchingAnchorUrls(shadowRoot);
+    });
+});
+
+observer.observe(document.body, { childList: true, subtree: true });

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,13 +28,13 @@ project = "Imagecraft"
 author = "Canonical"
 
 # Version string in sidebar
-if os.environ.get("READTHEDOCS_VERSION_TYPE", "external") == "external":  # PR or local build
-    # Because of setuptools, we can safely assume the version starts with `n.n`
-    major, minor, *_ = imagecraft.__version__.split(".")
-    release = f"{major}.{minor}"
-else:  # Branch build
-    rtd_version = os.environ.get("READTHEDOCS_VERSION", "latest")
-    release = "dev" if rtd_version == "latest" else rtd_version
+# if os.environ.get("READTHEDOCS_VERSION_TYPE", "external") == "external":  # PR or local build
+#     # Because of setuptools, we can safely assume the version starts with `n.n`
+#     major, minor, *_ = imagecraft.__version__.split(".")
+#     release = f"{major}.{minor}"
+# else:  # Branch build
+#     release = os.environ.get("READTHEDOCS_VERSION", "latest")
+release = "latest"
 
 # Sidebar documentation title; best kept reasonably short
 html_title = project + " documentation"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -5,6 +5,8 @@ import sys
 
 import craft_parts_docs  # type: ignore
 
+import imagecraft
+
 
 # Configuration for the Sphinx documentation builder.
 # All configuration specific to your project should be done in this file.
@@ -25,15 +27,23 @@ import craft_parts_docs  # type: ignore
 project = "Imagecraft"
 author = "Canonical"
 
+# Version string in sidebar
+if os.environ.get("READTHEDOCS_VERSION_TYPE", "external") == "external":  # PR or local build
+    # Because of setuptools, we can safely assume the version starts with `n.n`
+    major, minor, *_ = imagecraft.__version__.split(".")
+    release = f"{major}.{minor}"
+else:  # Branch build
+    rtd_version = os.environ.get("READTHEDOCS_VERSION", "latest")
+    release = "dev" if rtd_version == "latest" else rtd_version
+
 # Sidebar documentation title; best kept reasonably short
 html_title = project + " documentation"
 
 # Copyright string; shown at the bottom of the page
 copyright = "2023-%s, %s" % (datetime.date.today().year, author)
 
-# Use RTD canonical URL to ensure duplicate pages have a specific canonical URL
-html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "/")
-ogp_site_url = html_baseurl
+
+ogp_site_url = "https://ubuntu.com/docs/imagecraft"
 
 # Preview name of the documentation website
 ogp_site_name = project
@@ -76,24 +86,27 @@ html_theme_options = {
 }
 
 # Project slug; see https://meta.discourse.org/t/what-is-category-slug/87897
-# slug = ''
+slug = "docs/imagecraft"
 
 
 #########################
 # Sitemap configuration #
 #########################
 
+# Use RTD canonical URL to ensure duplicate pages have a specific canonical URL
+html_baseurl = f"{ogp_site_url}/{release}/"
+
 # sphinx-sitemap uses html_baseurl to generate the full URL for each page:
-sitemap_url_scheme = '{link}'
+sitemap_url_scheme = "{link}"
 
 # Include `lastmod` dates in the sitemap:
 sitemap_show_lastmod = False
 
 # Exclude generated pages from the sitemap:
 sitemap_excludes = [
-    '404/',
-    'genindex/',
-    'search/',
+    "404/",
+    "genindex/",
+    "search/",
 ]
 
 
@@ -247,12 +260,13 @@ exclude_patterns = [
 
 # Adds custom CSS files, located under 'html_static_path'
 html_css_files = [
-    'css/cookie-banner.css'
+    "css/cookie-banner.css",
 ]
 
 # Adds custom JavaScript files, located under 'html_static_path'
 html_js_files = [
-    'js/bundle.js',
+    "js/bundle.js",
+    "js/overwrite-links.js",
 ]
 
 # Specifies a reST snippet to be appended to each .rst file


### PR DESCRIPTION
Configure the docs for migration to the ubuntu.com domain

---

- [X] I've followed the [contribution guidelines](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md).
- [X] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [ ] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
