### PR TITLE
feat(pack): add partition size and by-number lookup helpers to gptutil

### DIFF
--- a/imagecraft/pack/gptutil.py
+++ b/imagecraft/pack/gptutil.py
@@ -222,7 +222,7 @@ def _partition_node_number(
     """
     device = str(table.get("device", ""))
     node = str(partition.get("node", ""))
-    suffix = node[len(device) :] if node.startswith(device) else node
+    suffix = node.removeprefix(device)
     match = re.fullmatch(r"p?(\d+)", suffix)
     return int(match.group(1)) if match else None
 

--- a/imagecraft/pack/gptutil.py
+++ b/imagecraft/pack/gptutil.py
@@ -15,6 +15,7 @@
 """Utility functions for GPT-formatted disks."""
 
 import json
+import re
 import subprocess
 from pathlib import Path
 from typing import Any, cast
@@ -202,10 +203,43 @@ def _get_partition_info(imagepath: Path, partname: str) -> dict[str, Any]:
 
     :raises CalledProcessError: If sfdisk fails.
     """
-    for partition in _get_partition_table(imagepath)["partitions"]:
-        if partition["name"] == partname:
+    for partition in _get_partition_table(imagepath).get("partitions", []):
+        if partition.get("name") == partname:
             return cast(dict[str, Any], partition)
     raise CraftError(f"No partition named {partname} in {imagepath}")
+
+
+def _partition_node_number(
+    table: dict[str, Any], partition: dict[str, Any]
+) -> int | None:
+    """Return the partition number sfdisk reported for a partition entry.
+
+    sfdisk only lists partitions that are in use, so a table with gaps in its
+    numbering (possible for GPT, which lets users pick partition numbers) has
+    entries whose number doesn't match their position in the list. The number
+    has to be recovered from the node name, which is the device path with the
+    partition number (optionally prefixed by "p") appended.
+    """
+    device = str(table.get("device", ""))
+    node = str(partition.get("node", ""))
+    suffix = node[len(device) :] if node.startswith(device) else node
+    match = re.fullmatch(r"p?(\d+)", suffix)
+    return int(match.group(1)) if match else None
+
+
+def _get_partition_info_by_number(imagepath: Path, partnum: int) -> dict[str, Any]:
+    """Return a dict representing info about partition number partnum (1-based).
+
+    MBR partition tables have no per-partition name field (unlike GPT), so
+    MBR partitions must be looked up by their number instead.
+
+    :raises CalledProcessError: If sfdisk fails.
+    """
+    table = _get_partition_table(imagepath)
+    for partition in table.get("partitions", []):
+        if _partition_node_number(table, partition) == partnum:
+            return cast(dict[str, Any], partition)
+    raise CraftError(f"No partition number {partnum} in {imagepath}")
 
 
 def get_partition_sector_offset(imagepath: Path, partname: str) -> int:
@@ -214,6 +248,39 @@ def get_partition_sector_offset(imagepath: Path, partname: str) -> int:
     :raises CalledProcessError: If sfdisk fails.
     """
     return cast(int, _get_partition_info(imagepath, partname)["start"])
+
+
+def get_partition_size_sectors(imagepath: Path, partname: str) -> int:
+    """Return the size (in sectors) for the partition indicated by partname.
+
+    Only GPT partitions are named in sfdisk's output; use
+    `get_partition_size_sectors_by_number` for MBR volumes.
+
+    :raises CalledProcessError: If sfdisk fails.
+    """
+    return cast(int, _get_partition_info(imagepath, partname)["size"])
+
+
+def get_partition_sector_offset_by_number(imagepath: Path, partnum: int) -> int:
+    """Return the start sector (offset) for partition number partnum (1-based).
+
+    Use this instead of `get_partition_sector_offset` for MBR volumes, whose
+    partitions aren't named in sfdisk's output.
+
+    :raises CalledProcessError: If sfdisk fails.
+    """
+    return cast(int, _get_partition_info_by_number(imagepath, partnum)["start"])
+
+
+def get_partition_size_sectors_by_number(imagepath: Path, partnum: int) -> int:
+    """Return the size (in sectors) for partition number partnum (1-based).
+
+    Use this instead of `get_partition_size_sectors` for MBR volumes, whose
+    partitions aren't named in sfdisk's output.
+
+    :raises CalledProcessError: If sfdisk fails.
+    """
+    return cast(int, _get_partition_info_by_number(imagepath, partnum)["size"])
 
 
 def verify_partition_tables(imagepath: Path) -> None:

--- a/tests/integration/pack/test_gptutil.py
+++ b/tests/integration/pack/test_gptutil.py
@@ -1,0 +1,82 @@
+# Copyright 2026 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import pathlib
+
+import pytest
+from imagecraft.models import GPTVolume
+from imagecraft.pack import gptutil
+from imagecraft.pack.gptutil import SECTOR_SIZE_512
+
+EFI_PARTITION_SIZE_BYTES = 32 * (1024**2)  # 32 MiB
+BOOT_PARTITION_SIZE_BYTES = 20 * (1024**2)  # 20 MiB
+ROOTFS_PARTITION_SIZE_BYTES = 128 * (1024**2)  # 128 MiB
+
+
+@pytest.fixture
+def layout():
+    return GPTVolume.unmarshal(
+        {
+            "schema": "gpt",
+            "structure": [
+                {
+                    "name": "efi",
+                    "role": "system-boot",
+                    "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+                    "filesystem": "vfat",
+                    "size": "32M",
+                    "filesystem-label": "",
+                },
+                {
+                    "name": "boot",
+                    "role": "system-boot",
+                    "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                    "filesystem": "fat16",
+                    "size": "20M",
+                },
+                {
+                    "name": "rootfs",
+                    "role": "system-data",
+                    "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                    "id": "6fa819a0-a35a-487a-82d4-a86d1a46b2bb",
+                    "filesystem": "ext4",
+                    "size": "128M",
+                    "filesystem-label": "writable",
+                },
+            ],
+        }
+    )
+
+
+@pytest.fixture
+def image(tmp_path, request: pytest.FixtureRequest, layout: GPTVolume):
+    image_path = tmp_path / "empty.img"
+    gptutil.create_empty_gpt_image(image_path, SECTOR_SIZE_512, layout)
+    return image_path
+
+
+def test_get_partition_size_sectors(tmp_path, layout: GPTVolume, image: pathlib.Path):
+    """Check that the partition's size is what's expected."""
+    assert (
+        gptutil.get_partition_size_sectors(image, "efi")
+        == EFI_PARTITION_SIZE_BYTES // SECTOR_SIZE_512
+    )
+    assert (
+        gptutil.get_partition_size_sectors(image, "boot")
+        == BOOT_PARTITION_SIZE_BYTES // SECTOR_SIZE_512
+    )
+    assert (
+        gptutil.get_partition_size_sectors(image, "rootfs")
+        == ROOTFS_PARTITION_SIZE_BYTES // SECTOR_SIZE_512
+    )

--- a/tests/unit/pack/test_gptutil.py
+++ b/tests/unit/pack/test_gptutil.py
@@ -208,6 +208,168 @@ def test_get_partition_sector_offset(mocker, tmp_path):
     assert gptutil.get_partition_sector_offset(tmp_path, "rootfs") == 526336
 
 
+_TWO_PARTITION_SFDISK_JSON = """
+{
+   "partitiontable": {
+      "label": "gpt",
+      "device": "example/packt/pc.img",
+      "unit": "sectors",
+      "sectorsize": 512,
+      "partitions": [
+         {
+            "node": "example/packt/pc.img1",
+            "start": 2048,
+            "size": 524288,
+            "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+            "name": "efi"
+         },{
+            "node": "example/packt/pc.img2",
+            "start": 526336,
+            "size": 12582912,
+            "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+            "name": "rootfs"
+         }
+      ]
+   }
+}
+"""
+
+
+@pytest.fixture
+def fake_sfdisk(mocker):
+    """Patch sfdisk to report a two-partition (efi, rootfs) GPT layout."""
+    return mocker.patch(
+        "imagecraft.pack.gptutil.subprocess.run",
+        autospec=True,
+        side_effect=[
+            CompletedProcess(args=[], returncode=0, stdout=_TWO_PARTITION_SFDISK_JSON)
+        ],
+    )
+
+
+@pytest.mark.usefixtures("fake_sfdisk")
+@pytest.mark.parametrize(
+    ("partname", "expected"), [("efi", 524288), ("rootfs", 12582912)]
+)
+def test_get_partition_size_sectors(tmp_path, partname, expected):
+    assert gptutil.get_partition_size_sectors(tmp_path, partname) == expected
+
+
+@pytest.mark.usefixtures("fake_sfdisk")
+def test_get_partition_size_sectors_unknown_name(tmp_path):
+    with pytest.raises(CraftError, match="No partition named nope"):
+        gptutil.get_partition_size_sectors(tmp_path, "nope")
+
+
+@pytest.mark.usefixtures("fake_sfdisk")
+@pytest.mark.parametrize(("partnum", "expected"), [(1, 2048), (2, 526336)])
+def test_get_partition_sector_offset_by_number(tmp_path, partnum, expected):
+    assert gptutil.get_partition_sector_offset_by_number(tmp_path, partnum) == expected
+
+
+@pytest.mark.usefixtures("fake_sfdisk")
+@pytest.mark.parametrize(("partnum", "expected"), [(1, 524288), (2, 12582912)])
+def test_get_partition_size_sectors_by_number(tmp_path, partnum, expected):
+    assert gptutil.get_partition_size_sectors_by_number(tmp_path, partnum) == expected
+
+
+@pytest.mark.usefixtures("fake_sfdisk")
+@pytest.mark.parametrize("partnum", [0, 3, -1])
+def test_get_partition_info_by_number_out_of_range(tmp_path, partnum):
+    """Partition numbers are 1-based, so 0 and len+1 are both out of range."""
+    with pytest.raises(CraftError, match=f"No partition number {partnum}"):
+        gptutil.get_partition_sector_offset_by_number(tmp_path, partnum)
+
+
+_EMPTY_SFDISK_JSON = """
+{
+   "partitiontable": {
+      "label": "dos",
+      "device": "example/packt/pc.img",
+      "unit": "sectors",
+      "sectorsize": 512
+   }
+}
+"""
+
+
+@pytest.fixture
+def fake_sfdisk_empty(mocker):
+    """Patch sfdisk to report a partition table with no partitions at all."""
+    return mocker.patch(
+        "imagecraft.pack.gptutil.subprocess.run",
+        autospec=True,
+        side_effect=[
+            CompletedProcess(args=[], returncode=0, stdout=_EMPTY_SFDISK_JSON)
+        ],
+    )
+
+
+@pytest.mark.usefixtures("fake_sfdisk_empty")
+def test_get_partition_size_sectors_empty_table(tmp_path):
+    with pytest.raises(CraftError, match="No partition named rootfs"):
+        gptutil.get_partition_size_sectors(tmp_path, "rootfs")
+
+
+@pytest.mark.usefixtures("fake_sfdisk_empty")
+def test_get_partition_size_sectors_by_number_empty_table(tmp_path):
+    with pytest.raises(CraftError, match="No partition number 1"):
+        gptutil.get_partition_size_sectors_by_number(tmp_path, 1)
+
+
+_SPARSE_SFDISK_JSON = """
+{
+   "partitiontable": {
+      "label": "gpt",
+      "device": "example/packt/pc.img",
+      "unit": "sectors",
+      "sectorsize": 512,
+      "partitions": [
+         {
+            "node": "example/packt/pc.img2",
+            "start": 2048,
+            "size": 524288,
+            "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+            "name": "efi"
+         },{
+            "node": "example/packt/pc.img5",
+            "start": 526336,
+            "size": 12582912,
+            "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+            "name": "rootfs"
+         }
+      ]
+   }
+}
+"""
+
+
+@pytest.fixture
+def fake_sfdisk_sparse(mocker):
+    """Patch sfdisk to report a table numbered 2 and 5, with 1, 3 and 4 unused."""
+    return mocker.patch(
+        "imagecraft.pack.gptutil.subprocess.run",
+        autospec=True,
+        side_effect=[
+            CompletedProcess(args=[], returncode=0, stdout=_SPARSE_SFDISK_JSON)
+        ],
+    )
+
+
+@pytest.mark.usefixtures("fake_sfdisk_sparse")
+@pytest.mark.parametrize(("partnum", "expected"), [(2, 2048), (5, 526336)])
+def test_get_partition_sector_offset_by_number_sparse(tmp_path, partnum, expected):
+    """sfdisk omits unused slots, so numbers can't be treated as list positions."""
+    assert gptutil.get_partition_sector_offset_by_number(tmp_path, partnum) == expected
+
+
+@pytest.mark.usefixtures("fake_sfdisk_sparse")
+@pytest.mark.parametrize("partnum", [1, 3, 4])
+def test_get_partition_info_by_number_sparse_unused(tmp_path, partnum):
+    with pytest.raises(CraftError, match=f"No partition number {partnum}"):
+        gptutil.get_partition_size_sectors_by_number(tmp_path, partnum)
+
+
 def test_verify_partition_tables(mocker, tmp_path):
     fake_result = CompletedProcess(
         args=[],


### PR DESCRIPTION
Part 2 of a stack that makes GRUB installation work without loop devices.

To write into a partition of a disk image without mounting it, we need to know
where that partition starts and how big it is. `gptutil` could already list
partitions, but callers had to hand-roll the arithmetic to turn a partition
number into a byte offset and size.

This adds small helpers to do that lookup, plus unit tests. There are no callers
yet -- the code that uses them arrives later in the stack.

Also backfills tests for the existing helpers, which were only covered
indirectly by slow end-to-end tests.

IMAGECRAFT-176