### PR TITLE
test: add core pi boot spread test

### DIFF
--- a/tests/spread/boot/core/pi/imagecraft.yaml
+++ b/tests/spread/boot/core/pi/imagecraft.yaml
@@ -1,0 +1,40 @@
+name: test
+version: "0.1"
+summary: test
+description: test
+base: bare
+build-base: ubuntu@24.04
+
+platforms:
+  arm64:
+    build-on: [arm64, amd64]
+    build-for: arm64
+
+filesystems:
+  default:
+    - mount: /
+      device: (volume/pc/ubuntu-seed)
+
+parts:
+  seed:
+    plugin: uc-prepare
+    source: .
+    uc-prepare-model-assert: model.assert
+    uc-prepare-snaps:
+      - sentinel.snap
+    organize:
+      "system-seed/*": (volume/pc/ubuntu-seed)
+    prime:
+      - -kernel
+      - -gadget
+      - -resolved-content
+
+volumes:
+  pc:
+    schema: mbr
+    structure:
+      - name: ubuntu-seed
+        role: system-seed
+        filesystem: vfat
+        type: 0C
+        size: 1200M

--- a/tests/spread/boot/core/pi/model.assert
+++ b/tests/spread/boot/core/pi/model.assert
@@ -1,0 +1,49 @@
+type: model
+authority-id: canonical
+revision: 2
+series: 16
+brand-id: canonical
+model: ubuntu-core-24-pi-arm64-dangerous
+architecture: arm64
+base: core24
+grade: dangerous
+snaps:
+  -
+    default-channel: 24/edge
+    id: YbGa9O3dAXl88YLI6Y1bGG74pwBxZyKg
+    name: pi
+    type: gadget
+  -
+    default-channel: 24/beta
+    id: jeIuP6tfFrvAdic8DMWqHmoaoukAPNbJ
+    name: pi-kernel
+    type: kernel
+  -
+    default-channel: latest/edge
+    id: dwTAh7MZZ01zyriOZErqd1JynQLiOGvM
+    name: core24
+    type: base
+  -
+    default-channel: latest/edge
+    id: PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4
+    name: snapd
+    type: snapd
+  -
+    default-channel: 24/edge
+    id: ASctKBEHzVt3f1pbZLoekCvcigRjtuqw
+    name: console-conf
+    presence: optional
+    type: app
+timestamp: 2024-03-12T08:42:32+00:00
+sign-key-sha3-384: 9tydnLa6MTJ-jaQTFUXEwHl1yRx7ZS4K5cyFDhYDcPzhS7uyEkDxdUjg9g08BtNn
+
+AcLBXAQAAQoABgUCZfBvFwAKCRDgT5vottzAElwRD/9kvDyjS0W+w57xCdnZnAKb4lVJfbXfi8oU
+S0WKJH7TrNGsc1vX/ta1iVurMd7/zpEE2QFQjw8TCElItDpoe+1eEFnEpuIeiwn6Lax/eaISAQUv
+9+fjZYlD1DeQ9Yg3ZI2CRaDPCkO1KzL6A7jgaqsmS9/EM3PGrWtkvv5edJ0208vtY6zJkjXq0Gku
+xFwu6r8PTozG8SUqr3U5uDWsP2ROjIifrgEZbiWrlFT+eEIldBxSuWhMs+DlMZjttUABkSMv7DnC
+Q97OzXgzoMgI0YbY69Fw5Arz+Ng5+9naSXMuigyWc8vdklRcefsJTfxINBLak1pK2hjSrb2Sz3PN
+mw5FMtFQzDgLdLyPVmdldSSk0am+aCyKVvCl9Jc1Mvu2r/fQ86d/sxRBx7ePTYD1Uita/rkED8IM
+3aNp3fjEV6U7K+/h5GlcnUnKsIcy3fpCO0W7R+GiXS6EzC/xm/ikW3Oh/EhSZ2H8uVS5N7BulLmo
+DYZHhBvj3Jq0VLmb/ORizrP28zBQ6QqtcGoDymLNxEl3cElWkgyRfkbEc8vI/RLee5+uRfRQ91zZ
+HptZ0UBxNGzTiQOmGPOH3S/CpARFiKDy5IxbccVj94plWD6DITCbjoAUda60x06n0+qJiDXmLGD1
+cyQQV18rRgqEWhmABpZ/KJ06WWSx1xgF09wmLilL/A==

--- a/tests/spread/boot/core/sentinel/bin/sentinel.sh
+++ b/tests/spread/boot/core/sentinel/bin/sentinel.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-for dev in /dev/ttyS0 /dev/ttyAMA0 /dev/ttyAMA1; do
+for dev in /dev/console /dev/ttyS0 /dev/ttyAMA0 /dev/ttyAMA1; do
   echo "HELLO FROM SENTINEL SNAP" 2>/dev/null > "$dev"
 done
 

--- a/tests/spread/boot/core/sentinel/bin/sentinel.sh
+++ b/tests/spread/boot/core/sentinel/bin/sentinel.sh
@@ -1,11 +1,8 @@
 #!/bin/bash
 
-if [ "$(uname -m)" = "x86_64" ]; then
-  SERIAL_CONSOLE="/dev/ttyS0"
-else
-  SERIAL_CONSOLE="/dev/ttyAMA0"
-fi
-echo "HELLO FROM SENTINEL SNAP" > $SERIAL_CONSOLE
+for dev in /dev/ttyS0 /dev/ttyAMA0 /dev/ttyAMA1; do
+  echo "HELLO FROM SENTINEL SNAP" 2>/dev/null > "$dev"
+done
 
 sleep 5
 dbus-send --system --print-reply \

