### PR TITLE
fix: use build_dir for snap prepare-image output

### DIFF
--- a/docs/how-to/pre-install-snaps.rst
+++ b/docs/how-to/pre-install-snaps.rst
@@ -82,16 +82,10 @@ Next, copy the following part into your project file, replacing ``<assertion-nam
       uc-prepare-preseed: true
       uc-prepare-preseed-sign-key: <key-name>
       organize:
-        "system-seed/*": (volume/disk/ubuntu-seed)/
-      prime:
-        - -kernel
-        - -gadget
-        - -resolved-content
-        - -system-seed
+        system-seed: (volume/disk/ubuntu-seed)
 
-This part prepares the scaffolding for the snaps in a ``system-seed/`` directory, copies
-them to your image's ``ubuntu-seed`` partition, and cleans up the original copies so
-they don't cause conflicts.
+This part prepares the scaffolding for the snaps in a ``system-seed/`` directory and
+moves it to your image's ``ubuntu-seed`` partition.
 
 If your model assertion contains optional snaps that you wish to install, list them with
 the ``uc-prepare-snaps`` key:
@@ -111,12 +105,7 @@ the ``uc-prepare-snaps`` key:
         - core22
         - hello-world@latest/edge
       organize:
-        "system-seed/*": (volume/disk/ubuntu-seed)/
-      prime:
-        - -kernel
-        - -gadget
-        - -resolved-content
-        - -system-seed
+        system-seed: (volume/disk/ubuntu-seed)
 
 To tweak the snaps' channels or revisions further, refer to the additional keys in the
 :ref:`reference-uc-prepare-plugin` reference. Configuration that deviates from the model

--- a/docs/reference/plugins/uc_prepare_plugin.rst
+++ b/docs/reference/plugins/uc_prepare_plugin.rst
@@ -176,4 +176,4 @@ assertion file named ``model.assert``.
        plugin: uc-prepare
        uc-prepare-model-assert: model.assert
        organize:
-         "system-seed/*": (volume/disk/ubuntu-seed)/
+         system-seed: (volume/disk/ubuntu-seed)

--- a/imagecraft/plugins/uc_prepare_plugin.py
+++ b/imagecraft/plugins/uc_prepare_plugin.py
@@ -16,6 +16,7 @@
 
 """The uc-prepare plugin."""
 
+import shlex
 from typing import Literal, cast
 
 from craft_parts.plugins import Plugin, PluginProperties
@@ -135,8 +136,13 @@ class UcPreparePlugin(Plugin):
 
         cmd.extend(f"--snap={resolve_snap(snap)}" for snap in options.uc_prepare_snaps)
 
-        cmd.append(
-            f"{options.uc_prepare_model_assert} {self._part_info.part_install_dir}"
-        )
+        prepare_dir = self._part_info.part_build_dir / "prepare-image"
+        cmd.append(options.uc_prepare_model_assert)
+        cmd.append(str(prepare_dir))
 
-        return [" ".join(cmd)]
+        return [
+            # snap prepare-image command will fail if prepare_dir is non-empty
+            f"rm -rf {prepare_dir} {self._part_info.part_install_dir}/system-seed",
+            shlex.join(cmd),
+            f"mv {prepare_dir}/system-seed {self._part_info.part_install_dir}/",
+        ]

--- a/tests/spread/boot/core/arm64/imagecraft.yaml
+++ b/tests/spread/boot/core/arm64/imagecraft.yaml
@@ -23,11 +23,7 @@ parts:
     uc-prepare-snaps:
       - sentinel.snap
     organize:
-      "system-seed/*": (volume/pc/ubuntu-seed)
-    prime:
-      - -kernel
-      - -gadget
-      - -resolved-content
+      system-seed: (volume/pc/ubuntu-seed)
 
 volumes:
   pc:

--- a/tests/spread/plugins/uc-prepare/imagecraft.yaml
+++ b/tests/spread/plugins/uc-prepare/imagecraft.yaml
@@ -19,12 +19,7 @@ parts:
     source: .
     uc-prepare-model-assert: model.assert
     organize:
