### PR TITLE
build: install grub/ext4/blkid tooling in `make setup`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,18 @@ APT_PACKAGES :=
 ifeq ($(shell which mtools),)
 APT_PACKAGES += mtools
 endif
+ifeq ($(shell command -v grub-mkimage 2>/dev/null),)
+APT_PACKAGES += grub-common
+endif
+# debugfs and blkid live in /usr/sbin, which is not on the default non-root
+# PATH on every distribution, so search there explicitly to avoid reinstalling
+# packages that are already present.
+ifeq ($(shell PATH="$(PATH):/usr/sbin:/sbin" command -v debugfs 2>/dev/null),)
+APT_PACKAGES += e2fsprogs
+endif
+ifeq ($(shell PATH="$(PATH):/usr/sbin:/sbin" command -v blkid 2>/dev/null),)
+APT_PACKAGES += util-linux
+endif
 ifeq ($(wildcard /usr/include/libxml2/libxml/xpath.h),)
 APT_PACKAGES += libxml2-dev
 endif


### PR DESCRIPTION
Part 1 of a stack that makes GRUB installation work without root privileges.

`tests/unit/pack/test_grubutil.py` has an autouse fixture that hard-fails
(rather than skips) when the GRUB tooling is missing, telling the developer to
run `make setup`. That advice did not actually work, because `make setup` only
installed `mtools`.

This adds the packages providing the other binaries the pack tests shell out to,
so that a fresh `make setup` is enough to run the test suite:

| Binary | Package |
| --- | --- |
| `grub-mkimage` | `grub-common` |
| `debugfs` | `e2fsprogs` |
| `blkid` | `util-linux` |

No production code changes.

IMAGECRAFT-176