--- a/tests/spread/boot/core/task.yaml
+++ b/tests/spread/boot/core/task.yaml
@@ -4,6 +4,7 @@ systems: [ubuntu-24.04-64]
 
 environment:
   TARGET_ARCH/arm64: arm64
+  TARGET_ARCH/pi: arm64
 
 prepare: |
   snap install snapcraft --classic
@@ -17,39 +18,65 @@ execute: |
   cd sentinel && snapcraft pack --build-for=$TARGET_ARCH --destructive-mode && cd ..
   mv sentinel/sentinel_*_$TARGET_ARCH.snap ./sentinel.snap
 
-  cp ${TARGET_ARCH}/* .
+  cp ${SPREAD_VARIANT}/* .
 
   imagecraft pack --destructive-mode
 
-  if [ "$TARGET_ARCH" = "arm64" ]; then
-    QEMU_BIN="qemu-system-aarch64"
-    QEMU_ARGS="-machine virt -cpu neoverse-n1"
-    UEFI_CODE=/usr/share/AAVMF/AAVMF_CODE.fd
-    UEFI_VARS=/usr/share/AAVMF/AAVMF_VARS.fd
+  if [ "$SPREAD_VARIANT" = "pi" ]; then
+    unsquashfs -q -d kernel prime/snaps/pi-kernel_*.snap \
+      kernel.img initrd.img dtbs/broadcom/bcm2710-rpi-3-b.dtb
+    gunzip -c kernel/kernel.img > kernel/Kernel
+
+    SYSTEM_LABEL=$(ls prime/systems | head -n1)
+    truncate -s 4G pc.img
+    for mode in install run; do
+      if [ "$mode" = install ]; then
+        SNAPD_ARGS="snapd_recovery_mode=install snapd_recovery_system=$SYSTEM_LABEL"
+        EXTRA_ARGS="-no-reboot"
+      else
+        SNAPD_ARGS="snapd_recovery_mode=run"
+        EXTRA_ARGS=""
+      fi
+      qemu-system-aarch64 -machine raspi3b \
+        -kernel kernel/Kernel \
+        -initrd kernel/initrd.img \
+        -dtb kernel/dtbs/broadcom/bcm2710-rpi-3-b.dtb \
+        -append "console=ttyAMA1 $SNAPD_ARGS" \
+        -drive file=pc.img,format=raw,if=sd \
+        -display none -serial mon:stdio -serial null $EXTRA_ARGS 2>&1 | tee -a output.log || true
+    done
   else
-    QEMU_BIN="qemu-system-x86_64"
-    QEMU_ARGS=""
-    UEFI_CODE=/usr/share/OVMF/OVMF_CODE_4M.fd
-    UEFI_VARS=/usr/share/OVMF/OVMF_VARS_4M.fd
+    if [ "$TARGET_ARCH" = "arm64" ]; then
+      QEMU_BIN="qemu-system-aarch64"
+      QEMU_ARGS="-machine virt -cpu neoverse-n1"
+      UEFI_CODE=/usr/share/AAVMF/AAVMF_CODE.fd
+      UEFI_VARS=/usr/share/AAVMF/AAVMF_VARS.fd
+    else
+      QEMU_BIN="qemu-system-x86_64"
+      QEMU_ARGS=""
+      UEFI_CODE=/usr/share/OVMF/OVMF_CODE_4M.fd
+      UEFI_VARS=/usr/share/OVMF/OVMF_VARS_4M.fd
+    fi
+
+    cp "$UEFI_VARS" /tmp/uefi_vars.fd
+
+    $QEMU_BIN \
+      $QEMU_ARGS \
+      -accel kvm -accel tcg,thread=multi \
+      -smp "$(nproc)" \
+      -nographic \
+      -m 1G \
+      -drive if=pflash,format=raw,readonly=on,file=$UEFI_CODE \
+      -drive if=pflash,format=raw,file=/tmp/uefi_vars.fd \
+      -drive file=pc.img,format=raw,index=0,if=virtio,cache=unsafe 2>&1 | tee output.log || true
   fi
-
-  cp "$UEFI_VARS" /tmp/uefi_vars.fd
-
-  $QEMU_BIN \
-    $QEMU_ARGS \
-    -accel kvm -accel tcg,thread=multi \
-    -smp "$(nproc)" \
-    -nographic \
-    -m 1G \
-    -drive if=pflash,format=raw,readonly=on,file=$UEFI_CODE \
-    -drive if=pflash,format=raw,file=/tmp/uefi_vars.fd \
-    -drive file=pc.img,format=raw,index=0,if=virtio,cache=unsafe 2>&1 | tee output.log || true
 
   MATCH "HELLO FROM SENTINEL SNAP" output.log
 
 restore: |
   imagecraft clean --destructive-mode || true
   rm -f pc.img output.log /tmp/uefi_vars.fd sentinel.snap
+  rm -rf kernel
 
 debug: |
   cat output.log 2>/dev/null || echo "No serial output log"


### PR DESCRIPTION
This PR adds a pi variant for the core spread boot tests.

QEMU doesn't run the Pi firmware so we need to extract and pass the kernel, initrd and device tree. We also need to invoke the command twice, once for install mode and another for run mode. Snapd switches this in cmdline.txt but qemu doesnt not read cmdline.txt (the image works as is with a physical device)

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/imagecraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
