### PR TITLE
feat(pack): add imgfs for unprivileged partition image manipulation

### DIFF
--- a/imagecraft/pack/imgfs.py
+++ b/imagecraft/pack/imgfs.py
@@ -1,0 +1,492 @@
+# Copyright 2025 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Low-privilege partition image manipulation.
+
+These helpers let callers read and write files inside FAT and ext2/3/4
+partitions *embedded in a raw disk image* without mounting anything,
+attaching loop devices, chrooting, or spinning up a VM. This lets imagecraft
+run in unprivileged containers that can't do any of those things.
+
+FAT partitions are manipulated in place with ``mtools`` using its
+``image@@offset`` addressing (no extraction needed). Ext partitions are
+manipulated with ``debugfs``, which only understands whole filesystem
+images, so the partition is first extracted to a temporary file with
+``dd``, edited, then written back with ``dd``.
+"""
+
+import contextlib
+import os
+import posixpath
+import re
+import shutil
+import subprocess
+import tempfile
+from collections.abc import Iterator
+from pathlib import Path
+
+from imagecraft import errors
+from imagecraft.subprocesses import run
+
+SECTOR_SIZE = 512
+# A `debugfs ls -l` row: inode, mode, (filetype), uid, gid, size, date, time,
+# then the name, which may itself contain spaces and so runs to end of line.
+_DEBUGFS_LS_LINE_RE = re.compile(
+    r"^\s*\d+\s+\d+\s+\(\d+\)\s+\d+\s+\d+\s+\d+\s+\S+\s+\S+\s(?P<name>.+)$"
+)
+# debugfs exits 0 even when it couldn't open the filesystem at all, so that
+# failure has to be spotted in its output instead of via the return code.
+# These markers only appear when the image itself is unusable; an ordinary
+# missing path reports "File not found by ext2_lookup" and is not fatal.
+_DEBUGFS_OPEN_FAILURE_MARKERS = ("Filesystem not open", "while trying to open")
+# debugfs also exits 0 when an individual request fails, and a failed "write"
+# leaves behind an inode of the right size holding truncated data, so the
+# result can't be validated by inspecting the image afterwards either.
+_DEBUGFS_REQUEST_FAILURE_MARKERS = (
+    "Could not allocate",
+    "No space left",
+    "while allocating",
+    "while expanding",
+    "while writing",
+    "Usage: ",
+)
+_DEBUGFS_NOT_FOUND_MARKERS = ("File not found", "Inode is not in use")
+# `ls` on a regular file reports this and still exits 0, which would
+# otherwise be indistinguishable from an empty directory.
+_DEBUGFS_NOT_A_DIRECTORY_MARKER = "Ext2 inode is not a directory"
+# debugfs prefixes every request it echoes back with its own prompt.
+_DEBUGFS_ECHO_PREFIX = "debugfs: "
+# `stat` reports the inode type on the same line as the inode number, which
+# is where it has to be read from: debugfs echoes the requested path too, so
+# scanning the whole output would let a crafted path fake a type.
+_DEBUGFS_STAT_TYPE_RE = re.compile(r"^Inode:.*\bType:\s+(\w+)", re.MULTILINE)
+# A symlink short enough to live in the inode itself has its target reported
+# by `stat`; longer ones are stored in a block and aren't reported at all.
+_DEBUGFS_FAST_LINK_RE = re.compile(r'^Fast link dest: "(.*)"', re.MULTILINE)
+# debugfs escapes bytes it can't print in `ls` output, one `\xNN` per byte.
+_DEBUGFS_ESCAPE_RE = re.compile(r"\\x([0-9a-fA-F]{2})")
+# Characters that can't be expressed in a debugfs script argument: the quote
+# character it delimits arguments with, and control characters (a newline in
+# particular terminates the request and starts another one).
+_DEBUGFS_UNSAFE_PATH_RE = re.compile(r'["\x00-\x1f\x7f]')
+# debugfs reports failures only in prose, which e2fsprogs translates, so its
+# messages have to be forced back to English to stay machine-readable.
+_C_LOCALE_ENV = {**os.environ, "LC_ALL": "C", "LANGUAGE": "C"}
+
+
+def _dd_copy(
+    *, src: Path, dst: Path, bs: int, skip: int = 0, seek: int = 0, count: int | None
+) -> None:
+    args = [
+        "dd",
+        f"if={src}",
+        f"of={dst}",
+        f"bs={bs}",
+        f"skip={skip}",
+        f"seek={seek}",
+        "conv=notrunc",
+        "status=none",
+    ]
+    if count is not None:
+        args.append(f"count={count}")
+    run(*args)
+
+
+def _dd_copy_exact(
+    *, src: Path, dst: Path, bs: int, skip: int = 0, seek: int = 0, count: int
+) -> None:
+    """Copy exactly ``count`` blocks, failing if fewer are available.
+
+    ``dd`` stops at end-of-input and still exits 0, so a truncated image or
+    an out-of-range partition would otherwise yield a short filesystem that
+    subsequent tools happily corrupt.
+    """
+    available = src.stat().st_size - skip * bs
+    if available < count * bs:
+        raise errors.GRUBInstallError(
+            f"{src} is too small: needs {count * bs} bytes at offset {skip * bs}"
+        )
+    _dd_copy(src=src, dst=dst, bs=bs, skip=skip, seek=seek, count=count)
+
+
+@contextlib.contextmanager
+def edit_ext_partition(
+    imagepath: Path, offset_sectors: int, size_sectors: int
+) -> Iterator[Path]:
+    """Extract an ext2/3/4 partition to a temp file for editing with debugfs.
+
+    On successful exit, the (possibly modified) temp file is written back
+    into ``imagepath`` at the same location. No mount, loop device, or
+    elevated privilege is needed: extraction/injection is done with plain
+    ``dd`` reads/writes, and the temp file is edited with ``debugfs -w``.
+
+    :param imagepath: Path to the whole-disk image.
+    :param offset_sectors: Partition start, in sectors.
+    :param size_sectors: Partition size, in sectors.
+    """
+    with tempfile.NamedTemporaryFile(
+        prefix="imagecraft-ext-", suffix=".img"
+    ) as tmp_file:
+        tmp_path = Path(tmp_file.name)
+        _dd_copy_exact(
+            src=imagepath,
+            dst=tmp_path,
+            bs=SECTOR_SIZE,
+            skip=offset_sectors,
+            count=size_sectors,
+        )
+        yield tmp_path
+        _dd_copy_exact(
+            src=tmp_path,
+            dst=imagepath,
+            bs=SECTOR_SIZE,
+            seek=offset_sectors,
+            count=size_sectors,
+        )
+
+
+def _debugfs_quote(path: str) -> str:
+    """Quote a path for debugfs's script parser.
+
+    debugfs reads its script line by line and splits on whitespace, so an
+    unquoted path containing a space silently turns into the wrong request,
+    and a path containing a newline injects an entirely new request.
+    """
+    if _DEBUGFS_UNSAFE_PATH_RE.search(path):
+        raise errors.GRUBInstallError(
+            f"Refusing to pass unsafe path to debugfs: {path!r}"
+        )
+    return f'"{path}"'
+
+
+def debugfs_run(image: Path, commands: list[str]) -> str:
+    """Run one or more debugfs requests against an ext2/3/4 image file.
+
+    :param image: Path to the ext2/3/4 filesystem image (a plain file).
+    :param commands: debugfs requests to run, e.g. ``["mkdir /foo"]``.
+    :raises errors.GRUBInstallError: If debugfs fails.
+    """
+    script = "\n".join(commands)
+    try:
+        res = run(
+            "debugfs",
+            "-w",
+            "-f",
+            "-",
+            str(image),
+            input=script,
+            stderr=subprocess.STDOUT,
+            env=_C_LOCALE_ENV,
+            # The forced C locale applies to debugfs, not to this process's
+            # pipes, which would otherwise be encoded using the ambient
+            # locale and fail on a non-ASCII path.
+            encoding="utf-8",
+        )
+    except subprocess.CalledProcessError as err:
+        raise errors.GRUBInstallError(f"debugfs failed running: {commands!r}") from err
+    if any(
+        marker in line
+        for line in _debugfs_diagnostic_lines(res.stdout)
+        for marker in _DEBUGFS_OPEN_FAILURE_MARKERS + _DEBUGFS_REQUEST_FAILURE_MARKERS
+    ):
+        raise errors.GRUBInstallError(
+            f"debugfs failed running: {commands!r}", details=res.stdout
+        )
+    return res.stdout
+
+
+def _debugfs_diagnostic_lines(output: str) -> list[str]:
+    """Return the lines of debugfs output that can carry an error message.
+
+    debugfs echoes every request it runs, and ``ls`` prints file names, so
+    both can contain arbitrary caller-supplied text; scanning them for error
+    markers would let a path such as "/No space left" fake a failure.
+    """
+    return [
+        line
+        for line in output.splitlines()
+        if not line.startswith(_DEBUGFS_ECHO_PREFIX)
+        and not _DEBUGFS_LS_LINE_RE.match(line)
+    ]
+
+
+def debugfs_mkdir_p(image: Path, target_dir: str) -> None:
+    """Recursively create a directory inside an ext image, ignoring existing ones.
+
+    :raises errors.GRUBInstallError: If the directory isn't there afterwards.
+    """
+    parts = [p for p in target_dir.strip("/").split("/") if p]
+    current = ""
+    commands = []
+    for part in parts:
+        current += f"/{part}"
+        # mkdir errors if the directory already exists; debugfs just prints
+        # a warning to stdout in that case rather than failing the script.
+        commands.append(f"mkdir {_debugfs_quote(current)}")
+    if not commands:
+        return
+    debugfs_run(image, commands)
+    # A regular file anywhere along the path defeats mkdir while debugfs
+    # still exits 0, so confirm a directory really landed.
+    if _debugfs_stat_type(image, current) != "directory":
+        raise errors.GRUBInstallError(
+            f"debugfs failed creating directory {target_dir} in {image}"
+        )
+
+
+def debugfs_write_file(image: Path, local_path: Path, target_path: str) -> None:
+    """Write a local file into an ext image at target_path.
+
+    :raises errors.GRUBInstallError: If the file isn't present afterwards.
+    """
+    # debugfs happily allocates an inode from a directory source and exits 0,
+    # writing junk rather than failing.
+    if not local_path.is_file():
+        raise errors.GRUBInstallError(
+            f"Cannot write {local_path} into {image}: not a regular file"
+        )
+    debugfs_mkdir_p(image, str(Path(target_path).parent))
+    # debugfs's "write" request creates the destination; remove it first so
+    # re-runs (e.g. spread -reuse) don't fail on an existing inode.
+    debugfs_run(
+        image,
+        [
+            f"rm {_debugfs_quote(target_path)}",
+            f"write {_debugfs_quote(str(local_path))} {_debugfs_quote(target_path)}",
+        ],
+    )
+    # debugfs reports per-request failures (a full filesystem, a bad request)
+    # on stdout and still exits 0, so confirm a regular file really landed:
+    # a pre-existing directory at target_path defeats both rm and write while
+    # still satisfying a plain existence check.
+    if _debugfs_stat_type(image, target_path) != "regular":
+        raise errors.GRUBInstallError(
+            f"debugfs failed writing {local_path} to {target_path} in {image}"
+        )
+
+
+def debugfs_read_file(image: Path, target_path: str, local_path: Path) -> None:
+    """Dump a file out of an ext image to a local path.
+
+    Symlinks are resolved first: "dump" reads the inode it is given, so
+    dumping a symlink writes an empty file rather than the file linked to.
+
+    :raises errors.GRUBInstallError: If the file couldn't be dumped.
+    """
+    # A failed "dump" would otherwise leave any pre-existing local file in
+    # place, making the caller silently read stale content.
+    local_path.unlink(missing_ok=True)
+    resolved = _debugfs_resolve_symlinks(image, target_path)
+    if resolved is None:
+        raise errors.GRUBInstallError(
+            f"debugfs failed dumping {target_path} from {image}: not a regular file"
+        )
+    debugfs_run(
+        image,
+        [f"dump {_debugfs_quote(resolved)} {_debugfs_quote(str(local_path))}"],
+    )
+    if not local_path.exists():
+        raise errors.GRUBInstallError(
+            f"debugfs failed dumping {target_path} from {image}"
+        )
+
+
+def _debugfs_stat(image: Path, target_path: str) -> str:
+    return debugfs_run(image, [f"stat {_debugfs_quote(target_path)}"])
+
+
+def _debugfs_stat_type(image: Path, target_path: str) -> str | None:
+    """Return the inode type reported by ``stat``, or None if there is none.
+
+    debugfs echoes each request, including the target path, so the type has
+    to be read off the ``Inode:`` line rather than found anywhere in the
+    output: a path containing "Type: regular" would otherwise forge it.
+    """
+    match = _DEBUGFS_STAT_TYPE_RE.search(_debugfs_stat(image, target_path))
+    return match.group(1) if match else None
+
+
+def debugfs_exists(image: Path, target_path: str) -> bool:
+    """Check whether a path exists inside an ext image."""
+    return _debugfs_stat_type(image, target_path) is not None
+
+
+def _debugfs_resolve_symlinks(
+    image: Path, target_path: str, *, max_hops: int = 8
+) -> str | None:
+    """Follow symlinks inside an ext image down to a regular file.
+
+    Returns the resolved path, or None if it isn't a regular file, the link
+    dangles, the chain is too long, or a target that debugfs stores outside
+    the inode (a "slow" symlink, i.e. one over 59 bytes) is encountered.
+    """
+    current = target_path
+    for _ in range(max_hops):
+        stat_output = _debugfs_stat(image, current)
+        match = _DEBUGFS_STAT_TYPE_RE.search(stat_output)
+        if match is None:
+            return None
+        if match.group(1) == "regular":
+            return current
+        if match.group(1) != "symlink":
+            return None
+        dest = _DEBUGFS_FAST_LINK_RE.search(stat_output)
+        if dest is None:
+            return None
+        current = posixpath.normpath(
+            posixpath.join(posixpath.dirname(current), dest.group(1))
+        )
+    return None
+
+
+def debugfs_is_regular_file(image: Path, target_path: str) -> bool:
+    """Check whether a path inside an ext image resolves to a regular file."""
+    return _debugfs_resolve_symlinks(image, target_path) is not None
+
+
+def _debugfs_unescape(name: str) -> str:
+    r"""Undo the `\xNN` escaping debugfs applies to names it can't print."""
+    unescaped = _DEBUGFS_ESCAPE_RE.sub(lambda m: chr(int(m.group(1), 16)), name)
+    # Each escape stood for one byte, so the escaped bytes have to be
+    # reassembled before they can be decoded as (multi-byte) UTF-8.
+    return unescaped.encode("latin-1", "backslashreplace").decode("utf-8", "replace")
+
+
+def debugfs_list_dir(image: Path, target_dir: str) -> list[str]:
+    """List file names directly under target_dir inside an ext image.
+
+    :raises errors.GRUBInstallError: If target_dir doesn't exist.
+    """
+    output = debugfs_run(image, [f"ls -l {_debugfs_quote(target_dir)}"])
+    names: list[str] = []
+    for line in output.splitlines():
+        # Only accept well-formed rows; error text such as "File not found by
+        # ext2_lookup" would otherwise be parsed as a file name.
+        match = _DEBUGFS_LS_LINE_RE.match(line)
+        if match is None:
+            # Conversely, only lines that aren't entries can report an error,
+            # so a file whose name contains "File not found" is listed fine.
+            # The echoed request carries the caller's path, so skip it too.
+            if line.startswith(_DEBUGFS_ECHO_PREFIX):
+                continue
+            if any(marker in line for marker in _DEBUGFS_NOT_FOUND_MARKERS):
+                raise errors.GRUBInstallError(
+                    f"No such directory {target_dir} in {image}"
+                )
+            if _DEBUGFS_NOT_A_DIRECTORY_MARKER in line:
+                raise errors.GRUBInstallError(
+                    f"{target_dir} in {image} is not a directory"
+                )
+            continue
+        name = _debugfs_unescape(match.group("name").strip())
+        if name in (".", ".."):
+            continue
+        names.append(name)
+    return names
+
+
+def _mtools_spec(imagepath: Path, offset_bytes: int) -> str:
+    return f"{imagepath}@@{offset_bytes}"
+
+
+def _mdir_ok(spec: str, path: str) -> bool:
+    return (
+        subprocess.run(
+            ["mdir", "-i", spec, f"::{path}"],
+            check=False,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        ).returncode
+        == 0
+    )
+
+
+def _is_fat_dir(spec: str, path: str) -> bool:
+    # mdir lists the *parent* when given a file, and so succeeds either way;
+    # a trailing slash makes it reject anything that isn't a directory.
+    return _mdir_ok(spec, f"{path}/")
+
+
+def mcopy_in(
+    imagepath: Path, offset_bytes: int, local_path: Path, target_path: str
+) -> None:
+    """Copy a local file into a FAT partition embedded in imagepath.
+
+    No mount or loop device is used: mtools reads/writes the FAT filesystem
+    directly at the given byte offset within the disk image.
+    """
+    mmd_p(imagepath, offset_bytes, str(Path(target_path).parent))
+    spec = _mtools_spec(imagepath, offset_bytes)
+    # mcopy treats an existing directory at target_path as a destination
+    # *directory* and silently copies the source in under its own basename.
+    if _is_fat_dir(spec, target_path):
+        raise errors.GRUBInstallError(
+            f"mcopy cannot write {target_path}: it is a directory"
+        )
+    try:
+        run("mcopy", "-n", "-o", "-i", spec, str(local_path), f"::{target_path}")
+    except subprocess.CalledProcessError as err:
+        raise errors.GRUBInstallError(f"mcopy failed writing {target_path}") from err
+
+
+def mmd_p(imagepath: Path, offset_bytes: int, target_dir: str) -> None:
+    """Recursively create a directory inside a FAT partition, ignoring existing ones."""
+    target_dir = target_dir.strip("/")
+    if not target_dir:
+        return
+    spec = _mtools_spec(imagepath, offset_bytes)
+    parts = target_dir.split("/")
+    current = ""
+    for part in parts:
+        current += f"/{part}"
+        # mmd fails if the directory already exists; that's fine here, and
+        # mtools reports it the same way as a genuine failure, so the result
+        # is checked below instead.
+        subprocess.run(
+            ["mmd", "-i", spec, f"::{current}"],
+            check=False,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+    if not _is_fat_dir(spec, current):
+        raise errors.GRUBInstallError(
+            f"mmd failed creating {target_dir} in {imagepath}"
+        )
+
+
+def write_local_bytes(local_path: Path, data: bytes) -> None:
+    """Write bytes to a local (host, not image) path, creating parent dirs."""
+    local_path.parent.mkdir(parents=True, exist_ok=True)
+    local_path.write_bytes(data)
+
+
+def copy_local_tree(src: Path, dst: Path) -> None:
+    """Copy a local (host, not image) directory tree, merging into dst."""
+    dst.mkdir(parents=True, exist_ok=True)
+    for item in src.rglob("*"):
+        if item.is_dir():
+            continue
+        rel = item.relative_to(src)
+        target = dst / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(item, target)
+
+
+def read_ext_uuid(image: Path) -> str:
+    """Return the filesystem UUID of an ext2/3/4 image file."""
+    try:
+        res = run("blkid", "-o", "value", "-s", "UUID", str(image))
+    except subprocess.CalledProcessError as err:
+        raise errors.GRUBInstallError(f"Failed to read UUID of {image}") from err
+    return res.stdout.strip()

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -84,10 +84,14 @@ parts:
       "usr/lib/python3/dist-packages/apt*": "lib/python3.12/site-packages/"
       "usr/sbin/sfdisk": "libexec/imagecraft/sfdisk"
       "usr/bin/mcopy": "libexec/imagecraft/mcopy"
+      "usr/bin/mmd": "libexec/imagecraft/mmd"
+      "usr/bin/mdir": "libexec/imagecraft/mdir"
       "usr/bin/mtools": "libexec/imagecraft/mtools"
       "usr/bin/dd": "libexec/imagecraft/dd"
       "usr/bin/truncate": "libexec/imagecraft/truncate"
       "usr/sbin/mkfs*": "libexec/imagecraft/"
+      "usr/sbin/debugfs": "libexec/imagecraft/debugfs"
+      "usr/sbin/blkid": "libexec/imagecraft/blkid"
   # Build our own version of fuse-overlayfs due to https://github.com/containers/fuse-overlayfs/issues/429
   # The apt and Launchpad repositories as of 23/07/25 do not have a sufficiently new version to get this patch
   fuse-overlayfs:

--- a/tests/unit/pack/test_imgfs.py
+++ b/tests/unit/pack/test_imgfs.py
@@ -1,0 +1,698 @@
+# Copyright 2025 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests for low-privilege partition image manipulation.
+
+These exercise the real debugfs/mtools/dd tools rather than mocking them:
+imgfs is a thin wrapper whose whole job is getting those command lines and
+their quirky output formats right, so mocking the tools would test nothing.
+"""
+
+import os
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+from imagecraft import errors
+from imagecraft.pack import imgfs
+
+_EXT_IMAGE_SIZE = "16M"
+_FAT_IMAGE_SIZE = "8M"
+# Offset the embedded partitions so tests actually exercise the offset
+# addressing rather than accidentally passing against a zero offset.
+_PARTITION_OFFSET_SECTORS = 2048
+_PARTITION_OFFSET_BYTES = _PARTITION_OFFSET_SECTORS * imgfs.SECTOR_SIZE
+
+
+@pytest.fixture(scope="module")
+def ext_template(tmp_path_factory) -> Path:
+    """A freshly formatted ext4 filesystem image, made once for the module."""
+    image = tmp_path_factory.mktemp("templates") / "ext4.img"
+    subprocess.run(["truncate", "-s", _EXT_IMAGE_SIZE, image], check=True)
+    subprocess.run(["mkfs.ext4", "-q", "-F", image], check=True)
+    return image
+
+
+@pytest.fixture(scope="module")
+def fat_template(tmp_path_factory) -> Path:
+    """A freshly formatted FAT filesystem image, made once for the module."""
+    image = tmp_path_factory.mktemp("templates") / "fat.img"
+    subprocess.run(["truncate", "-s", _FAT_IMAGE_SIZE, image], check=True)
+    subprocess.run(["mkfs.vfat", image], check=True, stdout=subprocess.DEVNULL)
+    return image
+
+
+@pytest.fixture
+def ext_image(ext_template, tmp_path) -> Path:
+    """A writable copy of the ext4 filesystem image."""
+    image = tmp_path / "ext4.img"
+    shutil.copy2(ext_template, image)
+    return image
+
+
+@pytest.fixture
+def fat_disk(fat_template, tmp_path) -> Path:
+    """A disk image containing a FAT partition at a non-zero offset."""
+    disk = tmp_path / "disk.img"
+    subprocess.run(["truncate", "-s", "16M", disk], check=True)
+    subprocess.run(
+        [
+            "dd",
+            f"if={fat_template}",
+            f"of={disk}",
+            f"bs={imgfs.SECTOR_SIZE}",
+            f"seek={_PARTITION_OFFSET_SECTORS}",
+            "conv=notrunc",
+            "status=none",
+        ],
+        check=True,
+    )
+    return disk
+
+
+@pytest.fixture
+def ext_disk(ext_template, tmp_path) -> tuple[Path, int]:
+    """A disk image containing an ext4 partition at a non-zero offset."""
+    disk = tmp_path / "disk.img"
+    size_sectors = ext_template.stat().st_size // imgfs.SECTOR_SIZE
+    subprocess.run(["truncate", "-s", "32M", disk], check=True)
+    subprocess.run(
+        [
+            "dd",
+            f"if={ext_template}",
+            f"of={disk}",
+            f"bs={imgfs.SECTOR_SIZE}",
+            f"seek={_PARTITION_OFFSET_SECTORS}",
+            "conv=notrunc",
+            "status=none",
+        ],
+        check=True,
+    )
+    return disk, size_sectors
+
+
+def _fat_list(disk: Path, target_dir: str) -> list[str]:
+    """List a FAT directory, using mdir's bare output for stable parsing."""
+    result = subprocess.run(
+        ["mdir", "-b", "-i", f"{disk}@@{_PARTITION_OFFSET_BYTES}", target_dir],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.split()
+
+
+def _fat_read(disk: Path, target_path: str, local_path: Path) -> bytes:
+    """Read a file back out of a FAT partition."""
+    subprocess.run(
+        [
+            "mcopy",
+            "-n",
+            "-i",
+            f"{disk}@@{_PARTITION_OFFSET_BYTES}",
+            f"::{target_path}",
+            str(local_path),
+        ],
+        check=True,
+        capture_output=True,
+    )
+    return local_path.read_bytes()
+
+
+def test_debugfs_write_and_read_file_round_trip(ext_image, tmp_path):
+    source = tmp_path / "grub.cfg"
+    source.write_text("set timeout=5\n")
+    readback = tmp_path / "readback.cfg"
+
+    imgfs.debugfs_write_file(ext_image, source, "/boot/grub/grub.cfg")
+    imgfs.debugfs_read_file(ext_image, "/boot/grub/grub.cfg", readback)
+
+    assert readback.read_text() == "set timeout=5\n"
+
+
+def test_debugfs_write_file_overwrites_existing(ext_image, tmp_path):
+    """Re-running an install (e.g. spread -reuse) must not fail on an existing inode."""
+    source = tmp_path / "grub.cfg"
+    readback = tmp_path / "readback.cfg"
+
+    source.write_text("first\n")
+    imgfs.debugfs_write_file(ext_image, source, "/boot/grub.cfg")
+    source.write_text("second\n")
+    imgfs.debugfs_write_file(ext_image, source, "/boot/grub.cfg")
+
+    imgfs.debugfs_read_file(ext_image, "/boot/grub.cfg", readback)
+    assert readback.read_text() == "second\n"
+
+
+def test_debugfs_mkdir_p_creates_nested_directories(ext_image):
+    imgfs.debugfs_mkdir_p(ext_image, "/boot/grub/i386-pc")
+
+    assert imgfs.debugfs_exists(ext_image, "/boot")
+    assert imgfs.debugfs_exists(ext_image, "/boot/grub")
+    assert imgfs.debugfs_exists(ext_image, "/boot/grub/i386-pc")
+
+
+def test_debugfs_mkdir_p_is_idempotent(ext_image):
+    imgfs.debugfs_mkdir_p(ext_image, "/boot/grub")
+    imgfs.debugfs_mkdir_p(ext_image, "/boot/grub")
+
+    assert imgfs.debugfs_exists(ext_image, "/boot/grub")
+
+
+def test_debugfs_mkdir_p_ignores_empty_path(ext_image):
+    """A target of "/" has no components to create and must not invoke debugfs."""
+    imgfs.debugfs_mkdir_p(ext_image, "/")
+
+
+def test_debugfs_mkdir_p_raises_when_a_file_is_in_the_way(ext_image, tmp_path):
+    """debugfs prints "already exists" for a blocking file and still exits 0."""
+    source = tmp_path / "src"
+    source.write_text("data\n")
+    imgfs.debugfs_write_file(ext_image, source, "/boot/grub")
+
+    with pytest.raises(errors.GRUBInstallError, match="failed creating directory"):
+        imgfs.debugfs_mkdir_p(ext_image, "/boot/grub")
+
+
+def test_debugfs_mkdir_p_raises_when_a_parent_is_a_file(ext_image, tmp_path):
+    """A file part-way down the path stops every directory below it."""
+    source = tmp_path / "src"
+    source.write_text("data\n")
+    imgfs.debugfs_write_file(ext_image, source, "/boot/grub")
+
+    with pytest.raises(errors.GRUBInstallError, match="failed creating directory"):
+        imgfs.debugfs_mkdir_p(ext_image, "/boot/grub/x86_64-efi")
+
+
+def test_debugfs_exists_false_for_missing_path(ext_image):
+    assert not imgfs.debugfs_exists(ext_image, "/nonexistent")
+
+
+def _make_symlink(image, link_path: str, dest: str) -> None:
+    imgfs.debugfs_mkdir_p(image, link_path.rsplit("/", 1)[0])
+    imgfs.debugfs_run(image, [f'symlink "{link_path}" "{dest}"'])
+
+
+def test_debugfs_read_file_follows_symlinks(ext_image, tmp_path):
+    """Ubuntu ships /usr/lib/shim/shimx64.efi.signed as a symlink."""
+    source = tmp_path / "shim"
+    source.write_bytes(b"signed shim\n")
+    readback = tmp_path / "readback"
+    imgfs.debugfs_write_file(ext_image, source, "/usr/lib/shim/shimx64.efi.signed.real")
+    _make_symlink(
+        ext_image, "/usr/lib/shim/shimx64.efi.signed", "shimx64.efi.signed.real"
+    )
+
+    imgfs.debugfs_read_file(ext_image, "/usr/lib/shim/shimx64.efi.signed", readback)
+
+    assert readback.read_bytes() == b"signed shim\n"
+
+
+def test_debugfs_read_file_follows_absolute_symlink_chain(ext_image, tmp_path):
+    source = tmp_path / "shim"
+    source.write_bytes(b"signed shim\n")
+    readback = tmp_path / "readback"
+    imgfs.debugfs_write_file(
+        ext_image, source, "/usr/lib/shim/shimx64.efi.signed.latest"
+    )
+    _make_symlink(
+        ext_image,
+        "/etc/alternatives/shimx64.efi.signed",
+        "/usr/lib/shim/shimx64.efi.signed.latest",
+    )
+    _make_symlink(
+        ext_image,
+        "/usr/lib/shim/shimx64.efi.signed",
+        "/etc/alternatives/shimx64.efi.signed",
+    )
+
+    imgfs.debugfs_read_file(ext_image, "/usr/lib/shim/shimx64.efi.signed", readback)
+
+    assert readback.read_bytes() == b"signed shim\n"
+
+
+def test_debugfs_read_file_raises_on_dangling_symlink(ext_image, tmp_path):
+    """A dangling link would otherwise dump an empty file and be deployed as-is."""
+    _make_symlink(ext_image, "/usr/lib/shim/shimx64.efi.signed", "gone.efi")
+
+    with pytest.raises(errors.GRUBInstallError):
+        imgfs.debugfs_read_file(
+            ext_image, "/usr/lib/shim/shimx64.efi.signed", tmp_path / "out"
+        )
+
+
+def test_debugfs_is_regular_file_rejects_directories_and_dangling_links(ext_image):
+    imgfs.debugfs_mkdir_p(ext_image, "/boot/grub")
+    _make_symlink(ext_image, "/boot/dangling", "nowhere")
+
+    assert not imgfs.debugfs_is_regular_file(ext_image, "/boot/grub")
+    assert not imgfs.debugfs_is_regular_file(ext_image, "/boot/dangling")
+    assert not imgfs.debugfs_is_regular_file(ext_image, "/nonexistent")
+
+
+def test_debugfs_is_regular_file_rejects_symlink_loop(ext_image):
+    _make_symlink(ext_image, "/boot/a", "/boot/b")
+    _make_symlink(ext_image, "/boot/b", "/boot/a")
+
+    assert not imgfs.debugfs_is_regular_file(ext_image, "/boot/a")
+
+
+@pytest.mark.parametrize(
+    "name", ["No space left", "Could not allocate", "File not found"]
+)
+def test_debugfs_tolerates_paths_that_look_like_errors(ext_image, tmp_path, name):
+    """debugfs echoes each request, so a path must not be read as its output."""
+    source = tmp_path / "payload"
+    source.write_text("payload\n")
+
+    imgfs.debugfs_write_file(ext_image, source, f"/{name}")
+
+    assert name in imgfs.debugfs_list_dir(ext_image, "/")
+
+
+def test_debugfs_list_dir_excludes_dot_entries(ext_image, tmp_path):
+    source = tmp_path / "vmlinuz"
+    source.write_text("kernel\n")
+    imgfs.debugfs_write_file(ext_image, source, "/boot/vmlinuz-6.8.0-generic")
+
+    names = imgfs.debugfs_list_dir(ext_image, "/boot")
+
+    assert "vmlinuz-6.8.0-generic" in names
+    assert "." not in names
+    assert ".." not in names
+
+
+def test_debugfs_list_dir_on_empty_directory(ext_image):
+    imgfs.debugfs_mkdir_p(ext_image, "/empty")
+
+    assert imgfs.debugfs_list_dir(ext_image, "/empty") == []
+
+
+def test_debugfs_run_raises_when_image_cannot_be_opened(tmp_path):
+    """debugfs exits 0 on an unusable image, so failure must be caught in its output."""
+    not_an_image = tmp_path / "garbage.img"
+    not_an_image.write_text("definitely not a filesystem")
+
+    with pytest.raises(errors.GRUBInstallError, match="debugfs failed running"):
+        imgfs.debugfs_run(not_an_image, ["ls -l /"])
+
+
+def test_debugfs_run_raises_for_missing_image(tmp_path):
+    with pytest.raises(errors.GRUBInstallError, match="debugfs failed running"):
+        imgfs.debugfs_run(tmp_path / "missing.img", ["ls -l /"])
+
+
+def test_debugfs_run_does_not_raise_for_missing_path(ext_image):
+    """A missing path inside a healthy image is not a fatal error."""
+    output = imgfs.debugfs_run(ext_image, ["stat /nonexistent"])
+
+    assert "File not found" in output
+
+
+@pytest.mark.parametrize("bad_path", ["/a\nmkdir /pwned", "/a\rb", "/a\x01b", '/a"b'])
+def test_debugfs_helpers_reject_unsafe_paths(ext_image, tmp_path, bad_path):
+    """debugfs scripts are newline-delimited, so a newline injects a request."""
+    source = tmp_path / "payload"
+    source.write_text("payload\n")
+
+    with pytest.raises(errors.GRUBInstallError, match="unsafe path"):
+        imgfs.debugfs_write_file(ext_image, source, bad_path)
+
+    assert not imgfs.debugfs_exists(ext_image, "/pwned")
+
+
+def test_debugfs_write_and_read_file_with_spaces_in_path(ext_image, tmp_path):
+    """Unquoted paths with spaces are silently mis-parsed by debugfs."""
+    source = tmp_path / "src with space"
+    source.write_text("spaced\n")
+    imgfs.debugfs_write_file(ext_image, source, "/dir with space/file name.txt")
+
+    assert imgfs.debugfs_list_dir(ext_image, "/dir with space") == ["file name.txt"]
+
+    dest = tmp_path / "out"
+    imgfs.debugfs_read_file(ext_image, "/dir with space/file name.txt", dest)
+    assert dest.read_text() == "spaced\n"
+
+
+def test_debugfs_read_file_raises_for_missing_file(ext_image, tmp_path):
+    """A failed dump must not leave the caller reading stale local content."""
+    dest = tmp_path / "out"
+    dest.write_text("stale\n")
+
+    with pytest.raises(errors.GRUBInstallError, match="failed dumping"):
+        imgfs.debugfs_read_file(ext_image, "/nonexistent", dest)
+
+    assert not dest.exists()
+
+
+def test_debugfs_write_file_rejects_a_missing_source(ext_image, tmp_path):
+    """debugfs creates an empty target from a missing source and exits 0."""
+    with pytest.raises(errors.GRUBInstallError, match="not a regular file"):
+        imgfs.debugfs_write_file(ext_image, tmp_path / "missing", "/target.txt")
+
+    assert not imgfs.debugfs_exists(ext_image, "/target.txt")
+
+
+def test_debugfs_run_forces_c_locale(ext_image, mocker):
+    """debugfs failures are detected by message text, which e2fsprogs translates."""
+    spy = mocker.spy(imgfs, "run")
+
+    imgfs.debugfs_run(ext_image, ["ls -l /"])
+
+    assert spy.call_args.kwargs["env"]["LC_ALL"] == "C"
+
+
+def test_debugfs_write_file_raises_when_filesystem_is_full(tmp_path):
+    """A failed write still creates an inode of the right size, holding garbage."""
+    small_image = tmp_path / "tiny.img"
+    subprocess.run(
+        [
+            "dd",
+            "if=/dev/zero",
+            f"of={small_image}",
+            "bs=1K",
+            "count=512",
+            "status=none",
+        ],
+        check=True,
+    )
+    subprocess.run(["mkfs.ext2", "-q", "-F", str(small_image)], check=True)
+    too_big = tmp_path / "too-big.bin"
+    too_big.write_bytes(b"\xab" * 600 * 1024)
+
+    with pytest.raises(errors.GRUBInstallError, match="debugfs failed running"):
+        imgfs.debugfs_write_file(small_image, too_big, "/too-big.bin")
+
+
+def test_debugfs_write_file_raises_when_target_is_a_directory(ext_image, tmp_path):
+    """A directory at the target defeats both the rm and the write."""
+    source = tmp_path / "grub.cfg"
+    source.write_text("cfg\n")
+    imgfs.debugfs_mkdir_p(ext_image, "/boot/grub.cfg")
+
+    with pytest.raises(errors.GRUBInstallError, match="failed writing"):
+        imgfs.debugfs_write_file(ext_image, source, "/boot/grub.cfg")
+
+
+def test_debugfs_write_file_rejects_forged_type_in_path(ext_image, tmp_path):
+    """debugfs echoes the requested path, which must not fake the stat type."""
+    source = tmp_path / "grub.cfg"
+    source.write_text("cfg\n")
+    forged = "/boot/x Type: regular"
+    imgfs.debugfs_mkdir_p(ext_image, forged)
+
+    with pytest.raises(errors.GRUBInstallError, match="failed writing"):
+        imgfs.debugfs_write_file(ext_image, source, forged)
+
+
+def test_debugfs_list_dir_unescapes_names(ext_image, tmp_path):
+    """debugfs escapes bytes it can't print, one `\\xNN` escape per byte."""
+    source = tmp_path / "src"
+    source.write_text("data\n")
+    for name in ("café.txt", "back\\slash.txt"):
+        imgfs.debugfs_write_file(ext_image, source, f"/escapes/{name}")
+
+    assert sorted(imgfs.debugfs_list_dir(ext_image, "/escapes")) == [
+        "back\\slash.txt",
+        "café.txt",
+    ]
+
+
+def test_debugfs_list_dir_allows_error_text_as_a_file_name(ext_image, tmp_path):
+    """Only lines that aren't directory entries can be reporting an error."""
+    source = tmp_path / "src"
+    source.write_text("data\n")
+    imgfs.debugfs_write_file(ext_image, source, "/tricky/File not found")
+
+    assert imgfs.debugfs_list_dir(ext_image, "/tricky") == ["File not found"]
+
+
+def test_debugfs_list_dir_raises_for_missing_directory(ext_image):
+    """Error text must not be parsed as if it were a directory entry."""
+    with pytest.raises(errors.GRUBInstallError, match="No such directory"):
+        imgfs.debugfs_list_dir(ext_image, "/nonexistent")
+
+
+def test_debugfs_list_dir_raises_for_a_regular_file(ext_image, tmp_path):
+    """`ls` on a file exits 0, which would otherwise look like an empty directory."""
+    source = tmp_path / "src"
+    source.write_text("data\n")
+    imgfs.debugfs_write_file(ext_image, source, "/boot/grub")
+
+    with pytest.raises(errors.GRUBInstallError, match="is not a directory"):
+        imgfs.debugfs_list_dir(ext_image, "/boot/grub")
+
+
+def test_debugfs_write_file_rejects_a_directory_source(ext_image, tmp_path):
+    """debugfs allocates an inode full of junk from a directory and exits 0."""
+    source = tmp_path / "srcdir"
+    source.mkdir()
+
+    with pytest.raises(errors.GRUBInstallError, match="not a regular file"):
+        imgfs.debugfs_write_file(ext_image, source, "/boot/grub.cfg")
+
+    assert not imgfs.debugfs_exists(ext_image, "/boot/grub.cfg")
+
+
+def test_edit_ext_partition_persists_changes_into_disk(ext_disk, tmp_path):
+    disk, size_sectors = ext_disk
+    source = tmp_path / "grub.cfg"
+    source.write_text("set default=0\n")
+
+    with imgfs.edit_ext_partition(
+        disk, _PARTITION_OFFSET_SECTORS, size_sectors
+    ) as partition:
+        imgfs.debugfs_write_file(partition, source, "/boot/grub/grub.cfg")
+
+    # Re-extract from the disk to prove the edit was written back, rather
+    # than only existing in the temporary file.
+    readback = tmp_path / "readback.cfg"
+    with imgfs.edit_ext_partition(
+        disk, _PARTITION_OFFSET_SECTORS, size_sectors
+    ) as partition:
+        assert imgfs.debugfs_exists(partition, "/boot/grub/grub.cfg")
+        imgfs.debugfs_read_file(partition, "/boot/grub/grub.cfg", readback)
+
+    assert readback.read_text() == "set default=0\n"
+
+
+def test_edit_ext_partition_does_not_disturb_surrounding_disk(ext_disk, tmp_path):
+    """Writing the partition back must not clobber bytes outside it."""
+    disk, size_sectors = ext_disk
+    sentinel = b"\xde\xad\xbe\xef"
+    with disk.open("r+b") as handle:
+        handle.write(sentinel)
+
+    source = tmp_path / "file"
+    source.write_text("data\n")
+    with imgfs.edit_ext_partition(
+        disk, _PARTITION_OFFSET_SECTORS, size_sectors
+    ) as partition:
+        imgfs.debugfs_write_file(partition, source, "/file")
+
+    with disk.open("rb") as handle:
+        assert handle.read(len(sentinel)) == sentinel
+
+
+def test_edit_ext_partition_reads_expected_region(ext_disk):
+    """The extracted temp file is a valid filesystem, proving the offset is right."""
+    disk, size_sectors = ext_disk
+
+    with imgfs.edit_ext_partition(
+        disk, _PARTITION_OFFSET_SECTORS, size_sectors
+    ) as partition:
+        assert partition.stat().st_size == size_sectors * imgfs.SECTOR_SIZE
+        assert imgfs.debugfs_exists(partition, "/lost+found")
+
+
+def test_edit_ext_partition_raises_when_disk_is_too_small(ext_disk):
+    """dd stops at end-of-input and exits 0, so short reads must be caught."""
+    disk, size_sectors = ext_disk
+
+    with pytest.raises(errors.GRUBInstallError, match="too small"):
+        with imgfs.edit_ext_partition(
+            disk, _PARTITION_OFFSET_SECTORS, size_sectors * 100
+        ):
+            pass
+
+
+def test_edit_ext_partition_raises_when_edited_partition_shrinks(ext_disk):
+    """A truncated temp file must not be written back over the disk."""
+    disk, size_sectors = ext_disk
+
+    with pytest.raises(errors.GRUBInstallError, match="too small"):  # noqa: PT012
+        with imgfs.edit_ext_partition(
+            disk, _PARTITION_OFFSET_SECTORS, size_sectors
+        ) as partition:
+            with partition.open("r+b") as handle:
+                handle.truncate(imgfs.SECTOR_SIZE)
+
+
+def test_mcopy_in_writes_file_at_offset(fat_disk, tmp_path):
+    source = tmp_path / "grubx64.efi"
+    source.write_bytes(b"EFI binary")
+
+    imgfs.mcopy_in(fat_disk, _PARTITION_OFFSET_BYTES, source, "/EFI/BOOT/BOOTX64.EFI")
+
+    assert _fat_list(fat_disk, "::/EFI/BOOT") == ["::/EFI/BOOT/BOOTX64.EFI"]
+    assert (
+        _fat_read(fat_disk, "/EFI/BOOT/BOOTX64.EFI", tmp_path / "out") == b"EFI binary"
+    )
+
+
+def test_mcopy_in_creates_parent_directories(fat_disk, tmp_path):
+    source = tmp_path / "grub.cfg"
+    source.write_text("configfile\n")
+
+    imgfs.mcopy_in(fat_disk, _PARTITION_OFFSET_BYTES, source, "/EFI/ubuntu/grub.cfg")
+
+    assert "::/EFI/ubuntu/grub.cfg" in _fat_list(fat_disk, "::/EFI/ubuntu")
+
+
+def test_mcopy_in_overwrites_existing_file(fat_disk, tmp_path):
+    source = tmp_path / "file"
+    source.write_bytes(b"first")
+    imgfs.mcopy_in(fat_disk, _PARTITION_OFFSET_BYTES, source, "/EFI/file")
+    source.write_bytes(b"second-and-longer")
+
+    imgfs.mcopy_in(fat_disk, _PARTITION_OFFSET_BYTES, source, "/EFI/file")
+
+    assert _fat_read(fat_disk, "/EFI/file", tmp_path / "out") == b"second-and-longer"
+
+
+def test_mcopy_in_raises_on_failure(fat_disk, tmp_path):
+    with pytest.raises(errors.GRUBInstallError, match="mcopy failed writing"):
+        imgfs.mcopy_in(
+            fat_disk, _PARTITION_OFFSET_BYTES, tmp_path / "missing", "/nope.efi"
+        )
+
+
+def test_mcopy_in_raises_when_target_is_a_directory(fat_disk, tmp_path):
+    """mcopy would otherwise copy the source in *under* the directory."""
+    source = tmp_path / "grub.cfg"
+    source.write_text("configfile\n")
+    imgfs.mmd_p(fat_disk, _PARTITION_OFFSET_BYTES, "/EFI/ubuntu")
+
+    with pytest.raises(errors.GRUBInstallError, match="it is a directory"):
+        imgfs.mcopy_in(fat_disk, _PARTITION_OFFSET_BYTES, source, "/EFI/ubuntu")
+
+
+def test_mmd_p_is_idempotent(fat_disk):
+    imgfs.mmd_p(fat_disk, _PARTITION_OFFSET_BYTES, "/EFI/BOOT")
+    imgfs.mmd_p(fat_disk, _PARTITION_OFFSET_BYTES, "/EFI/BOOT")
+
+    assert "::/EFI/BOOT/" in _fat_list(fat_disk, "::/EFI")
+
+
+def test_mmd_p_raises_when_a_file_is_in_the_way(fat_disk, tmp_path):
+    """mdir accepts a file path by listing its parent, so it can't be the check."""
+    source = tmp_path / "file"
+    source.write_bytes(b"not a directory")
+    imgfs.mcopy_in(fat_disk, _PARTITION_OFFSET_BYTES, source, "/EFI/BOOT")
+
+    with pytest.raises(errors.GRUBInstallError, match="mmd failed"):
+        imgfs.mmd_p(fat_disk, _PARTITION_OFFSET_BYTES, "/EFI/BOOT")
+
+
+def test_mmd_p_ignores_empty_path(fat_disk):
+    """A target of "/" is the FAT root, which always exists."""
+    imgfs.mmd_p(fat_disk, _PARTITION_OFFSET_BYTES, "/")
+
+
+def test_mmd_p_raises_when_directory_cannot_be_created(fat_disk):
+    """mtools reports a real failure the same way as an existing directory."""
+    with pytest.raises(errors.GRUBInstallError, match="mmd failed"):
+        imgfs.mmd_p(fat_disk, _PARTITION_OFFSET_BYTES + 1, "/EFI/BOOT")
+
+
+def test_write_local_bytes_creates_parents(tmp_path):
+    target = tmp_path / "deeply" / "nested" / "core.img"
+
+    imgfs.write_local_bytes(target, b"\x01\x02\x03")
+
+    assert target.read_bytes() == b"\x01\x02\x03"
+
+
+def test_copy_local_tree_preserves_nested_structure(tmp_path):
+    src = tmp_path / "src"
+    (src / "i386-pc").mkdir(parents=True)
+    (src / "i386-pc" / "boot.img").write_bytes(b"boot")
+    (src / "top.mod").write_bytes(b"mod")
+    dst = tmp_path / "dst"
+
+    imgfs.copy_local_tree(src, dst)
+
+    assert (dst / "i386-pc" / "boot.img").read_bytes() == b"boot"
+    assert (dst / "top.mod").read_bytes() == b"mod"
+
+
+def test_copy_local_tree_merges_into_existing_destination(tmp_path):
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "new.mod").write_bytes(b"new")
+    dst = tmp_path / "dst"
+    dst.mkdir()
+    (dst / "existing.mod").write_bytes(b"existing")
+
+    imgfs.copy_local_tree(src, dst)
+
+    assert (dst / "existing.mod").read_bytes() == b"existing"
+    assert (dst / "new.mod").read_bytes() == b"new"
+
+
+def test_read_ext_uuid(ext_image):
+    uuid = imgfs.read_ext_uuid(ext_image)
+
+    assert re.fullmatch(r"[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}", uuid)
+
+
+def test_read_ext_uuid_raises_on_failure(tmp_path):
+    missing = tmp_path / "missing.img"
+
+    with pytest.raises(errors.GRUBInstallError, match="Failed to read UUID"):
+        imgfs.read_ext_uuid(missing)
+
+
+def test_debugfs_handles_non_ascii_paths_under_a_non_utf8_locale(ext_image, tmp_path):
+    """The forced C locale must not make *this* process encode its pipes as ASCII."""
+    source = tmp_path / "payload"
+    source.write_text("payload\n")
+    # The child's source stays pure ASCII: under LC_ALL=C python decodes
+    # `-c` with the ASCII filesystem encoding.
+    script = (
+        "from pathlib import Path\n"
+        "from craft_cli import EmitterMode, emit\n"
+        "emit.init(EmitterMode.QUIET, 'test', 'test')\n"
+        "from imagecraft.pack import imgfs\n"
+        f"imgfs.debugfs_write_file(Path({str(ext_image)!r}), Path({str(source)!r}),"
+        ' "/boot/boot-\\u00e9.cfg")\n'
+    )
+
+    subprocess.run(
+        [sys.executable, "-c", script],
+        check=True,
+        env={
+            **os.environ,
+            "LC_ALL": "C",
+            "LANG": "C",
+            "PYTHONUTF8": "0",
+            "PYTHONCOERCECLOCALE": "0",
+        },
+        capture_output=True,
+    )
+
+    assert "boot-\u00e9.cfg" in imgfs.debugfs_list_dir(ext_image, "/boot")


### PR DESCRIPTION
Part 4 of a stack that makes GRUB installation work without root privileges.

Adds `imagecraft.pack.imgfs`, a small wrapper for reading and writing files
inside a partition of a disk image *in place*, without mounting it, attaching a
loop device or being root. ext2/3/4 goes through `debugfs` and FAT through
`mtools`, both of which understand their filesystems well enough to operate on a
plain file at an offset.

There are no callers yet -- the GRUB code that uses this arrives later in the
stack. This lands separately so the new module can be reviewed and tested on its
own.

### A note on `debugfs`

Writing the tests turned up a trap worth flagging: **`debugfs` exits 0 even when
it could not open the filesystem at all.** Pointing it at a corrupt image prints

```
Attempt to read block from filesystem resulted in short read while trying to open ...
/tmp/x.img: Filesystem not open
```

and then returns success. So the obvious `check=True` / `CalledProcessError`
handling never fires, and every write silently does nothing. `debugfs_run`
therefore also scans the output for those markers. The tests cover this
explicitly.
