### PR TITLE
chore(deps): update craft-providers to ~=3.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     "craft-platforms~=0.6",
     "craft-application~=7.2",
     "craft-grammar~=2.3",
-    "craft-providers~=3.0",
+    "craft-providers~=3.7",
     "pydantic~=2.8",
     "pygit2>=1.13.0,<1.15.0; python_version=='3.12'", # pin pygit2 to versions compatible with libgit2-1.7 for core24
     "pygit2>=1.19.0,<1.20.0; python_version=='3.14'", # Ubuntu 26.04 and core26

--- a/uv.lock
+++ b/uv.lock
@@ -856,7 +856,7 @@ requires-dist = [
     { name = "craft-grammar", specifier = "~=2.3" },
     { name = "craft-parts", specifier = "~=2.35.0" },
     { name = "craft-platforms", specifier = "~=0.6" },
-    { name = "craft-providers", specifier = "~=3.0" },
+    { name = "craft-providers", specifier = "~=3.7" },
     { name = "pydantic", specifier = "~=2.8" },
     { name = "pygit2", marker = "python_full_version == '3.12.*'", specifier = ">=1.13.0,<1.15.0" },
     { name = "pygit2", marker = "python_full_version == '3.14.*'", specifier = ">=1.19.0,<1.20.0" },


### PR DESCRIPTION
## Summary

Bumps the `craft-providers` dependency pin from `~=3.0` to `~=3.7` and regenerates `uv.lock`, which now resolves `craft-providers` to `3.7.1`.

## Testing

- `make test` — all tests pass except 2 pre-existing failures in `tests/unit/services/test_pack.py` (`Package backend 'apt' is not supported on this environment`), confirmed to fail identically on `main` and unrelated to this change.
- `make lint-ruff lint-uv-lockfile lint-ty` — all pass.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>