### PR TITLE
tests/spread: retry restore cleanup for pack tests

### DIFF
--- a/tests/spread/pack/grub-boot-partition/task.yaml
+++ b/tests/spread/pack/grub-boot-partition/task.yaml
@@ -15,7 +15,12 @@ execute: |
   MATCH "Adding boot menu entry for UEFI Firmware Settings" "$imagecraft_log_file"
 
 restore: |
-  imagecraft clean --destructive-mode
+  # Retry: imagecraft clean can transiently fail to remove work dirs
+  # if internal build mounts haven't fully released under host load.
+  for i in $(seq 1 5); do
+      imagecraft clean --destructive-mode && break
+      sleep 2
+  done
   rm -rf pc.img || true
 
 debug: |

--- a/tests/spread/pack/grub/task.yaml
+++ b/tests/spread/pack/grub/task.yaml
@@ -51,15 +51,31 @@ restore: |
       do
           p=${l#"$LOOP"}
           mount --make-rprivate ${TMP_MOUNT}/$p || true
-          umount --recursive ${TMP_MOUNT}/$p || true
+          # Retry: under host load the mount can still be transiently
+          # busy right after the previous command finished.
+          for i in $(seq 1 10); do
+              umount --recursive ${TMP_MOUNT}/$p && break
+              sleep 1
+          done
       done
 
-      losetup -d "$LOOP"
+      # losetup -d can fail with "device is busy" if a partition mount
+      # hasn't fully released yet; retry instead of failing the restore.
+      for i in $(seq 1 10); do
+          losetup -d "$LOOP" && break
+          sleep 1
+      done
       sync
-      losetup -l | NOMATCH "$LOOP"
+      for i in $(seq 1 10); do
+          losetup -l | NOMATCH "$LOOP" && break
+          sleep 1
+      done
       rm loop.txt
   fi
-  imagecraft clean --destructive-mode
+  for i in $(seq 1 5); do
+      imagecraft clean --destructive-mode && break
+      sleep 2
+  done
   rm -rf pc.img || true
 
 debug: |

--- a/tests/spread/pack/mbr-grub-boot-partition/task.yaml
+++ b/tests/spread/pack/mbr-grub-boot-partition/task.yaml
@@ -14,7 +14,12 @@ execute: |
   MATCH "Generating grub configuration file" "$imagecraft_log_file"
 
 restore: |
-  imagecraft clean --destructive-mode
+  # Retry: imagecraft clean can transiently fail to remove work dirs
+  # if internal build mounts haven't fully released under host load.
+  for i in $(seq 1 5); do
+      imagecraft clean --destructive-mode && break
+      sleep 2
+  done
   rm -rf pc.img || true
 
 debug: |

--- a/tests/spread/pack/mbr-grub/task.yaml
+++ b/tests/spread/pack/mbr-grub/task.yaml
@@ -48,15 +48,31 @@ restore: |
       do
           p=${l#"$LOOP"}
           mount --make-rprivate ${TMP_MOUNT}/$p || true
-          umount --recursive ${TMP_MOUNT}/$p || true
+          # Retry: under host load the mount can still be transiently
+          # busy right after the previous command finished.
+          for i in $(seq 1 10); do
+              umount --recursive ${TMP_MOUNT}/$p && break
+              sleep 1
+          done
       done
 
-      losetup -d "$LOOP"
+      # losetup -d can fail with "device is busy" if a partition mount
+      # hasn't fully released yet; retry instead of failing the restore.
+      for i in $(seq 1 10); do
+          losetup -d "$LOOP" && break
+          sleep 1
+      done
       sync
-      losetup -l | NOMATCH "$LOOP"
+      for i in $(seq 1 10); do
+          losetup -l | NOMATCH "$LOOP" && break
+          sleep 1
+      done
       rm loop.txt
   fi
-  imagecraft clean --destructive-mode
+  for i in $(seq 1 5); do
+      imagecraft clean --destructive-mode && break
+      sleep 2
+  done
   rm -rf pc.img || true
 
 debug: |

--- a/tests/spread/pack/organize-overlay/task.yaml
+++ b/tests/spread/pack/organize-overlay/task.yaml
@@ -8,7 +8,12 @@ execute: |
   test -f pc.img
 
 restore: |
-  imagecraft clean --destructive-mode
+  # Retry: imagecraft clean can transiently fail to remove work dirs
+  # if internal build mounts haven't fully released under host load.
+  for i in $(seq 1 5); do
+      imagecraft clean --destructive-mode && break
+      sleep 2
+  done
   rm -rf pc.img || true
 
 debug: |


### PR DESCRIPTION
Wraps loop-device unmount/detach and `imagecraft clean --destructive-mode` in retry loops in the `grub`, `mbr-grub`, `grub-boot-partition`, `mbr-grub-boot-partition`, and `organize-overlay` pack test restore scripts, so transient "device busy" errors under host load don't hard-fail the restore step.