### PR TITLE
fix(pack): mark system-data bootable when there is no system-boot

### DIFF
--- a/imagecraft/pack/mbrutil.py
+++ b/imagecraft/pack/mbrutil.py
@@ -15,13 +15,14 @@
 """Utility functions for MBR-formatted disks."""
 
 import subprocess
+from collections.abc import Sequence
 from pathlib import Path
 from typing import Any
 
 from craft_cli import emit
 
 from imagecraft.errors import MBRPartitionError
-from imagecraft.models.volume import MBRVolume, Role
+from imagecraft.models.volume import MBRStructureItem, MBRVolume, Role
 from imagecraft.pack import diskutil
 
 SECTOR_SIZE_512 = 512
@@ -62,6 +63,48 @@ def _create_sfdisk_lines(
         stdin_lines.append(", ".join(fields))
     stdin_lines.append("write")
     return stdin_lines
+
+
+def _select_bootable_item(
+    structure: Sequence[MBRStructureItem],
+    logical_items: Sequence[MBRStructureItem],
+) -> MBRStructureItem | None:
+    """Pick the single partition that gets the MBR active flag.
+
+    The BIOS/SeaBIOS boot process hands control to exactly one partition, the
+    one carrying the "active"/bootable flag in the MBR. That is normally the
+    system-boot partition, but layouts with no separate boot partition
+    (grub-pc's core.img lives in the MBR gap, and grub.cfg and the kernel live
+    directly on the root filesystem) have no system-boot role at all, so fall
+    back to the system-data partition.
+
+    :param structure: All structure items, in partition order.
+    :param logical_items: The items that will become logical partitions.
+    :returns: The item to mark bootable, or None if there is no candidate.
+    :raises MBRPartitionError: If the only candidate is a logical partition.
+    """
+    for role in (Role.SYSTEM_BOOT.value, Role.SYSTEM_DATA.value):
+        candidates = [item for item in structure if item.role == role]
+        if not candidates:
+            continue
+        # Only the first is flagged: an MBR with several active partitions is
+        # invalid, and firmware behaviour in that case is unpredictable.
+        bootable_item = candidates[0]
+        if any(item is bootable_item for item in logical_items):
+            raise MBRPartitionError(
+                f"The {role} partition '{bootable_item.name}' must be within "
+                f"the first {PRIMARY_SLOTS_WITH_EXTENDED} partitions to be "
+                "marked bootable when an extended partition is required.",
+                details=(
+                    "The BIOS only looks for the active flag in the four "
+                    "primary partition entries, not inside the extended "
+                    "partition chain."
+                ),
+                resolution=f"Move '{bootable_item.name}' to one of the first "
+                f"{PRIMARY_SLOTS_WITH_EXTENDED} partition slots.",
+            )
+        return bootable_item
+    return None
 
 
 def _create_mbr_layout(
@@ -107,6 +150,8 @@ def _create_mbr_layout(
         primary_items = structure
         logical_items = []
 
+    bootable_item = _select_bootable_item(structure, logical_items)
+
     partitions: list[dict[str, str | None]] = []
     start = _MBR_RESERVED_SECTORS
     for structure_item in primary_items:
@@ -116,7 +161,7 @@ def _create_mbr_layout(
             "size": str(sectors),
             "type": structure_item.structure_type.value,
         }
-        if structure_item.role == Role.SYSTEM_BOOT.value:
+        if structure_item is bootable_item:
             partition["bootable"] = None
         partitions.append(partition)
         start += sectors
@@ -135,8 +180,6 @@ def _create_mbr_layout(
                 "size": str(logical_sectors),
                 "type": logical.structure_type.value,
             }
-            if logical.role == Role.SYSTEM_BOOT.value:
-                logical_entry["bootable"] = None
             partitions.append(logical_entry)
             logical_start += logical_sectors + _EBR_OVERHEAD_SECTORS
 

--- a/tests/integration/pack/test_mbrutil.py
+++ b/tests/integration/pack/test_mbrutil.py
@@ -41,7 +41,13 @@ _VOLUME_SINGLE_SFDISK_EXPECTED = {
     "unit": "sectors",
     "sectorsize": 512,
     "partitions": [
-        {"node": "disk.img1", "start": 2048, "size": 4194304, "type": "83"},
+        {
+            "node": "disk.img1",
+            "start": 2048,
+            "size": 4194304,
+            "type": "83",
+            "bootable": True,
+        },
     ],
 }
 

--- a/tests/unit/pack/test_mbrutil.py
+++ b/tests/unit/pack/test_mbrutil.py
@@ -206,10 +206,6 @@ def test_create_mbr_layout_calls_sfdisk(mocker, tmp_path, volume):
 
 
 def test_create_mbr_layout_no_system_boot_marks_system_data_bootable(mocker, tmp_path):
-    # Regression test: layouts with no system-boot partition (e.g. grub-pc
-    # BIOS-only images where core.img lives in the MBR gap) must still mark
-    # a partition bootable, or SeaBIOS has no active partition to boot from
-    # and hangs at "Booting from Hard Disk...".
     layout = MBRVolume.unmarshal(_VOLUME_SINGLE)
     mocked_run = mocker.patch("imagecraft.pack.mbrutil.subprocess.run", autospec=True)
 
@@ -252,10 +248,6 @@ _VOLUME_MULTI_DATA_NO_BOOT = {
 
 
 def test_create_mbr_layout_marks_exactly_one_partition_bootable(mocker, tmp_path):
-    # An MBR may only have one active partition. When several partitions share
-    # the system-data role and there is no system-boot partition, only the
-    # first may be flagged, otherwise sfdisk writes several active entries and
-    # the firmware picks one unpredictably.
     layout = MBRVolume.unmarshal(_VOLUME_MULTI_DATA_NO_BOOT)
     mocked_run = mocker.patch("imagecraft.pack.mbrutil.subprocess.run", autospec=True)
 
@@ -277,8 +269,6 @@ def test_create_mbr_layout_marks_exactly_one_partition_bootable(mocker, tmp_path
 
 
 def test_create_mbr_layout_prefers_system_boot_over_system_data(mocker, tmp_path):
-    # When a system-boot partition exists it wins, and the system-data
-    # partition must not also be flagged.
     layout = MBRVolume.unmarshal(_VOLUME_TWO_PARTS)
     mocked_run = mocker.patch("imagecraft.pack.mbrutil.subprocess.run", autospec=True)
 

--- a/tests/unit/pack/test_mbrutil.py
+++ b/tests/unit/pack/test_mbrutil.py
@@ -205,6 +205,97 @@ def test_create_mbr_layout_calls_sfdisk(mocker, tmp_path, volume):
     assert "bootable" in stdin  # ubuntu-seed has role system-boot
 
 
+def test_create_mbr_layout_no_system_boot_marks_system_data_bootable(mocker, tmp_path):
+    # Regression test: layouts with no system-boot partition (e.g. grub-pc
+    # BIOS-only images where core.img lives in the MBR gap) must still mark
+    # a partition bootable, or SeaBIOS has no active partition to boot from
+    # and hangs at "Booting from Hard Disk...".
+    layout = MBRVolume.unmarshal(_VOLUME_SINGLE)
+    mocked_run = mocker.patch("imagecraft.pack.mbrutil.subprocess.run", autospec=True)
+
+    mbrutil._create_mbr_layout(
+        imagepath=tmp_path / "image.img",
+        sector_size=512,
+        layout=layout,
+    )
+
+    stdin = mocked_run.call_args.kwargs["input"]
+    assert "bootable" in stdin
+
+
+_VOLUME_MULTI_DATA_NO_BOOT = {
+    "schema": "mbr",
+    "structure": [
+        {
+            "name": "rootfs",
+            "role": "system-data",
+            "type": "83",
+            "filesystem": "ext4",
+            "size": "2G",
+        },
+        {
+            "name": "data",
+            "role": "system-data",
+            "type": "83",
+            "filesystem": "ext4",
+            "size": "1G",
+        },
+        {
+            "name": "home",
+            "role": "system-data",
+            "type": "83",
+            "filesystem": "ext4",
+            "size": "1G",
+        },
+    ],
+}
+
+
+def test_create_mbr_layout_marks_exactly_one_partition_bootable(mocker, tmp_path):
+    # An MBR may only have one active partition. When several partitions share
+    # the system-data role and there is no system-boot partition, only the
+    # first may be flagged, otherwise sfdisk writes several active entries and
+    # the firmware picks one unpredictably.
+    layout = MBRVolume.unmarshal(_VOLUME_MULTI_DATA_NO_BOOT)
+    mocked_run = mocker.patch("imagecraft.pack.mbrutil.subprocess.run", autospec=True)
+
+    mbrutil._create_mbr_layout(
+        imagepath=tmp_path / "image.img",
+        sector_size=512,
+        layout=layout,
+    )
+
+    stdin = mocked_run.call_args.kwargs["input"]
+    partition_lines = [line for line in stdin.splitlines() if line.startswith("start=")]
+    bootable_lines = [line for line in partition_lines if "bootable" in line]
+
+    assert len(partition_lines) == 3
+    assert len(bootable_lines) == 1
+    # It must be the first partition, which is the one holding the root
+    # filesystem GRUB was pointed at.
+    assert bootable_lines[0] == partition_lines[0]
+
+
+def test_create_mbr_layout_prefers_system_boot_over_system_data(mocker, tmp_path):
+    # When a system-boot partition exists it wins, and the system-data
+    # partition must not also be flagged.
+    layout = MBRVolume.unmarshal(_VOLUME_TWO_PARTS)
+    mocked_run = mocker.patch("imagecraft.pack.mbrutil.subprocess.run", autospec=True)
+
+    mbrutil._create_mbr_layout(
+        imagepath=tmp_path / "image.img",
+        sector_size=512,
+        layout=layout,
+    )
+
+    stdin = mocked_run.call_args.kwargs["input"]
+    partition_lines = [line for line in stdin.splitlines() if line.startswith("start=")]
+    bootable_lines = [line for line in partition_lines if "bootable" in line]
+
+    assert len(bootable_lines) == 1
+    assert bootable_lines[0] == partition_lines[0]
+
+
 def test_create_mbr_layout_sfdisk_failure_raises(mocker, tmp_path, volume):
     mocked_run = mocker.patch("imagecraft.pack.mbrutil.subprocess.run", autospec=True)
     mocked_run.side_effect = subprocess.CalledProcessError(


### PR DESCRIPTION
Part 3 of a stack that makes GRUB installation work without loop devices.

A BIOS/MBR image needs a partition flagged bootable for the firmware to hand
over to it. We previously only ever set that flag on the `system-boot`
partition, so an MBR image with no separate boot partition -- everything on the
rootfs, which is a perfectly normal layout -- ended up with no bootable
partition at all and would not boot.

Fall back to marking the `system-data` partition bootable when there is no
`system-boot` partition.

IMAGECRAFT-176
