### PR TITLE
ci: add manual spread workflow with per-suite labels

### DIFF
--- a/.github/workflows/spread-manual.yaml
+++ b/.github/workflows/spread-manual.yaml
@@ -10,25 +10,62 @@ on:
   workflow_dispatch:
 
 jobs:
-  # Decide which manual suites should run, one output per suite/label so new
-  # manual suites can be added without affecting the others.
+  # Discover every suite marked `manual: true` in spread.yaml, and decide
+  # whether each one should run this workflow. A suite runs if:
+  # - This is an actual scheduled run
+  # - This is a manually triggered run via the Actions tab
+  # - This is a PR with that suite's specific "PR: Run Manual Spread (<suite>)" label
+  # Suite-specific jobs below still need to be added by hand (they encode
+  # which systems/runners to use), but they no longer need their own
+  # hardcoded label-matching logic: they just read this job's `suites` output.
   predicate:
     runs-on: ubuntu-slim
     outputs:
-      run-boot: ${{ steps.eval.outputs.run-boot }}
+      suites: ${{ steps.eval.outputs.suites }}
     steps:
-      - id: eval
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Install yq
+        env:
+          YQ_VERSION: v4.53.3
         run: |
-          # OR's the conditions in which each manual suite should run:
-          # - This is an actual scheduled run
-          # - This is a manually triggered run via the Actions tab
-          # - This is a PR with the suite's specific label
-          run_boot=${{ contains(github.event.pull_request.labels.*.name, 'PR: Run Manual Spread (boot)') || contains(fromJSON('["schedule", "workflow_dispatch"]'), github.event_name) }}
-          echo "run-boot=$run_boot" >> "$GITHUB_OUTPUT"
+          mkdir -p "$HOME/.local/bin"
+          curl -sL "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" -o "$HOME/.local/bin/yq"
+          chmod +x "$HOME/.local/bin/yq"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Discover manual spread suites and evaluate labels
+        id: eval
+        env:
+          PR_LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          set -euo pipefail
+
+          # Extract every suite path in spread.yaml marked `manual: true`
+          manual_paths=$(yq e -o=json '.suites' spread.yaml | jq -r 'to_entries | map(select(.value.manual == true)) | .[].key')
+
+          run_flags="{}"
+          while IFS= read -r path; do
+            [ -z "$path" ] && continue
+            suite=$(basename "${path%/}")
+            label="PR: Run Manual Spread ($suite)"
+            has_label=$(jq --arg l "$label" 'any(.[]; . == $l)' <<< "$PR_LABELS")
+            if [ "$has_label" = "true" ] || [ "$EVENT_NAME" = "schedule" ] || [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+              should_run=true
+            else
+              should_run=false
+            fi
+            run_flags=$(jq --arg k "$suite" --argjson v "$should_run" '. + {($k): $v}' <<< "$run_flags")
+          done <<< "$manual_paths"
+
+          echo "Discovered manual suites: $run_flags"
+          echo "suites=$run_flags" >> "$GITHUB_OUTPUT"
 
   snap-builds:
     needs: predicate
-    if: needs.predicate.outputs.run-boot == 'true'
+    if: fromJSON(needs.predicate.outputs.suites).boot == true
     strategy:
       matrix:
         include:
@@ -55,7 +92,7 @@ jobs:
 
   boot:
     needs: [predicate, snap-builds]
-    if: needs.predicate.outputs.run-boot == 'true'
+    if: fromJSON(needs.predicate.outputs.suites).boot == true
     runs-on: [self-hosted, spread-enabled]
     strategy:
       fail-fast: false

--- a/.github/workflows/spread-manual.yaml
+++ b/.github/workflows/spread-manual.yaml
@@ -1,0 +1,111 @@
+name: Spread (manual suites)
+
+on:
+  pull_request:
+    # The 3 default types + "labeled"
+    types: [labeled, opened, reopened, synchronize]
+  schedule:
+    # At 03:00 on Wednesday and Sunday.
+    - cron: "0 3 * * WED,SUN"
+  workflow_dispatch:
+
+jobs:
+  # Decide which manual suites should run, one output per suite/label so new
+  # manual suites can be added without affecting the others.
+  predicate:
+    runs-on: ubuntu-slim
+    outputs:
+      run-boot: ${{ steps.eval.outputs.run-boot }}
+    steps:
+      - id: eval
+        run: |
+          # OR's the conditions in which each manual suite should run:
+          # - This is an actual scheduled run
+          # - This is a manually triggered run via the Actions tab
+          # - This is a PR with the suite's specific label
+          run_boot=${{ contains(github.event.pull_request.labels.*.name, 'PR: Run Manual Spread (boot)') || contains(fromJSON('["schedule", "workflow_dispatch"]'), github.event_name) }}
+          echo "run-boot=$run_boot" >> "$GITHUB_OUTPUT"
+
+  snap-builds:
+    needs: predicate
+    if: needs.predicate.outputs.run-boot == 'true'
+    strategy:
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-24.04
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Build imagecraft snap
+        uses: canonical/craft-actions/snapcraft/pack@main
+        id: build-imagecraft
+
+      - name: Uploading imagecraft snap artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: snap-${{ matrix.arch }}
+          path: "*.snap"
+
+  boot:
+    needs: [predicate, snap-builds]
+    if: needs.predicate.outputs.run-boot == 'true'
+    runs-on: [self-hosted, spread-enabled]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - group: boot
+            systems: "ubuntu-24.04-64"
+            arch: amd64
+            tests: "tests/spread/boot/..."
+          - group: boot-arm-classic
+            systems: "ubuntu-24.04-arm-64"
+            arch: arm64
+            tests: "tests/spread/boot/classic"
+    steps:
+      - name: Cleanup job workspace
+        run: |
+          rm -rf "${{ github.workspace }}"
+          mkdir "${{ github.workspace }}"
+
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 2
+          submodules: true
+
+      - name: Download previously built artifact
+        uses: actions/download-artifact@v7
+        with:
+          name: snap-${{ matrix.arch }}
+
+      - name: Run spread tests
+        run: |
+          # Register a problem matcher to highlight spread failures
+          echo "::add-matcher::.github/spread-problem-matcher.json"
+
+          BACKEND=openstack
+          if [[ "${{ matrix.systems }}" =~ -arm- ]]; then
+            BACKEND=openstack-arm
+          fi
+
+          RUN_TESTS=""
+          for SYSTEM in ${{ matrix.systems }}; do
+              RUN_TESTS="$RUN_TESTS $BACKEND:$SYSTEM:${{ matrix.tests }}"
+          done
+          echo "Running command: spread $RUN_TESTS"
+          spread $RUN_TESTS
+
+      - name: Discard spread workers
+        if: always()
+        run: |
+          shopt -s nullglob
+          for r in .spread-reuse.*.yaml; do
+            spread -discard -reuse-pid="$(echo "$r" | grep -o -E '[0-9]+')"
+          done


### PR DESCRIPTION
## Overview

Adds a `spread-manual.yaml` workflow, similar to [Snapcraft's](https://github.com/canonical/snapcraft/blob/main/.github/workflows/spread-manual.yaml), for running manual/large/flaky spread suites outside the regular PR spread run.

Unlike Snapcraft's single blanket label, each manual suite gets its own label so suites can be run independently:

- `boot` (currently the only suite with `manual: true` in `spread.yaml`) is gated by the **`PR: Run Manual Spread (boot)`** label.

The workflow also runs on a schedule (Wed/Sun 03:00) and via `workflow_dispatch`.

Adding a future manual suite means adding a new `run-<suite>` predicate output/label and a job gated on it, without touching existing suites.

## IMAGECRAFT-176