-      "system-seed/*": (volume/disk/ubuntu-seed)/
-    prime:
-      - -kernel
-      - -gadget
-      - -resolved-content
-      - -system-seed
+      system-seed: (volume/disk/ubuntu-seed)
 
 volumes:
   disk:

--- a/tests/unit/plugins/test_uc_prepare_plugin.py
+++ b/tests/unit/plugins/test_uc_prepare_plugin.py
@@ -103,10 +103,11 @@ def test_get_build_commands(part_info):
 
     plugin = UcPreparePlugin(properties=properties, part_info=part_info)
 
-    assert (
-        plugin.get_build_commands()[0]
-        == f"snap prepare-image --validation=enforce model.assert {part_info.part_install_dir}"
-    )
+    assert plugin.get_build_commands() == [
+        f"rm -rf {part_info.part_build_dir}/prepare-image {part_info.part_install_dir}/system-seed",
+        f"snap prepare-image --validation=enforce model.assert {part_info.part_build_dir}/prepare-image",
+        f"mv {part_info.part_build_dir}/prepare-image/system-seed {part_info.part_install_dir}/",
+    ]
 
 
 def test_get_build_commands_with_preseed(part_info):
@@ -119,8 +120,8 @@ def test_get_build_commands_with_preseed(part_info):
     plugin = UcPreparePlugin(properties=properties, part_info=part_info)
 
     assert (
-        plugin.get_build_commands()[0]
-        == f"snap prepare-image --validation=enforce --preseed model.assert {part_info.part_install_dir}"
+        plugin.get_build_commands()[1]
+        == f"snap prepare-image --validation=enforce --preseed model.assert {part_info.part_build_dir}/prepare-image"
     )
 
 
@@ -135,8 +136,8 @@ def test_get_build_commands_with_preseed_sign_key(part_info):
     plugin = UcPreparePlugin(properties=properties, part_info=part_info)
 
     assert (
-        plugin.get_build_commands()[0]
-        == f"snap prepare-image --validation=enforce --preseed --preseed-sign-key=sign-key model.assert {part_info.part_install_dir}"
+        plugin.get_build_commands()[1]
+        == f"snap prepare-image --validation=enforce --preseed --preseed-sign-key=sign-key model.assert {part_info.part_build_dir}/prepare-image"
     )
 
 
@@ -152,8 +153,8 @@ def test_get_build_commands_with_apparmor_dir(part_info):
     plugin = UcPreparePlugin(properties=properties, part_info=part_info)
 
     assert (
-        plugin.get_build_commands()[0]
-        == f"snap prepare-image --validation=enforce --preseed --apparmor-features-dir={apparmor_features_dir} model.assert {part_info.part_install_dir}"
+        plugin.get_build_commands()[1]
+        == f"snap prepare-image --validation=enforce --preseed --apparmor-features-dir={apparmor_features_dir} model.assert {part_info.part_build_dir}/prepare-image"
     )
 
 
@@ -169,8 +170,8 @@ def test_get_build_commands_with_sysfs_overlay(part_info):
     plugin = UcPreparePlugin(properties=properties, part_info=part_info)
 
     assert (
-        plugin.get_build_commands()[0]
-        == f"snap prepare-image --validation=enforce --preseed --sysfs-overlay={sysfs_overlay} model.assert {part_info.part_install_dir}"
+        plugin.get_build_commands()[1]
+        == f"snap prepare-image --validation=enforce --preseed --sysfs-overlay={sysfs_overlay} model.assert {part_info.part_build_dir}/prepare-image"
     )
 
 
