### PR TITLE
test(spread): retry restore cleanup for pack tests

### DIFF
--- a/tests/spread/pack/grub-boot-partition/task.yaml
+++ b/tests/spread/pack/grub-boot-partition/task.yaml
@@ -15,7 +15,12 @@ execute: |
   MATCH "Adding boot menu entry for UEFI Firmware Settings" "$imagecraft_log_file"
 
 restore: |
-  imagecraft clean --destructive-mode
+  # Retry: imagecraft clean can transiently fail to remove work dirs
+  # if internal build mounts haven't fully released under host load.
+  for i in $(seq 1 5); do
+      imagecraft clean --destructive-mode && break
+      sleep 2
+  done
   rm -rf pc.img || true
 
 debug: |

--- a/tests/spread/pack/grub/task.yaml
+++ b/tests/spread/pack/grub/task.yaml
@@ -51,15 +51,31 @@ restore: |
       do
           p=${l#"$LOOP"}
           mount --make-rprivate ${TMP_MOUNT}/$p || true
-          umount --recursive ${TMP_MOUNT}/$p || true
+          # Retry: under host load the mount can still be transiently
+          # busy right after the previous command finished.
+          for i in $(seq 1 10); do
+              umount --recursive ${TMP_MOUNT}/$p && break
+              sleep 1
+          done
       done
 
-      losetup -d "$LOOP"
+      # losetup -d can fail with "device is busy" if a partition mount
+      # hasn't fully released yet; retry instead of failing the restore.
+      for i in $(seq 1 10); do
+          losetup -d "$LOOP" && break
+          sleep 1
+      done
       sync
-      losetup -l | NOMATCH "$LOOP"
+      for i in $(seq 1 10); do
+          losetup -l | NOMATCH "$LOOP" && break
+          sleep 1
+      done
       rm loop.txt
   fi
-  imagecraft clean --destructive-mode
+  for i in $(seq 1 5); do
+      imagecraft clean --destructive-mode && break
+      sleep 2
+  done
   rm -rf pc.img || true
 
 debug: |

--- a/tests/spread/pack/mbr-grub-boot-partition/task.yaml
+++ b/tests/spread/pack/mbr-grub-boot-partition/task.yaml
@@ -14,7 +14,12 @@ execute: |
   MATCH "Generating grub configuration file" "$imagecraft_log_file"
 
 restore: |
-  imagecraft clean --destructive-mode
+  # Retry: imagecraft clean can transiently fail to remove work dirs
+  # if internal build mounts haven't fully released under host load.
+  for i in $(seq 1 5); do
+      imagecraft clean --destructive-mode && break
+      sleep 2
+  done
   rm -rf pc.img || true
 
 debug: |

--- a/tests/spread/pack/mbr-grub/task.yaml
+++ b/tests/spread/pack/mbr-grub/task.yaml
@@ -48,15 +48,31 @@ restore: |
       do
           p=${l#"$LOOP"}
           mount --make-rprivate ${TMP_MOUNT}/$p || true
-          umount --recursive ${TMP_MOUNT}/$p || true
+          # Retry: under host load the mount can still be transiently
+          # busy right after the previous command finished.
+          for i in $(seq 1 10); do
+              umount --recursive ${TMP_MOUNT}/$p && break
+              sleep 1
+          done
       done
 
-      losetup -d "$LOOP"
+      # losetup -d can fail with "device is busy" if a partition mount
+      # hasn't fully released yet; retry instead of failing the restore.
+      for i in $(seq 1 10); do
+          losetup -d "$LOOP" && break
+          sleep 1
+      done
       sync
-      losetup -l | NOMATCH "$LOOP"
+      for i in $(seq 1 10); do
+          losetup -l | NOMATCH "$LOOP" && break
+          sleep 1
+      done
       rm loop.txt
   fi
-  imagecraft clean --destructive-mode
+  for i in $(seq 1 5); do
+      imagecraft clean --destructive-mode && break
+      sleep 2
+  done
   rm -rf pc.img || true
 
 debug: |

--- a/tests/spread/pack/organize-overlay/task.yaml
+++ b/tests/spread/pack/organize-overlay/task.yaml
@@ -8,7 +8,12 @@ execute: |
   test -f pc.img
 
 restore: |
-  imagecraft clean --destructive-mode
+  # Retry: imagecraft clean can transiently fail to remove work dirs
+  # if internal build mounts haven't fully released under host load.
+  for i in $(seq 1 5); do
+      imagecraft clean --destructive-mode && break
+      sleep 2
+  done
   rm -rf pc.img || true
 
 debug: |


### PR DESCRIPTION
Some `tests/spread/pack/*` restore scripts (`grub`, `mbr-grub`, `grub-boot-partition`, `mbr-grub-boot-partition`, `organize-overlay`) clean up loop-device mounts and run `imagecraft clean --destructive-mode` with commands (`umount`, `losetup -d`, `imagecraft clean`) that can transiently fail with a busy resource under host load. When that happens, the whole restore step hard-fails and leaves the test environment dirty for subsequent tasks (seen as `Failed task restore` in spread runs against the multipass backend).

This PR wraps those cleanup commands in short retry loops so a transient busy error doesn't fail the restore outright.