@@ -185,8 +186,8 @@ def test_get_build_commands_with_snaps(part_info):
     plugin = UcPreparePlugin(properties=properties, part_info=part_info)
 
     assert (
-        plugin.get_build_commands()[0]
-        == f"snap prepare-image --validation=enforce --snap=core24 --snap=hello-world=latest/stable model.assert {part_info.part_install_dir}"
+        plugin.get_build_commands()[1]
+        == f"snap prepare-image --validation=enforce --snap=core24 --snap=hello-world=latest/stable model.assert {part_info.part_build_dir}/prepare-image"
     )
 
 
@@ -201,8 +202,8 @@ def test_get_build_commands_with_assertions(part_info):
     plugin = UcPreparePlugin(properties=properties, part_info=part_info)
 
     assert (
-        plugin.get_build_commands()[0]
-        == f"snap prepare-image --validation=enforce --assert=system-user.assert --assert=account.assert model.assert {part_info.part_install_dir}"
+        plugin.get_build_commands()[1]
+        == f"snap prepare-image --validation=enforce --assert=system-user.assert --assert=account.assert model.assert {part_info.part_build_dir}/prepare-image"
     )
 
 
@@ -217,8 +218,8 @@ def test_get_build_commands_with_channel(part_info):
     plugin = UcPreparePlugin(properties=properties, part_info=part_info)
 
     assert (
-        plugin.get_build_commands()[0]
-        == f"snap prepare-image --validation=enforce --channel=latest/stable model.assert {part_info.part_install_dir}"
+        plugin.get_build_commands()[1]
+        == f"snap prepare-image --validation=enforce --channel=latest/stable model.assert {part_info.part_build_dir}/prepare-image"
     )
 
 
@@ -233,8 +234,8 @@ def test_get_build_commands_with_validation_enforce(part_info):
     plugin = UcPreparePlugin(properties=properties, part_info=part_info)
 
     assert (
-        plugin.get_build_commands()[0]
-        == f"snap prepare-image --validation=ignore model.assert {part_info.part_install_dir}"
+        plugin.get_build_commands()[1]
+        == f"snap prepare-image --validation=ignore model.assert {part_info.part_build_dir}/prepare-image"
     )
 
 
@@ -249,8 +250,8 @@ def test_get_build_commands_with_revisions(part_info):
     plugin = UcPreparePlugin(properties=properties, part_info=part_info)
 
     assert (
-        plugin.get_build_commands()[0]
-        == f"snap prepare-image --validation=enforce --revisions=./revisions.txt model.assert {part_info.part_install_dir}"
+        plugin.get_build_commands()[1]
+        == f"snap prepare-image --validation=enforce --revisions=./revisions.txt model.assert {part_info.part_build_dir}/prepare-image"
     )
 
 
@@ -265,8 +266,8 @@ def test_get_build_commands_with_write_revisions(part_info):
     plugin = UcPreparePlugin(properties=properties, part_info=part_info)
 
     assert (
-        plugin.get_build_commands()[0]
-        == f"snap prepare-image --validation=enforce --write-revisions={part_info.part_install_dir}/seed.manifest model.assert {part_info.part_install_dir}"
+        plugin.get_build_commands()[1]
+        == f"snap prepare-image --validation=enforce --write-revisions={part_info.part_install_dir}/seed.manifest model.assert {part_info.part_build_dir}/prepare-image"
     )
 
 
@@ -281,6 +282,6 @@ def test_get_build_commands_with_write_revisions_path(part_info):
     plugin = UcPreparePlugin(properties=properties, part_info=part_info)
 
     assert (
-        plugin.get_build_commands()[0]
-        == f"snap prepare-image --validation=enforce --write-revisions={part_info.part_install_dir}/revisions.txt model.assert {part_info.part_install_dir}"
+        plugin.get_build_commands()[1]
+        == f"snap prepare-image --validation=enforce --write-revisions={part_info.part_install_dir}/revisions.txt model.assert {part_info.part_build_dir}/prepare-image"
     )


### PR DESCRIPTION
The uc-prepare plugin writes output from the snap prepare-image command to the install directory, leaving unwanted directories in prime. This PR changes the command to output to the build directory, moving only the system-seed contents to the install directory.

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/imagecraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [x] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
