### PR TITLE
feat(grub): install BIOS GRUB without loop devices or chroot

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -47,9 +47,9 @@ jobs:
     needs: filter
     with:
       source-files: ${{ needs.filter.outputs.source-files }}
-      fast-test-platforms: '["ubuntu-24.04", "ubuntu-24.04-arm"]'
+      fast-test-platforms: '["ubuntu-24.04", "ubuntu-24.04-arm", "ubuntu-26.04-arm"]'
       fast-test-python-versions: '["3.12"]'
-      slow-test-platforms: '["ubuntu-24.04", "ubuntu-24.04-arm"]'
+      slow-test-platforms: '["ubuntu-24.04", "ubuntu-24.04-arm", "ubuntu-26.04-arm"]'
       slow-test-python-versions: '["3.12"]'
       lowest-python-version: ""
       pytest-markers: requires_root

--- a/.github/workflows/spread-test.yaml
+++ b/.github/workflows/spread-test.yaml
@@ -77,7 +77,7 @@ jobs:
           - group: boot-arm-classic
             systems: "ubuntu-24.04-arm-64"
             arch: arm64
-            tests: "tests/spread/boot/classic"
+            tests: "tests/spread/boot/classic-efi"
     steps:
       - name: Cleanup job workspace
         id: cleanup-job-workspace

--- a/Makefile
+++ b/Makefile
@@ -45,17 +45,35 @@ APT_PACKAGES :=
 ifeq ($(shell which mtools),)
 APT_PACKAGES += mtools
 endif
-ifeq ($(shell command -v grub-mkimage 2>/dev/null),)
+ifeq ($(shell which mkfs.vfat),)
+APT_PACKAGES += dosfstools
+endif
+ifeq ($(shell which grub-mkimage),)
 APT_PACKAGES += grub-common
 endif
-# debugfs and blkid live in /usr/sbin, which is not on the default non-root
-# PATH on every distribution, so search there explicitly to avoid reinstalling
-# packages that are already present.
-ifeq ($(shell PATH="$(PATH):/usr/sbin:/sbin" command -v debugfs 2>/dev/null),)
+ifeq ($(shell which mke2fs),)
 APT_PACKAGES += e2fsprogs
 endif
-ifeq ($(shell PATH="$(PATH):/usr/sbin:/sbin" command -v blkid 2>/dev/null),)
-APT_PACKAGES += util-linux
+ifeq ($(shell which sfdisk),)
+APT_PACKAGES += fdisk
+endif
+ifeq ($(shell which fuse2fs),)
+APT_PACKAGES += fuse2fs
+endif
+ifeq ($(shell which fusefile),)
+APT_PACKAGES += fusefile
+endif
+# fusefat is only packaged for amd64 in Ubuntu 24.04 (Noble) universe repositories.
+# On newer releases it may be available across architectures, but on Noble it is only
+# available on x86_64/amd64.
+ifneq ($(VERSION_CODENAME),noble)
+ifeq ($(shell which fusefat),)
+APT_PACKAGES += fusefat
+endif
+else ifeq ($(shell uname -m),x86_64)
+ifeq ($(shell which fusefat),)
+APT_PACKAGES += fusefat
+endif
 endif
 ifeq ($(wildcard /usr/include/libxml2/libxml/xpath.h),)
 APT_PACKAGES += libxml2-dev

--- a/imagecraft/errors.py
+++ b/imagecraft/errors.py
@@ -27,6 +27,10 @@ class ImageError(ImagecraftError):
     """Raised when an error occurs when dealing with the Image class."""
 
 
+class MountError(ImagecraftError):
+    """Raised when an error occurs mounting or unmounting an image or partition."""
+
+
 class GRUBInstallError(ImagecraftError):
     """Raised when an error occurs when installing grub."""
 

--- a/imagecraft/models/__init__.py
+++ b/imagecraft/models/__init__.py
@@ -23,26 +23,29 @@ from imagecraft.models.project import (
 )
 
 from imagecraft.models.volume import (
-    FileSystem,
     BaseVolume,
+    FileSystem,
+    GPTStructureItem,
     GPTVolume,
     MBRVolume,
-    Volume,
+    PartitionSchema,
     Role,
-    GPTStructureItem,
+    Volume,
 )
 from imagecraft.models.grammar import get_grammar_aware_volume_keywords
 
 __all__ = [
+    "BaseVolume",
     "FileSystem",
-    "Project",
-    "Platform",
+    "GPTStructureItem",
     "GPTVolume",
     "MBRVolume",
+    "PartitionSchema",
+    "Platform",
+    "Project",
+    "Role",
     "Volume",
     "VolumeFilesystemsModel",
-    "Role",
-    "GPTStructureItem",
-    "get_partition_name",
     "get_grammar_aware_volume_keywords",
+    "get_partition_name",
 ]

--- a/imagecraft/pack/__init__.py
+++ b/imagecraft/pack/__init__.py
@@ -33,14 +33,14 @@ from imagecraft.pack.grubutil import setup_grub
 from imagecraft.pack.image import Image
 
 __all__ = [
+    "Image",
+    "SUPPORTED_SECTOR_SIZES",
     "bytes_to_sectors",
+    "create_empty_gpt_image",
+    "create_empty_mbr_image",
     "create_zero_image",
     "format_populate_partition",
-    "inject_partition_into_image",
-    "SUPPORTED_SECTOR_SIZES",
-    "create_empty_gpt_image",
     "get_partition_sector_offset",
-    "create_empty_mbr_image",
+    "inject_partition_into_image",
     "setup_grub",
-    "Image",
 ]

--- a/imagecraft/pack/grubutil.py
+++ b/imagecraft/pack/grubutil.py
@@ -12,10 +12,38 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""GRUB utils."""
+"""GRUB utils.
 
+Installs and configures GRUB for EFI-capable (GPT/hybrid) images directly
+against a raw disk image, without attaching loop devices, chrooting, or
+spinning up a VM. This lets imagecraft build images in unprivileged
+containers that can't do any of those things.
+
+For EFI images, this module:
+
+- Builds GRUB boot images with ``grub-mkimage`` (or deploys Ubuntu's
+  pre-signed Secure Boot shim/GRUB, when available) and writes them straight
+  into the EFI System Partition.
+- Writes GRUB runtime assets and ``grub.cfg`` into the ext4 boot partition.
+
+Ext partitions are accessed through the FUSE mounts provided by
+:mod:`imagecraft.utils.mount`, which expose a partition of a raw disk image
+as a regular directory. The ESP is written in place with ``mtools``.
+
+Legacy BIOS/MBR images still take the original privileged path, installing
+GRUB with ``grub-install`` inside a chroot over a loop device. They are
+converted to direct disk image manipulation in a follow-up change, after
+which the chroot machinery is removed entirely.
+"""
+
+import contextlib
+import re
+import shutil
 import subprocess
-from pathlib import Path
+import tempfile
+import uuid
+from pathlib import Path, PurePosixPath
+from typing import NamedTuple, cast
 
 from craft_cli import emit
 from craft_parts.filesystem_mounts import FilesystemMount
@@ -27,10 +55,11 @@ from imagecraft.models.volume import (
     PartitionSchema,
     StructureList,
 )
-from imagecraft.pack import mbrutil
+from imagecraft.pack import gptutil, mbrutil
 from imagecraft.pack.chroot import Chroot, Mount
 from imagecraft.pack.image import Image
 from imagecraft.subprocesses import run
+from imagecraft.utils.mount import mount_partition
 
 _ARCH_TO_GRUB_EFI_TARGET: dict[str, str] = {
     DebianArchitecture.AMD64: "x86_64-efi",
@@ -40,6 +69,653 @@ _ARCH_TO_GRUB_EFI_TARGET: dict[str, str] = {
 
 _GRUB_BIOS_TARGET = "i386-pc"
 _GRUB_BIOS_ARCHS = {DebianArchitecture.AMD64, DebianArchitecture.I386}
+
+# Maps grub EFI target -> (grub binary filename, UEFI fallback filename).
+_EFI_TARGET_TO_FILENAMES: dict[str, tuple[str, str]] = {
+    "x86_64-efi": ("grubx64.efi", "BOOTX64.EFI"),
+    "arm64-efi": ("grubaa64.efi", "BOOTAA64.EFI"),
+    "arm-efi": ("grubarm.efi", "BOOTARM.EFI"),
+}
+
+# Maps grub EFI target -> shim filename, for Secure Boot deployments.
+_EFI_TARGET_TO_SHIM_FILENAME: dict[str, str] = {
+    "x86_64-efi": "shimx64.efi",
+    "arm64-efi": "shimaa64.efi",
+    "arm-efi": "shimarm.efi",
+}
+
+# Core modules embedded into the standalone GRUB EFI image so it can find
+# and load the rest of GRUB (partition tables, filesystems, search-by-UUID).
+_EFI_CORE_MODULES = [
+    "part_gpt",
+    "part_msdos",
+    "fat",
+    "ext2",
+    "normal",
+    "search",
+    "search_fs_uuid",
+    "search_label",
+    "search_fs_file",
+    "boot",
+    "linux",
+    "configfile",
+    "echo",
+    "loadenv",
+    "test",
+    "efi_gop",
+    "gfxterm",
+    "font",
+    # Ubuntu's 10_linux always emits "insmod gzio"; compressed kernels and
+    # initrds are unreadable without it.
+    "gzio",
+]
+
+# Signed shim/grub filename suffixes, in preference order.
+_SIGNED_SHIM_SUFFIXES = (".efi.signed.latest", ".efi.signed", ".efi.dualsigned")
+
+_DEFAULT_GRUB_PATH = "/etc/default/grub"
+
+# Split a filename into digit and non-digit runs, so versions compare
+# numerically rather than lexicographically.
+_VERSION_PART_RE = re.compile(r"(\d+)")
+
+# Match the shell assignments in /etc/default/grub that carry kernel
+# arguments, with an optionally quoted value. Commented-out lines are skipped.
+_GRUB_CMDLINE_RE = re.compile(
+    r"^[ \t]*(?:export[ \t]+)?"
+    r"(?P<key>GRUB_CMDLINE_LINUX(?:_DEFAULT)?|GRUB_TIMEOUT)="
+    r"""(?:"(?P<dq>[^"]*)"|'(?P<sq>[^']*)'|(?P<bare>[^\s#]*))""",
+    re.MULTILINE,
+)
+# A reference to one of the keys above, which shell would have expanded when
+# it sourced the file: `GRUB_CMDLINE_LINUX_DEFAULT="$GRUB_CMDLINE_LINUX foo"`.
+_GRUB_VAR_REF_RE = re.compile(r"\$\{?(GRUB_CMDLINE_LINUX(?:_DEFAULT)?|GRUB_TIMEOUT)\}?")
+# A shell line continuation, which joins the next line onto this one.
+_LINE_CONTINUATION_RE = re.compile(r"\\\n")
+
+_DEFAULT_GRUB_TIMEOUT = 5
+
+
+class GrubDefaults(NamedTuple):
+    """The subset of ``/etc/default/grub`` that the generated config honours."""
+
+    cmdline: str = ""
+    timeout: int = _DEFAULT_GRUB_TIMEOUT
+
+
+_STOCK_GRUB_DEFAULTS = GrubDefaults()
+
+
+def setup_grub(
+    image: Image,
+    workdir: Path,
+    arch: str,
+    filesystem_mount: FilesystemMount,
+) -> None:
+    """Set up GRUB directly on the disk image.
+
+    :param image: Image object handling the actual disk file
+    :param workdir: working directory
+    :param arch: architecture the image is built for
+    :param filesystem_mount: order in which partitions should be mounted
+    """
+    emit.progress("Setting up GRUB in the image")
+
+    if not image.has_data_partition:
+        emit.progress(
+            "Skipping GRUB installation because no data partition was found",
+            permanent=True,
+        )
+        return
+
+    schema = image.volume.volume_schema
+    if schema == PartitionSchema.MBR:
+        if arch not in _GRUB_BIOS_ARCHS:
+            emit.progress("Cannot install GRUB on this architecture", permanent=True)
+            return
+        # Legacy BIOS/MBR images are still installed through a loop device
+        # and a chroot. They move over to direct image manipulation in a
+        # follow-up change, once the EFI path has settled.
+        _setup_grub_bios_chroot(image, workdir, _GRUB_BIOS_TARGET, filesystem_mount)
+        return
+
+    # GPT or hybrid — EFI boot
+    if not image.has_boot_partition:
+        emit.progress(
+            "Skipping GRUB installation because no boot partition was found",
+            permanent=True,
+        )
+        return
+    if arch not in _ARCH_TO_GRUB_EFI_TARGET:
+        emit.progress("Cannot install GRUB on this architecture", permanent=True)
+        return
+    grub_target = _ARCH_TO_GRUB_EFI_TARGET[arch]
+
+    try:
+        _setup_grub_efi(image, grub_target, filesystem_mount)
+    except errors.ImageError as err:
+        emit.progress(f"Cannot install GRUB on this rootfs: {err}", permanent=True)
+
+
+def _mount_entry(filesystem_mount: FilesystemMount, mount: str) -> str | None:
+    for entry in filesystem_mount:
+        if entry.mount.rstrip("/") == mount.rstrip("/") or (
+            mount == "/" and entry.mount in ("", "/")
+        ):
+            return entry.device
+    return None
+
+
+def _partition_geometry(
+    disk_path: Path,
+    structure: StructureList,
+    filesystem_mount: FilesystemMount,
+    mount: str,
+) -> tuple[str, int, int]:
+    """Return (partition_name, offset_sectors, size_sectors) for the given mountpoint."""
+    device = _mount_entry(filesystem_mount, mount)
+    if device is None:
+        raise errors.ImageError(message=f"No partition mounted at {mount!r}")
+    partition_name = _partition_name_from_device(device)
+    partnum = _part_num(partition_name, structure)
+    if partnum is None:
+        raise errors.ImageError(
+            message=f"Cannot find a partition named {partition_name}"
+        )
+    if isinstance(structure[0], MBRStructureItem):
+        # MBR partitions aren't named in sfdisk's output; look them up by
+        # their 1-based position instead.
+        offset = gptutil.get_partition_sector_offset_by_number(disk_path, partnum)
+        size = gptutil.get_partition_size_sectors_by_number(disk_path, partnum)
+    else:
+        offset = gptutil.get_partition_sector_offset(disk_path, partition_name)
+        size = gptutil.get_partition_size_sectors(disk_path, partition_name)
+    return partition_name, offset, size
+
+
+def _has_separate_boot(filesystem_mount: FilesystemMount) -> bool:
+    return _mount_entry(filesystem_mount, "/boot") is not None
+
+
+def _setup_grub_efi(
+    image: Image, grub_target: str, filesystem_mount: FilesystemMount
+) -> None:
+    """Install GRUB for an EFI-capable (GPT/hybrid) image.
+
+    The root (and optional boot) ext partitions are exposed through FUSE
+    mounts, and GRUB's EFI binary is built with the image's own
+    ``grub-mkimage`` inside a chroot of the mounted rootfs — guaranteeing the
+    builder matches the modules it consumes. ESP files are written in place
+    with mtools, and all grub.cfg content is generated here because
+    ``grub-mkconfig`` needs a real block device that FUSE cannot provide.
+    """
+    structure = image.volume.structure
+    disk_path = image.disk_path
+    sector = gptutil.SECTOR_SIZE_512
+
+    _, root_offset, root_size = _partition_geometry(
+        disk_path, structure, filesystem_mount, "/"
+    )
+    has_separate_boot = _has_separate_boot(filesystem_mount)
+    if has_separate_boot:
+        _, boot_offset, boot_size = _partition_geometry(
+            disk_path, structure, filesystem_mount, "/boot"
+        )
+    else:
+        boot_offset, boot_size = root_offset, root_size
+    # When /boot lives on its own partition, that partition's root directory
+    # *is* /boot, so paths written to it must not be prefixed with "/boot".
+    boot_prefix = "" if has_separate_boot else "/boot"
+    _, esp_offset_sectors, esp_size_sectors = _partition_geometry(
+        disk_path, structure, filesystem_mount, "/boot/efi"
+    )
+    esp_offset_bytes = esp_offset_sectors * sector
+
+    grub_fname, fallback_fname = _EFI_TARGET_TO_FILENAMES[grub_target]
+    shim_fname = _EFI_TARGET_TO_SHIM_FILENAME.get(grub_target)
+
+    with tempfile.TemporaryDirectory(prefix="imagecraft-grub-") as tmp_str:
+        tmp_dir = Path(tmp_str)
+
+        # Each partition gets its own FUSE mount. They deliberately stay
+        # flat: stacking a FAT-over-fusefile mount inside the fuse2fs
+        # mountpoint breaks path traversal, so /boot and /boot/efi are
+        # separate handles rather than a nested tree.
+        with contextlib.ExitStack() as stack:
+            rootfs = stack.enter_context(
+                mount_partition(
+                    disk_path,
+                    "ext4",
+                    offset=root_offset * sector,
+                    size=root_size * sector,
+                )
+            )
+            if has_separate_boot:
+                bootfs = stack.enter_context(
+                    mount_partition(
+                        disk_path,
+                        "ext4",
+                        offset=boot_offset * sector,
+                        size=boot_size * sector,
+                    )
+                )
+            else:
+                bootfs = rootfs
+            signed = _dump_signed_efi_binaries(rootfs, grub_target, tmp_dir)
+
+            if signed:
+                emit.progress(f"Deploying signed GRUB ({grub_target})")
+                local_binary = tmp_dir / grub_fname
+                shutil.copy2(signed["grub"], local_binary)
+            else:
+                emit.progress(f"Building unsigned GRUB image ({grub_target})")
+                local_binary = _build_grub_image(rootfs, grub_target, grub_fname)
+
+            _deploy_efi_binary(
+                disk_path,
+                esp_offset_bytes,
+                tmp_dir,
+                local_binary,
+                grub_fname,
+                fallback_fname,
+                signed_shim=signed["shim"] if signed else None,
+                shim_fname=shim_fname,
+            )
+            if not signed:
+                # The binary was built inside the image's /tmp; remove it so
+                # it doesn't ship in the final image.
+                local_binary.unlink(missing_ok=True)
+
+            # GRUB has to find its config and the kernels on whichever
+            # partition holds /boot, which isn't necessarily the root one.
+            boot_uuid = _read_ext_uuid(disk_path, boot_offset * sector)
+            root_uuid = _read_ext_uuid(disk_path, root_offset * sector)
+            kernels = _find_kernels(bootfs, boot_prefix)
+            emit.progress("Generating grub configuration file")
+            emit.progress("Adding boot menu entry for UEFI Firmware Settings")
+            cfg = _generate_grub_cfg(
+                kernels,
+                root_uuid,
+                boot_uuid,
+                boot_prefix,
+                _read_grub_defaults(rootfs),
+                include_fw_setup=True,
+            )
+            _write_ext_file(bootfs, cfg.encode(), f"{boot_prefix}/grub/grub.cfg")
+
+            stub_cfg = _efi_stub_grub_cfg(boot_uuid, boot_prefix)
+            _write_esp_file(
+                disk_path,
+                esp_offset_bytes,
+                tmp_dir,
+                stub_cfg.encode(),
+                "/EFI/ubuntu/grub.cfg",
+            )
+            _write_esp_file(
+                disk_path,
+                esp_offset_bytes,
+                tmp_dir,
+                stub_cfg.encode(),
+                "/EFI/BOOT/grub.cfg",
+            )
+
+    emit.progress("GRUB installation complete")
+
+
+def _build_grub_image(rootfs: Path, grub_target: str, grub_fname: str) -> Path:
+    """Build a standalone GRUB EFI binary using the image's own grub-mkimage.
+
+    Running ``grub-mkimage`` inside a chroot of the mounted rootfs guarantees
+    the builder matches the module files it consumes — no host/image version
+    skew. The binary is built into ``/tmp`` inside the tree; the returned path
+    is on the host side of the same mount.
+
+    :raises errors.ImageError: If the image has no GRUB modules installed.
+    :raises errors.GRUBInstallError: If the image's grub-mkimage fails.
+    """
+    modules_dir = rootfs / "usr/lib/grub" / grub_target
+    if not modules_dir.is_dir():
+        # A rootfs with no GRUB package installed simply gets no bootloader;
+        # setup_grub turns this into a skip rather than failing the pack.
+        raise errors.ImageError(
+            message=f"GRUB modules for {grub_target} are not installed in the image"
+        )
+
+    # A fixed location inside the image's own /tmp — not a host temp file.
+    output_rel = Path("/tmp") / f"imagecraft-{grub_fname}"  # noqa: S108
+    output_host = rootfs / output_rel.relative_to("/")
+    output_host.parent.mkdir(parents=True, exist_ok=True)
+
+    # Run the image's own grub-mkimage via chroot(1) as a plain subprocess:
+    # a clean single-threaded process, unaffected by any threads in this one.
+    try:
+        run(
+            "chroot",
+            str(rootfs),
+            "grub-mkimage",
+            "-d",
+            f"/usr/lib/grub/{grub_target}",
+            "-o",
+            str(output_rel),
+            "-O",
+            grub_target,
+            "-p",
+            "/EFI/ubuntu",
+            *_EFI_CORE_MODULES,
+            stderr=subprocess.STDOUT,
+        )
+    except FileNotFoundError as err:
+        raise errors.GRUBInstallError(
+            "Cannot build a GRUB image: chroot is not available"
+        ) from err
+    except subprocess.CalledProcessError as err:
+        raise errors.GRUBInstallError(
+            f"Cannot build a GRUB image: grub-mkimage failed for {grub_target}: {err}"
+        ) from err
+
+    return output_host
+
+
+def _fat_mkdir_p(spec: str, target_dir: str) -> None:
+    """Recursively create a directory inside a FAT filesystem, ignoring existing."""
+    target_dir = target_dir.strip("/")
+    if not target_dir:
+        return
+    current = ""
+    for part in target_dir.split("/"):
+        current += f"/{part}"
+        # mmd fails if the directory already exists; that's fine here, and
+        # mtools reports it the same way as a genuine failure, so the result
+        # is verified below instead.
+        subprocess.run(
+            ["mmd", "-i", spec, f"::{current}"],
+            check=False,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+
+
+def _write_esp_file(
+    disk_path: Path,
+    esp_offset_bytes: int,
+    tmp_dir: Path,
+    data: bytes,
+    target_path: str,
+) -> None:
+    """Write raw bytes into the ESP at target_path using mtools.
+
+    The FAT partition is addressed in place via mtools' ``image@@offset``
+    syntax — no mount required.
+    """
+    spec = f"{disk_path}@@{esp_offset_bytes}"
+    local = tmp_dir / "esp-payload"
+    local.write_bytes(data)
+    _fat_mkdir_p(spec, str(PurePosixPath(target_path).parent))
+    try:
+        run("mcopy", "-n", "-o", "-i", spec, str(local), f"::{target_path}")
+    except (subprocess.CalledProcessError, FileNotFoundError) as err:
+        raise errors.GRUBInstallError(
+            f"Failed writing {target_path} to the EFI System Partition"
+        ) from err
+
+
+def _write_ext_file(rootfs: Path, data: bytes, target_path: str) -> None:
+    """Write raw bytes into a mounted ext partition at target_path."""
+    dest = rootfs / target_path.lstrip("/")
+    try:
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_bytes(data)
+    except OSError as err:
+        raise errors.GRUBInstallError(
+            f"Failed writing {target_path} to the boot partition"
+        ) from err
+
+
+_EXT_UUID_BYTES = 16  # Length of an ext filesystem UUID (s_uuid field).
+
+
+def _read_ext_uuid(disk_path: Path, partition_offset_bytes: int) -> str:
+    """Return the filesystem UUID of the ext partition at the given offset.
+
+    The ext2/3/4 superblock starts 1024 bytes into the filesystem, and its
+    ``s_uuid`` field sits 104 bytes into the superblock.
+    """
+    superblock_offset = partition_offset_bytes + 1024 + 104
+    with disk_path.open("rb") as disk_file:
+        disk_file.seek(superblock_offset)
+        raw = disk_file.read(_EXT_UUID_BYTES)
+    if len(raw) != _EXT_UUID_BYTES:
+        raise errors.GRUBInstallError(
+            f"Failed to read the filesystem UUID at offset {partition_offset_bytes} "
+            f"of {disk_path}"
+        )
+    return str(uuid.UUID(bytes=raw))
+
+
+def _deploy_efi_binary(
+    disk_path: Path,
+    esp_offset_bytes: int,
+    tmp_dir: Path,
+    local_binary: Path,
+    grub_fname: str,
+    fallback_fname: str,
+    *,
+    signed_shim: Path | None,
+    shim_fname: str | None,
+) -> None:
+    """Deploy the GRUB EFI binary to both the vendor and fallback ESP paths."""
+    _write_esp_file(
+        disk_path,
+        esp_offset_bytes,
+        tmp_dir,
+        local_binary.read_bytes(),
+        f"/EFI/ubuntu/{grub_fname}",
+    )
+    if signed_shim and shim_fname:
+        # Shim is the entry point that chainloads grubx64.efi from the
+        # same directory it resides in.
+        _write_esp_file(
+            disk_path,
+            esp_offset_bytes,
+            tmp_dir,
+            signed_shim.read_bytes(),
+            f"/EFI/ubuntu/{shim_fname}",
+        )
+        _write_esp_file(
+            disk_path,
+            esp_offset_bytes,
+            tmp_dir,
+            signed_shim.read_bytes(),
+            f"/EFI/BOOT/{fallback_fname}",
+        )
+        _write_esp_file(
+            disk_path,
+            esp_offset_bytes,
+            tmp_dir,
+            local_binary.read_bytes(),
+            f"/EFI/BOOT/{grub_fname}",
+        )
+    else:
+        _write_esp_file(
+            disk_path,
+            esp_offset_bytes,
+            tmp_dir,
+            local_binary.read_bytes(),
+            f"/EFI/BOOT/{fallback_fname}",
+        )
+
+
+def _dump_signed_efi_binaries(
+    rootfs: Path, grub_target: str, dest_dir: Path
+) -> dict[str, Path] | None:
+    """Dump Ubuntu's pre-signed shim+GRUB from rootfs, if both are present.
+
+    Returns a dict with "shim" and "grub" local paths, or None if either
+    piece isn't installed (in which case an unsigned image should be built
+    with grub-mkimage instead).
+    """
+    grub_fname, _ = _EFI_TARGET_TO_FILENAMES[grub_target]
+    shim_fname = _EFI_TARGET_TO_SHIM_FILENAME.get(grub_target)
+    if shim_fname is None:
+        return None
+
+    shim_base = shim_fname.removesuffix(".efi")
+    shim_src = None
+    for suffix in _SIGNED_SHIM_SUFFIXES:
+        # Ubuntu ships some of these as symlinks managed by update-alternatives,
+        # so a candidate that doesn't resolve to a real file has to be skipped.
+        candidate = rootfs / f"usr/lib/shim/{shim_base}{suffix}".lstrip("/")
+        if candidate.is_file():
+            shim_src = candidate
+            break
+    grub_src = rootfs / f"usr/lib/grub/{grub_target}-signed/{grub_fname}.signed"
+    if shim_src is None or not grub_src.is_file():
+        return None
+
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    shim_dest = dest_dir / shim_fname
+    grub_dest = dest_dir / f"{grub_fname}.signed"
+    shutil.copy2(shim_src, shim_dest)
+    shutil.copy2(grub_src, grub_dest)
+    return {"shim": shim_dest, "grub": grub_dest}
+
+
+def _version_sort_key(name: str) -> tuple[object, ...]:
+    """Order kernel filenames by version, comparing digit runs numerically.
+
+    A plain string sort puts ``vmlinuz-6.8.0-100`` before ``vmlinuz-6.8.0-9``,
+    which would make the newest kernel look like the oldest.
+    """
+    return tuple(
+        (1, int(part)) if part.isdigit() else (0, part)
+        for part in _VERSION_PART_RE.split(name)
+        if part
+    )
+
+
+def _find_kernels(bootfs: Path, boot_prefix: str) -> list[tuple[str, str]]:
+    """Return (vmlinuz, initrd) filename pairs found under boot_prefix on bootfs.
+
+    Newest kernel first, so the generated ``default=0`` entry boots it — the
+    same ordering ``update-grub`` produces.
+    """
+    search_dir = bootfs / boot_prefix.lstrip("/")
+    if not search_dir.is_dir():
+        return []
+    names = [entry.name for entry in search_dir.iterdir()]
+    vmlinuzes = sorted(
+        (n for n in names if n.startswith("vmlinuz-")),
+        key=_version_sort_key,
+        reverse=True,
+    )
+    kernels = []
+    for vmlinuz in vmlinuzes:
+        version = vmlinuz.removeprefix("vmlinuz-")
+        initrd = f"initrd.img-{version}"
+        kernels.append((vmlinuz, initrd if initrd in names else ""))
+    return kernels
+
+
+def _read_grub_defaults(rootfs: Path) -> GrubDefaults:
+    """Read the settings configured in ``/etc/default/grub``.
+
+    ``update-grub`` is not run any more, so the settings that would have fed
+    the generated menu entries have to be honoured here instead. Mirrors
+    stock ``/etc/grub.d/10_linux``, which appends ``GRUB_CMDLINE_LINUX``
+    followed by ``GRUB_CMDLINE_LINUX_DEFAULT`` to the default entry.
+    """
+    defaults_file = rootfs / _DEFAULT_GRUB_PATH.lstrip("/")
+    if not defaults_file.is_file():
+        return GrubDefaults()
+    content = defaults_file.read_text(encoding="utf-8", errors="replace")
+
+    values: dict[str, str] = {}
+    # Shell joins continuation lines before assigning, and collapsing the
+    # result keeps a value that spanned lines from breaking the generated
+    # config, whose `linux` directive has to stay on one line.
+    for match in _GRUB_CMDLINE_RE.finditer(_LINE_CONTINUATION_RE.sub(" ", content)):
+        raw = match.group("dq") or match.group("sq") or match.group("bare") or ""
+        if match.group("sq") is None:
+            # Single quotes suppress expansion; anything else expands, and an
+            # undefined variable expands to nothing, as it would in shell.
+            raw = _GRUB_VAR_REF_RE.sub(lambda m: values.get(m.group(1), ""), raw)
+        values[match.group("key")] = " ".join(raw.split())
+
+    parts = [
+        values.get("GRUB_CMDLINE_LINUX", ""),
+        values.get("GRUB_CMDLINE_LINUX_DEFAULT", ""),
+    ]
+    timeout = _DEFAULT_GRUB_TIMEOUT
+    with contextlib.suppress(ValueError):
+        timeout = int(values["GRUB_TIMEOUT"]) if "GRUB_TIMEOUT" in values else timeout
+    return GrubDefaults(
+        cmdline=" ".join(part for part in parts if part), timeout=timeout
+    )
+
+
+def _generate_grub_cfg(
+    kernels: list[tuple[str, str]],
+    root_uuid: str,
+    boot_uuid: str,
+    boot_prefix: str,
+    defaults: GrubDefaults = _STOCK_GRUB_DEFAULTS,
+    *,
+    include_fw_setup: bool = False,
+) -> str:
+    """Hand-generate a minimal grub.cfg with a menu entry per kernel found.
+
+    :param root_uuid: UUID of the partition to boot as ``/``.
+    :param boot_uuid: UUID of the partition holding ``/boot``, which GRUB
+        needs to select before it can load a kernel from it. Equal to
+        ``root_uuid`` unless ``/boot`` has a partition of its own.
+    :param boot_prefix: Path prefix of ``/boot`` on the boot partition.
+    :param defaults: Settings read from ``/etc/default/grub``.
+    :param include_fw_setup: Add a "UEFI Firmware Settings" menu entry that
+        reboots into the firmware setup UI via GRUB's ``fwsetup`` command
+        (mirrors what stock Ubuntu's ``/etc/grub.d/30_uefi-firmware`` script
+        generates). Only meaningful/available on EFI-booted systems.
+    """
+    lines = [
+        "set default=0",
+        f"set timeout={defaults.timeout}",
+        "insmod part_gpt",
+        "insmod part_msdos",
+        "insmod ext2",
+        f"search --no-floppy --fs-uuid --set=root {boot_uuid}",
+        "",
+    ]
+    extra = f" {defaults.cmdline}" if defaults.cmdline else ""
+    for vmlinuz, initrd in kernels:
+        lines.append(f'menuentry "{vmlinuz}" {{')
+        lines.append(f"\tlinux {boot_prefix}/{vmlinuz} root=UUID={root_uuid} ro{extra}")
+        if initrd:
+            lines.append(f"\tinitrd {boot_prefix}/{initrd}")
+        lines.append("}")
+    if include_fw_setup:
+        lines += [
+            'if [ "${grub_platform}" = "efi" ]; then',
+            "\tmenuentry 'UEFI Firmware Settings' {",
+            "\t\tfwsetup",
+            "\t}",
+            "fi",
+        ]
+    return "\n".join(lines) + "\n"
+
+
+def _efi_stub_grub_cfg(boot_uuid: str, boot_prefix: str) -> str:
+    """Build the tiny loader config placed on the ESP that chains to the real config."""
+    return (
+        "\n".join(
+            [
+                "insmod part_gpt",
+                "insmod ext2",
+                f"search.fs_uuid {boot_uuid} root",
+                f"set prefix=($root)'{boot_prefix}/grub'",
+                "configfile $prefix/grub.cfg",
+            ]
+        )
+        + "\n"
+    )
 
 
 def _grub_install(grub_target: str, loop_dev: str) -> None:
@@ -117,44 +793,18 @@ def _grub_install(grub_target: str, loop_dev: str) -> None:
         raise errors.GRUBInstallError("Missing tool to install grub") from err
 
 
-def setup_grub(
-    image: Image, workdir: Path, arch: str, filesystem_mount: FilesystemMount
+def _setup_grub_bios_chroot(
+    image: Image,
+    workdir: Path,
+    grub_target: str,
+    filesystem_mount: FilesystemMount,
 ) -> None:
-    """Setups GRUB in the image.
+    """Install GRUB for a legacy BIOS/MBR image via a loop device and chroot.
 
-    :param image: Image object handling the actual disk file
-    :param workdir: working directory
-    :param arch: architecture the image is built for
-    :param filesystem_mount: order in which partitions should be mounted
-
+    This is the original, privileged installation path. It is retained only
+    for BIOS/MBR images until they are converted to direct disk image
+    manipulation, at which point this and its helpers are removed.
     """
-    emit.progress("Setting up GRUB in the image")
-
-    if not image.has_data_partition:
-        emit.progress(
-            "Skipping GRUB installation because no data partition was found",
-            permanent=True,
-        )
-        return
-
-    schema = image.volume.volume_schema
-    if schema == PartitionSchema.MBR:
-        if arch not in _GRUB_BIOS_ARCHS:
-            emit.progress("Cannot install GRUB on this architecture", permanent=True)
-            return
-        grub_target = _GRUB_BIOS_TARGET
-    else:  # GPT or hybrid — EFI boot
-        if not image.has_boot_partition:
-            emit.progress(
-                "Skipping GRUB installation because no boot partition was found",
-                permanent=True,
-            )
-            return
-        if arch not in _ARCH_TO_GRUB_EFI_TARGET:
-            emit.progress("Cannot install GRUB on this architecture", permanent=True)
-            return
-        grub_target = _ARCH_TO_GRUB_EFI_TARGET[arch]
-
     mount_dir = workdir / "mount"
     mount_dir.mkdir(exist_ok=True)
 
@@ -233,7 +883,7 @@ def _part_num(name: str, structure: StructureList) -> int | None:
         if structure_item.name == name:
             explicit = getattr(structure_item, "partition_number", None)
             if explicit is not None:
-                return explicit
+                return cast(int, explicit)
             pos = i + 1  # 1-based
             if needs_extended and pos > mbrutil.PRIMARY_SLOTS_WITH_EXTENDED:
                 return pos + 1  # skip slot 4 (extended container)

--- a/imagecraft/pack/mbrutil.py
+++ b/imagecraft/pack/mbrutil.py
@@ -15,13 +15,14 @@
 """Utility functions for MBR-formatted disks."""
 
 import subprocess
+from collections.abc import Sequence
 from pathlib import Path
 from typing import Any
 
 from craft_cli import emit
 
 from imagecraft.errors import MBRPartitionError
-from imagecraft.models.volume import MBRVolume, Role
+from imagecraft.models.volume import MBRStructureItem, MBRVolume, Role
 from imagecraft.pack import diskutil
 
 SECTOR_SIZE_512 = 512
@@ -62,6 +63,48 @@ def _create_sfdisk_lines(
         stdin_lines.append(", ".join(fields))
     stdin_lines.append("write")
     return stdin_lines
+
+
+def _select_bootable_item(
+    structure: Sequence[MBRStructureItem],
+    logical_items: Sequence[MBRStructureItem],
+) -> MBRStructureItem | None:
+    """Pick the single partition that gets the MBR active flag.
+
+    The BIOS/SeaBIOS boot process hands control to exactly one partition, the
+    one carrying the "active"/bootable flag in the MBR. That is normally the
+    system-boot partition, but layouts with no separate boot partition
+    (grub-pc's core.img lives in the MBR gap, and grub.cfg and the kernel live
+    directly on the root filesystem) have no system-boot role at all, so fall
+    back to the system-data partition.
+
+    :param structure: All structure items, in partition order.
+    :param logical_items: The items that will become logical partitions.
+    :returns: The item to mark bootable, or None if there is no candidate.
+    :raises MBRPartitionError: If the only candidate is a logical partition.
+    """
+    for role in (Role.SYSTEM_BOOT.value, Role.SYSTEM_DATA.value):
+        candidates = [item for item in structure if item.role == role]
+        if not candidates:
+            continue
+        # Only the first is flagged: an MBR with several active partitions is
+        # invalid, and firmware behaviour in that case is unpredictable.
+        bootable_item = candidates[0]
+        if any(item is bootable_item for item in logical_items):
+            raise MBRPartitionError(
+                f"The {role} partition '{bootable_item.name}' must be within "
+                f"the first {PRIMARY_SLOTS_WITH_EXTENDED} partitions to be "
+                "marked bootable when an extended partition is required.",
+                details=(
+                    "The BIOS only looks for the active flag in the four "
+                    "primary partition entries, not inside the extended "
+                    "partition chain."
+                ),
+                resolution=f"Move '{bootable_item.name}' to one of the first "
+                f"{PRIMARY_SLOTS_WITH_EXTENDED} partition slots.",
+            )
+        return bootable_item
+    return None
 
 
 def _create_mbr_layout(
@@ -107,6 +150,8 @@ def _create_mbr_layout(
         primary_items = structure
         logical_items = []
 
+    bootable_item = _select_bootable_item(structure, logical_items)
+
     partitions: list[dict[str, str | None]] = []
     start = _MBR_RESERVED_SECTORS
     for structure_item in primary_items:
@@ -116,7 +161,7 @@ def _create_mbr_layout(
             "size": str(sectors),
             "type": structure_item.structure_type.value,
         }
-        if structure_item.role == Role.SYSTEM_BOOT.value:
+        if structure_item is bootable_item:
             partition["bootable"] = None
         partitions.append(partition)
         start += sectors
@@ -135,8 +180,6 @@ def _create_mbr_layout(
                 "size": str(logical_sectors),
                 "type": logical.structure_type.value,
             }
-            if logical.role == Role.SYSTEM_BOOT.value:
-                logical_entry["bootable"] = None
             partitions.append(logical_entry)
             logical_start += logical_sectors + _EBR_OVERHEAD_SECTORS
 

--- a/imagecraft/services/image.py
+++ b/imagecraft/services/image.py
@@ -39,6 +39,9 @@ from imagecraft.subprocesses import run
 
 _LOSETUP_BIN = "losetup"
 
+# Maximum time to wait for kernel-created loop partition nodes to appear.
+_PARTSCAN_TIMEOUT_SECONDS = 10.0
+
 
 class ImageService(AppService):
     """Service for accessing the final image file."""
@@ -119,6 +122,9 @@ class ImageService(AppService):
         This method is idempotent. It will reuse existing loop devices if they
         are already attached to the correct files, and clean up stale devices
         pointing to deleted inodes.
+
+        Upon return, the partition device nodes for every attached image are
+        guaranteed to exist on disk.
         """
         if self._loop_devices:
             return self._loop_devices
@@ -168,12 +174,45 @@ class ImageService(AppService):
                     ) from err
 
             self._loop_devices[name] = attached_device
+            self._wait_for_partition_nodes(attached_device, name)
 
         if not self._atexit_registered:
             atexit.register(self.detach_images)
             self._atexit_registered = True
 
         return self._loop_devices
+
+    def _wait_for_partition_nodes(self, device: str, volume_name: str) -> None:
+        """Wait for a loop device's partition nodes to be created by the kernel.
+
+        After losetup sets up a device with ``--partscan``, the partition device
+        nodes (``/dev/loopXpN``) are created asynchronously by devtmpfs/udev, so
+        they may not be visible yet when losetup returns. Consumers of
+        :meth:`get_loop_paths` expect those nodes to exist immediately.
+
+        :raises CraftError: If the expected partition nodes do not appear within
+            the timeout.
+        """
+        project = cast(Project, self._services.get("project").get())
+        volume = project.volumes[volume_name]
+        part_numbers = sorted(set(self._get_partition_numbers(volume).values()))
+        expected_nodes = [pathlib.Path(f"{device}p{number}") for number in part_numbers]
+
+        deadline = time.monotonic() + _PARTSCAN_TIMEOUT_SECONDS
+        while missing := [node for node in expected_nodes if not node.exists()]:
+            if time.monotonic() > deadline:
+                raise CraftError(
+                    f"Partition devices did not appear for {device}: "
+                    f"{[str(node) for node in missing]}.",
+                    details=(
+                        "The kernel creates loop-device partition nodes asynchronously."
+                    ),
+                    resolution=(
+                        "Verify that udev is running and that the image has a "
+                        "valid partition table."
+                    ),
+                )
+            time.sleep(0.1)
 
     def detach_images(self) -> None:
         """Detach all attached loop devices.

--- a/imagecraft/utils/__init__.py
+++ b/imagecraft/utils/__init__.py
@@ -1,0 +1,37 @@
+# This file is part of imagecraft.
+#
+# Copyright 2026 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 3, as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Utility modules for Imagecraft."""
+
+from imagecraft.utils.mount import (
+    BaseMount,
+    CompositeMount,
+    ExtFuseMount,
+    FatFuseMount,
+    VirtualOffsetDevice,
+    mount_partition,
+    mount_volume,
+)
+
+__all__ = [
+    "BaseMount",
+    "CompositeMount",
+    "ExtFuseMount",
+    "FatFuseMount",
+    "VirtualOffsetDevice",
+    "mount_partition",
+    "mount_volume",
+]

--- a/imagecraft/utils/mount.py
+++ b/imagecraft/utils/mount.py
@@ -34,7 +34,6 @@ from imagecraft.models import (
     Role,
     Volume,
 )
-from imagecraft.pack import gptutil
 from imagecraft.subprocesses import run
 
 
@@ -574,6 +573,10 @@ def mount_volume(
     :param fakeroot: If True, pass fakeroot option to ext mounts.
     :returns: A CompositeMount managing all partition mounts.
     """
+    # Imported here to avoid a circular import: imagecraft.pack imports
+    # this module's consumers (grubutil), while gptutil lives in that package.
+    from imagecraft.pack import gptutil  # noqa: PLC0415
+
     mountpoint_overrides = mountpoint_overrides or {}
     mount_entries: list[tuple[str, BaseMount]] = []
 

--- a/imagecraft/utils/mount.py
+++ b/imagecraft/utils/mount.py
@@ -80,6 +80,20 @@ def _unmount_path(
         raise last_err
 
 
+def _fuse_command(command: Sequence[str], description: str) -> None:
+    """Run a FUSE helper command, wrapping failures in ``MountError``.
+
+    :param command: The command and arguments to run.
+    :param description: Human-readable action description used when composing
+        the error message.
+    :raises errors.MountError: If the command fails or the binary is missing.
+    """
+    try:
+        run(*command)
+    except (subprocess.CalledProcessError, FileNotFoundError) as err:
+        raise errors.MountError(f"{description}: {err}") from err
+
+
 class BaseMount(abc.ABC):
     """Abstract base class for all filesystem mounts.
 
@@ -100,15 +114,6 @@ class BaseMount(abc.ABC):
     def is_mounted(self) -> bool:
         """Check if the filesystem is currently mounted."""
         return self._is_mounted
-
-    @property
-    def _mountpoint(self) -> Path | None:
-        """Alias for mountpoint property for internal consistency."""
-        return self.mountpoint
-
-    @_mountpoint.setter
-    def _mountpoint(self, value: Path | None) -> None:
-        self.mountpoint = value
 
     def _ensure_mountpoint(self, prefix: str) -> Path:
         """Ensure mountpoint directory exists and return it as a Path."""
@@ -147,8 +152,17 @@ class BaseMount(abc.ABC):
         """Exit context manager."""
         self.unmount()
 
+    def _cleanup(self) -> None:
+        """Reset mount state and remove the temporary mountpoint directory."""
+        self._is_mounted = False
+        if self._temp_dir is not None:
+            with contextlib.suppress(Exception):
+                self._temp_dir.cleanup()
+            self._temp_dir = None
+            self.mountpoint = None
 
-class VirtualOffsetDevice:
+
+class VirtualOffsetDevice(BaseMount):
     """Virtual partition device exposing a sub-slice of a disk image via fusefile.
 
     Used when mounting FAT filesystems with an offset > 0, as fusefat lacks native
@@ -159,21 +173,13 @@ class VirtualOffsetDevice:
     offset: int
     size: int
     part_file: Path | None
-    _temp_dir: tempfile.TemporaryDirectory[str] | None
-    _is_mounted: bool
 
     def __init__(self, disk_path: Path, offset: int, size: int) -> None:
+        super().__init__()
         self.disk_path = disk_path
         self.offset = offset
         self.size = size
         self.part_file = None
-        self._temp_dir = None
-        self._is_mounted = False
-
-    @property
-    def is_mounted(self) -> bool:
-        """Check if the virtual device is mounted."""
-        return self._is_mounted
 
     def mount(self) -> Path:
         """Create the virtual file and mount the slice via fusefile.
@@ -191,12 +197,13 @@ class VirtualOffsetDevice:
         emit.debug(f"Mounting virtual offset device {self.part_file} from {spec}")
 
         try:
-            run("fusefile", str(self.part_file), spec)
-        except (subprocess.CalledProcessError, FileNotFoundError) as err:
+            _fuse_command(
+                ["fusefile", str(self.part_file), spec],
+                "Failed to create virtual offset device with fusefile",
+            )
+        except errors.MountError:
             self._cleanup()
-            raise errors.MountError(
-                f"Failed to create virtual offset device with fusefile: {err}"
-            ) from err
+            raise
 
         self._is_mounted = True
         return self.part_file
@@ -218,25 +225,8 @@ class VirtualOffsetDevice:
             self._cleanup()
 
     def _cleanup(self) -> None:
-        self._is_mounted = False
+        super()._cleanup()
         self.part_file = None
-        if self._temp_dir is not None:
-            with contextlib.suppress(Exception):
-                self._temp_dir.cleanup()
-            self._temp_dir = None
-
-    def __enter__(self) -> Path:
-        """Enter context manager."""
-        return self.mount()
-
-    def __exit__(
-        self,
-        exc_type: type[BaseException] | None,
-        exc_val: BaseException | None,
-        exc_tb: TracebackType | None,
-    ) -> None:
-        """Exit context manager."""
-        self.unmount()
 
 
 class ExtFuseMount(BaseMount):
@@ -299,22 +289,23 @@ class ExtFuseMount(BaseMount):
 
         emit.debug(f"Mounting ext partition with: {cmd}")
         try:
-            run(*cmd)
-        except (subprocess.CalledProcessError, FileNotFoundError) as err:
+            _fuse_command(
+                cmd,
+                f"Failed to mount ext partition {self.imagepath} at {mountpoint}",
+            )
+        except errors.MountError:
             self._cleanup()
-            raise errors.MountError(
-                f"Failed to mount ext partition {self.imagepath} at {mountpoint}: {err}"
-            ) from err
+            raise
 
         self._is_mounted = True
         return mountpoint
 
     def unmount(self, *, lazy: bool = False) -> None:
         """Unmount the ext partition."""
-        if not self.is_mounted or self._mountpoint is None:
+        if not self.is_mounted or self.mountpoint is None:
             return
 
-        mountpoint = self._mountpoint
+        mountpoint = self.mountpoint
         emit.debug(f"Unmounting ext partition at {mountpoint}")
         try:
             _unmount_path(mountpoint, lazy=lazy, retries=10)
@@ -324,14 +315,6 @@ class ExtFuseMount(BaseMount):
             ) from err
         finally:
             self._cleanup()
-
-    def _cleanup(self) -> None:
-        self._is_mounted = False
-        if self._temp_dir is not None:
-            with contextlib.suppress(Exception):
-                self._temp_dir.cleanup()
-            self._temp_dir = None
-            self._mountpoint = None
 
 
 class FatFuseMount(BaseMount):
@@ -402,26 +385,27 @@ class FatFuseMount(BaseMount):
 
         emit.debug(f"Mounting FAT partition with: {cmd}")
         try:
-            run(*cmd)
-        except (subprocess.CalledProcessError, FileNotFoundError) as err:
+            _fuse_command(
+                cmd,
+                f"Failed to mount FAT partition {self.imagepath} at {mountpoint}",
+            )
+        except errors.MountError:
             if self._vpart is not None:
                 with contextlib.suppress(Exception):
                     self._vpart.unmount()
                 self._vpart = None
             self._cleanup()
-            raise errors.MountError(
-                f"Failed to mount FAT partition {self.imagepath} at {mountpoint}: {err}"
-            ) from err
+            raise
 
         self._is_mounted = True
         return mountpoint
 
     def unmount(self, *, lazy: bool = False) -> None:
         """Unmount the FAT partition and its virtual offset device if used."""
-        if not self.is_mounted or self._mountpoint is None:
+        if not self.is_mounted or self.mountpoint is None:
             return
 
-        mountpoint = self._mountpoint
+        mountpoint = self.mountpoint
         emit.debug(f"Unmounting FAT partition at {mountpoint}")
         err_mount: Exception | None = None
         try:
@@ -443,14 +427,6 @@ class FatFuseMount(BaseMount):
             raise errors.MountError(
                 f"Failed to unmount FAT partition at {mountpoint}: {err_mount}"
             ) from err_mount
-
-    def _cleanup(self) -> None:
-        self._is_mounted = False
-        if self._temp_dir is not None:
-            with contextlib.suppress(Exception):
-                self._temp_dir.cleanup()
-            self._temp_dir = None
-            self._mountpoint = None
 
 
 def mount_partition(
@@ -568,7 +544,7 @@ class CompositeMount(BaseMount):
             with contextlib.suppress(Exception):
                 self._temp_dir.cleanup()
             self._temp_dir = None
-            self._mountpoint = None
+            self.mountpoint = None
 
         if errors_encountered:
             raise errors.MountError(

--- a/imagecraft/utils/mount.py
+++ b/imagecraft/utils/mount.py
@@ -1,0 +1,649 @@
+# Copyright 2026 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""FUSE partition and volume mounting utilities."""
+
+import abc
+import contextlib
+import shutil
+import subprocess
+import tempfile
+import time
+from collections.abc import Sequence
+from pathlib import Path
+from types import TracebackType
+
+from craft_cli import emit
+
+from imagecraft import errors
+from imagecraft.models import (
+    FileSystem,
+    GPTVolume,
+    PartitionSchema,
+    Role,
+    Volume,
+)
+from imagecraft.pack import gptutil
+from imagecraft.subprocesses import run
+
+
+def _unmount_path(
+    target: Path,
+    *,
+    lazy: bool = False,
+    prefer_fuse2: bool = False,
+    retries: int = 1,
+) -> None:
+    """Unmount a FUSE mountpoint or virtual device file.
+
+    Tries fusermount, fusermount3, and umount depending on prefer_fuse2.
+    """
+    fuser_args = ["-u"]
+    if lazy:
+        fuser_args.append("-z")
+    fuser_args.append(str(target.resolve()))
+
+    umount_args = ["-l", str(target.resolve())] if lazy else [str(target.resolve())]
+
+    candidates = (
+        ["fusermount", "fusermount3", "umount"]
+        if prefer_fuse2
+        else ["fusermount3", "fusermount", "umount"]
+    )
+
+    last_err: Exception | None = None
+    for _ in range(retries):
+        for cmd in candidates:
+            if shutil.which(cmd) is None:
+                continue
+            args = umount_args if cmd == "umount" else fuser_args
+            try:
+                run(cmd, *args)
+            except (subprocess.CalledProcessError, FileNotFoundError) as err:
+                last_err = err
+            else:
+                return
+        time.sleep(0.1)
+
+    if last_err is not None:
+        raise last_err
+
+
+class BaseMount(abc.ABC):
+    """Abstract base class for all filesystem mounts.
+
+    Subclasses implement mounting and unmounting of specific filesystems or virtual
+    offset devices. Implements Python context manager protocol (__enter__/__exit__).
+    """
+
+    mountpoint: Path | None
+    _temp_dir: tempfile.TemporaryDirectory[str] | None
+    _is_mounted: bool
+
+    def __init__(self, *, mountpoint: Path | None = None) -> None:
+        self.mountpoint = mountpoint
+        self._temp_dir = None
+        self._is_mounted = False
+
+    @property
+    def is_mounted(self) -> bool:
+        """Check if the filesystem is currently mounted."""
+        return self._is_mounted
+
+    @property
+    def _mountpoint(self) -> Path | None:
+        """Alias for mountpoint property for internal consistency."""
+        return self.mountpoint
+
+    @_mountpoint.setter
+    def _mountpoint(self, value: Path | None) -> None:
+        self.mountpoint = value
+
+    def _ensure_mountpoint(self, prefix: str) -> Path:
+        """Ensure mountpoint directory exists and return it as a Path."""
+        if self.mountpoint is None:
+            self._temp_dir = tempfile.TemporaryDirectory(prefix=prefix)
+            self.mountpoint = Path(self._temp_dir.name)
+        else:
+            self.mountpoint.mkdir(parents=True, exist_ok=True)
+        return self.mountpoint
+
+    @abc.abstractmethod
+    def mount(self) -> Path:
+        """Mount the filesystem and return the mountpoint path.
+
+        :raises errors.MountError: If mounting fails.
+        """
+
+    @abc.abstractmethod
+    def unmount(self, *, lazy: bool = False) -> None:
+        """Unmount the filesystem.
+
+        :param lazy: If True, request lazy/detach unmount.
+        :raises errors.MountError: If unmounting fails.
+        """
+
+    def __enter__(self) -> Path:
+        """Enter context manager."""
+        return self.mount()
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        """Exit context manager."""
+        self.unmount()
+
+
+class VirtualOffsetDevice:
+    """Virtual partition device exposing a sub-slice of a disk image via fusefile.
+
+    Used when mounting FAT filesystems with an offset > 0, as fusefat lacks native
+    offset parameters.
+    """
+
+    disk_path: Path
+    offset: int
+    size: int
+    part_file: Path | None
+    _temp_dir: tempfile.TemporaryDirectory[str] | None
+    _is_mounted: bool
+
+    def __init__(self, disk_path: Path, offset: int, size: int) -> None:
+        self.disk_path = disk_path
+        self.offset = offset
+        self.size = size
+        self.part_file = None
+        self._temp_dir = None
+        self._is_mounted = False
+
+    @property
+    def is_mounted(self) -> bool:
+        """Check if the virtual device is mounted."""
+        return self._is_mounted
+
+    def mount(self) -> Path:
+        """Create the virtual file and mount the slice via fusefile.
+
+        :raises errors.MountError: If mounting the virtual device fails.
+        """
+        if self._is_mounted and self.part_file is not None:
+            return self.part_file
+
+        self._temp_dir = tempfile.TemporaryDirectory(prefix="imagecraft-vpart-")
+        self.part_file = Path(self._temp_dir.name) / "part.img"
+        self.part_file.touch()
+
+        spec = f"{self.disk_path.resolve()}/{self.offset}+{self.size}"
+        emit.debug(f"Mounting virtual offset device {self.part_file} from {spec}")
+
+        try:
+            run("fusefile", str(self.part_file), spec)
+        except (subprocess.CalledProcessError, FileNotFoundError) as err:
+            self._cleanup()
+            raise errors.MountError(
+                f"Failed to create virtual offset device with fusefile: {err}"
+            ) from err
+
+        self._is_mounted = True
+        return self.part_file
+
+    def unmount(self, *, lazy: bool = False) -> None:
+        """Unmount the virtual device."""
+        if not self._is_mounted or self.part_file is None:
+            return
+
+        part_file = self.part_file
+        emit.debug(f"Unmounting virtual offset device {part_file}")
+        try:
+            _unmount_path(part_file, lazy=lazy, prefer_fuse2=True, retries=30)
+        except (subprocess.CalledProcessError, FileNotFoundError) as err:
+            raise errors.MountError(
+                f"Failed to unmount virtual offset device {part_file}: {err}"
+            ) from err
+        finally:
+            self._cleanup()
+
+    def _cleanup(self) -> None:
+        self._is_mounted = False
+        self.part_file = None
+        if self._temp_dir is not None:
+            with contextlib.suppress(Exception):
+                self._temp_dir.cleanup()
+            self._temp_dir = None
+
+    def __enter__(self) -> Path:
+        """Enter context manager."""
+        return self.mount()
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        """Exit context manager."""
+        self.unmount()
+
+
+class ExtFuseMount(BaseMount):
+    """Mount an ext2/ext3/ext4 partition using fuse2fs.
+
+    :param imagepath: Path to the disk image or partition image.
+    :param offset: Byte offset of the partition within the image (0 if standalone).
+    :param mountpoint: Optional host directory mount point.
+    :param read_only: If True, mount read-only.
+    :param allow_other: If True, allow other users to access the mount.
+    :param fakeroot: If True, pass fakeroot option to fuse2fs.
+    """
+
+    imagepath: Path
+    offset: int
+    read_only: bool
+    allow_other: bool
+    fakeroot: bool
+
+    def __init__(
+        self,
+        imagepath: Path,
+        *,
+        offset: int = 0,
+        mountpoint: Path | None = None,
+        read_only: bool = False,
+        allow_other: bool = False,
+        fakeroot: bool = False,
+    ) -> None:
+        super().__init__(mountpoint=mountpoint)
+        self.imagepath = imagepath
+        self.offset = offset
+        self.read_only = read_only
+        self.allow_other = allow_other
+        self.fakeroot = fakeroot
+
+    def mount(self) -> Path:
+        """Mount the ext partition using fuse2fs."""
+        if self.is_mounted and self.mountpoint is not None:
+            return self.mountpoint
+
+        mountpoint = self._ensure_mountpoint("imagecraft-ext-mount-")
+
+        options: list[str] = []
+        if self.offset > 0:
+            options.append(f"offset={self.offset}")
+        if self.read_only:
+            options.append("ro")
+        else:
+            options.append("rw")
+        if self.allow_other:
+            options.append("allow_other")
+        if self.fakeroot:
+            options.append("fakeroot")
+
+        cmd: list[str] = ["fuse2fs"]
+        if options:
+            cmd.extend(["-o", ",".join(options)])
+        cmd.extend([str(self.imagepath.resolve()), str(mountpoint.resolve())])
+
+        emit.debug(f"Mounting ext partition with: {cmd}")
+        try:
+            run(*cmd)
+        except (subprocess.CalledProcessError, FileNotFoundError) as err:
+            self._cleanup()
+            raise errors.MountError(
+                f"Failed to mount ext partition {self.imagepath} at {mountpoint}: {err}"
+            ) from err
+
+        self._is_mounted = True
+        return mountpoint
+
+    def unmount(self, *, lazy: bool = False) -> None:
+        """Unmount the ext partition."""
+        if not self.is_mounted or self._mountpoint is None:
+            return
+
+        mountpoint = self._mountpoint
+        emit.debug(f"Unmounting ext partition at {mountpoint}")
+        try:
+            _unmount_path(mountpoint, lazy=lazy, retries=10)
+        except (subprocess.CalledProcessError, FileNotFoundError) as err:
+            raise errors.MountError(
+                f"Failed to unmount ext partition at {mountpoint}: {err}"
+            ) from err
+        finally:
+            self._cleanup()
+
+    def _cleanup(self) -> None:
+        self._is_mounted = False
+        if self._temp_dir is not None:
+            with contextlib.suppress(Exception):
+                self._temp_dir.cleanup()
+            self._temp_dir = None
+            self._mountpoint = None
+
+
+class FatFuseMount(BaseMount):
+    """Mount a FAT16/FAT32/VFAT partition using fusefat.
+
+    :param imagepath: Path to the disk image or partition image.
+    :param offset: Byte offset of the partition within the image (0 if standalone).
+    :param size: Byte size of the partition (required if offset > 0).
+    :param mountpoint: Optional host directory mount point.
+    :param read_only: If True, mount read-only.
+    :param allow_other: If True, allow other users to access the mount.
+    """
+
+    imagepath: Path
+    offset: int
+    size: int | None
+    read_only: bool
+    allow_other: bool
+    _vpart: VirtualOffsetDevice | None
+
+    def __init__(
+        self,
+        imagepath: Path,
+        *,
+        offset: int = 0,
+        size: int | None = None,
+        mountpoint: Path | None = None,
+        read_only: bool = False,
+        allow_other: bool = False,
+    ) -> None:
+        super().__init__(mountpoint=mountpoint)
+        self.imagepath = imagepath
+        self.offset = offset
+        self.size = size
+        self.read_only = read_only
+        self.allow_other = allow_other
+        self._vpart = None
+
+    def mount(self) -> Path:
+        """Mount the FAT partition using fusefat."""
+        if self.is_mounted and self.mountpoint is not None:
+            return self.mountpoint
+
+        mountpoint = self._ensure_mountpoint("imagecraft-fat-mount-")
+
+        target_file: Path
+        if self.offset > 0:
+            if self.size is None:
+                raise errors.MountError(
+                    "Partition size must be specified when offset > 0 for FAT partition."
+                )
+            self._vpart = VirtualOffsetDevice(self.imagepath, self.offset, self.size)
+            target_file = self._vpart.mount()
+        else:
+            target_file = self.imagepath
+
+        options = ["ro"] if self.read_only else ["rw+"]
+        if self.allow_other:
+            options.append("allow_other")
+
+        cmd = [
+            "fusefat",
+            "-o",
+            ",".join(options),
+            str(target_file.resolve()),
+            str(mountpoint.resolve()),
+        ]
+
+        emit.debug(f"Mounting FAT partition with: {cmd}")
+        try:
+            run(*cmd)
+        except (subprocess.CalledProcessError, FileNotFoundError) as err:
+            if self._vpart is not None:
+                with contextlib.suppress(Exception):
+                    self._vpart.unmount()
+                self._vpart = None
+            self._cleanup()
+            raise errors.MountError(
+                f"Failed to mount FAT partition {self.imagepath} at {mountpoint}: {err}"
+            ) from err
+
+        self._is_mounted = True
+        return mountpoint
+
+    def unmount(self, *, lazy: bool = False) -> None:
+        """Unmount the FAT partition and its virtual offset device if used."""
+        if not self.is_mounted or self._mountpoint is None:
+            return
+
+        mountpoint = self._mountpoint
+        emit.debug(f"Unmounting FAT partition at {mountpoint}")
+        err_mount: Exception | None = None
+        try:
+            _unmount_path(mountpoint, lazy=lazy, retries=10)
+        except (subprocess.CalledProcessError, FileNotFoundError) as err:
+            err_mount = err
+        finally:
+            if self._vpart is not None:
+                try:
+                    self._vpart.unmount(lazy=lazy)
+                except Exception as err_vpart:  # noqa: BLE001
+                    if err_mount is None:
+                        err_mount = err_vpart
+                finally:
+                    self._vpart = None
+            self._cleanup()
+
+        if err_mount is not None:
+            raise errors.MountError(
+                f"Failed to unmount FAT partition at {mountpoint}: {err_mount}"
+            ) from err_mount
+
+    def _cleanup(self) -> None:
+        self._is_mounted = False
+        if self._temp_dir is not None:
+            with contextlib.suppress(Exception):
+                self._temp_dir.cleanup()
+            self._temp_dir = None
+            self._mountpoint = None
+
+
+def mount_partition(
+    imagepath: Path,
+    filesystem: FileSystem | str,
+    *,
+    offset: int = 0,
+    size: int | None = None,
+    mountpoint: Path | None = None,
+    read_only: bool = False,
+    allow_other: bool = False,
+    fakeroot: bool = False,
+) -> BaseMount:
+    """Create the appropriate BaseMount instance for a partition.
+
+    :param imagepath: Path to the disk image or partition image.
+    :param filesystem: Filesystem type (e.g. ext4, fat32, vfat).
+    :param offset: Byte offset within the disk image.
+    :param size: Byte size of the partition (required for FAT when offset > 0).
+    :param mountpoint: Optional host mountpoint path.
+    :param read_only: If True, mount read-only.
+    :param allow_other: If True, pass allow_other option to FUSE.
+    :param fakeroot: If True, pass fakeroot option to FUSE (ext only).
+    :raises errors.MountError: If the filesystem type is unsupported.
+    """
+    if isinstance(filesystem, FileSystem):
+        fs_str = filesystem.value.lower()
+    else:
+        fs_str = str(filesystem).lower()
+    if fs_str in ("ext2", "ext3", "ext4"):
+        return ExtFuseMount(
+            imagepath,
+            offset=offset,
+            mountpoint=mountpoint,
+            read_only=read_only,
+            allow_other=allow_other,
+            fakeroot=fakeroot,
+        )
+    if fs_str in ("fat16", "fat32", "vfat"):
+        return FatFuseMount(
+            imagepath,
+            offset=offset,
+            size=size,
+            mountpoint=mountpoint,
+            read_only=read_only,
+            allow_other=allow_other,
+        )
+    raise errors.MountError(f"Unsupported filesystem for mounting: {filesystem}")
+
+
+class CompositeMount(BaseMount):
+    """Hierarchical composite mount managing multiple nested partition mounts.
+
+    :param mounts: Sequence of (relative_mountpoint_str, mount_instance) pairs.
+        The root filesystem should have relative mountpoint "" or "/".
+    :param mountpoint: Optional base host directory to mount under.
+    """
+
+    _mount_entries: list[tuple[str, BaseMount]]
+    _mounted_stack: list[BaseMount]
+
+    def __init__(
+        self,
+        mounts: Sequence[tuple[str, BaseMount]],
+        mountpoint: Path | None = None,
+    ) -> None:
+        super().__init__(mountpoint=mountpoint)
+        self._mount_entries = list(mounts)
+        self._mounted_stack = []
+
+    def mount(self) -> Path:
+        """Mount all sub-mounts in topological order (root to leaf)."""
+        if self.is_mounted and self.mountpoint is not None:
+            return self.mountpoint
+
+        mountpoint = self._ensure_mountpoint("imagecraft-composite-mount-")
+
+        sorted_entries = sorted(
+            self._mount_entries,
+            key=lambda item: (
+                len(Path(item[0].strip("/")).parts) if item[0].strip("/") else 0
+            ),
+        )
+
+        try:
+            for rel_path_str, mount_obj in sorted_entries:
+                rel_path = rel_path_str.strip("/")
+                target_dir = mountpoint if not rel_path else mountpoint / rel_path
+                target_dir.mkdir(parents=True, exist_ok=True)
+                mount_obj.mountpoint = target_dir
+                mount_obj.mount()
+                self._mounted_stack.append(mount_obj)
+        except Exception as err:
+            self.unmount()
+            raise errors.MountError(
+                f"Failed to mount composite mount hierarchy: {err}"
+            ) from err
+
+        self._is_mounted = True
+        return mountpoint
+
+    def unmount(self, *, lazy: bool = False) -> None:
+        """Unmount all sub-mounts in reverse topological order (leaf to root)."""
+        errors_encountered: list[Exception] = []
+
+        while self._mounted_stack:
+            mount_obj = self._mounted_stack.pop()
+            try:
+                mount_obj.unmount(lazy=lazy)
+            except Exception as err:  # noqa: BLE001
+                errors_encountered.append(err)
+
+        self._is_mounted = False
+        if self._temp_dir is not None:
+            with contextlib.suppress(Exception):
+                self._temp_dir.cleanup()
+            self._temp_dir = None
+            self._mountpoint = None
+
+        if errors_encountered:
+            raise errors.MountError(
+                f"Errors occurred during composite unmount: {errors_encountered}"
+            )
+
+
+def mount_volume(
+    volume: Volume,
+    disk_path: Path,
+    *,
+    mountpoint_overrides: dict[str, str] | None = None,
+    mountpoint: Path | None = None,
+    read_only: bool = False,
+    allow_other: bool = False,
+    fakeroot: bool = False,
+) -> CompositeMount:
+    """Mount all filesystems in a Volume as a composite tree.
+
+    :param volume: Volume definition containing partition structures.
+    :param disk_path: Path to the disk image.
+    :param mountpoint_overrides: Mapping from structure names to relative
+        mount paths inside the mounted root.
+    :param mountpoint: Optional host mountpoint path.
+    :param read_only: If True, mount all partitions read-only.
+    :param allow_other: If True, pass allow_other option to all mounts.
+    :param fakeroot: If True, pass fakeroot option to ext mounts.
+    :returns: A CompositeMount managing all partition mounts.
+    """
+    mountpoint_overrides = mountpoint_overrides or {}
+    mount_entries: list[tuple[str, BaseMount]] = []
+
+    is_gpt = (
+        isinstance(volume, GPTVolume)
+        or getattr(volume, "volume_schema", None) == PartitionSchema.GPT
+    )
+
+    for idx, item in enumerate(volume.structure, start=1):
+        filesystem = getattr(item, "filesystem", None)
+        if not filesystem:
+            continue
+
+        # Determine relative mount path
+        rel_path: str
+        if item.name in mountpoint_overrides:
+            rel_path = mountpoint_overrides[item.name]
+        elif item.role == Role.SYSTEM_DATA:
+            rel_path = ""
+        elif item.role == Role.SYSTEM_BOOT:
+            rel_path = "boot/efi"
+        elif item.role == Role.SYSTEM_SEED:
+            rel_path = "var/lib/snapd/seed"
+        else:
+            rel_path = f"mnt/{item.name}"
+
+        # Calculate byte offset and size
+        if is_gpt:
+            start_sector = gptutil.get_partition_sector_offset(disk_path, item.name)
+            size_sectors = gptutil.get_partition_size_sectors(disk_path, item.name)
+        else:
+            start_sector = gptutil.get_partition_sector_offset_by_number(disk_path, idx)
+            size_sectors = gptutil.get_partition_size_sectors_by_number(disk_path, idx)
+
+        offset_bytes = start_sector * gptutil.SECTOR_SIZE_512
+        size_bytes = size_sectors * gptutil.SECTOR_SIZE_512
+
+        part_mount = mount_partition(
+            disk_path,
+            filesystem,
+            offset=offset_bytes,
+            size=size_bytes,
+            read_only=read_only,
+            allow_other=allow_other,
+            fakeroot=fakeroot,
+        )
+        mount_entries.append((rel_path, part_mount))
+
+    return CompositeMount(mounts=mount_entries, mountpoint=mountpoint)

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -77,6 +77,7 @@ parts:
       - util-linux
       - fusefile
       - fuse3
+      - grub-common
     stage:
       - "-usr/lib/x86_64-linux-gnu/libicuio.so.*"
       - "-usr/lib/x86_64-linux-gnu/libicutest.so.*"
@@ -93,6 +94,7 @@ parts:
       "usr/sbin/fusefile": "libexec/imagecraft/fusefile"
       "usr/bin/fusermount3": "libexec/imagecraft/fusermount3"
       "usr/sbin/mkfs*": "libexec/imagecraft/"
+      "usr/bin/grub-mkimage": "libexec/imagecraft/grub-mkimage"
   # Build fusefat 0.4 from source because the archive only provides it on amd64 in Noble.
   # TODO: Remove when upgrading base to core26.
   fusefat:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -75,6 +75,8 @@ parts:
       - fdisk
       - coreutils
       - util-linux
+      - fusefile
+      - fuse3
     stage:
       - "-usr/lib/x86_64-linux-gnu/libicuio.so.*"
       - "-usr/lib/x86_64-linux-gnu/libicutest.so.*"
@@ -87,7 +89,33 @@ parts:
       "usr/bin/mtools": "libexec/imagecraft/mtools"
       "usr/bin/dd": "libexec/imagecraft/dd"
       "usr/bin/truncate": "libexec/imagecraft/truncate"
+      "usr/sbin/fuse2fs": "libexec/imagecraft/fuse2fs"
+      "usr/sbin/fusefile": "libexec/imagecraft/fusefile"
+      "usr/bin/fusermount3": "libexec/imagecraft/fusermount3"
       "usr/sbin/mkfs*": "libexec/imagecraft/"
+  # Build fusefat 0.4 from source because the archive only provides it on amd64 in Noble.
+  # TODO: Remove when upgrading base to core26.
+  fusefat:
+    source: https://github.com/virtualsquare/fusefatfs.git
+    source-commit: 9d612e83909f2719f004b8aad843ad9d320fece1 # 0.4
+    plugin: cmake
+    build-attributes:
+      - enable-patchelf
+    build-packages:
+      - libfuse3-dev
+      - pkgconf
+    stage-packages:
+      - libfuse3-3
+    override-build: |
+      craftctl default
+      for bindir in "${CRAFT_PART_INSTALL}/usr/local/bin" "${CRAFT_PART_INSTALL}/usr/bin"; do
+        if [ -f "${bindir}/fusefatfs" ] && [ ! -f "${bindir}/fusefat" ]; then
+          ln -sf fusefatfs "${bindir}/fusefat"
+        fi
+      done
+    organize:
+      "usr/local/bin/fusefat*": "libexec/imagecraft/"
+      "usr/bin/fusefat*": "libexec/imagecraft/"
   # Build our own version of fuse-overlayfs due to https://github.com/containers/fuse-overlayfs/issues/429
   # The apt and Launchpad repositories as of 23/07/25 do not have a sufficiently new version to get this patch
   fuse-overlayfs:
@@ -120,7 +148,7 @@ parts:
     prime:
       - -*
   imagecraft:
-    after: [imagecraft-libs, rustc]
+    after: [imagecraft-libs, rustc, fusefat]
     source: .
     plugin: uv
     build-attributes:

--- a/tests/integration/pack/test_grubutil.py
+++ b/tests/integration/pack/test_grubutil.py
@@ -1,0 +1,532 @@
+# Copyright 2026 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""End-to-end tests for imagecraft.pack.grubutil.
+
+These build small real disk images with the same helpers the production pack
+pipeline uses (gptutil/diskutil), populate them with fake-but-realistic GRUB,
+shim and kernel content, run the real ``setup_grub()`` — which mounts the
+partitions via FUSE and chroots into the rootfs — then inspect the result by
+mounting the partitions again.
+"""
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+from craft_parts.filesystem_mounts import FilesystemMount
+from craft_platforms import DebianArchitecture
+from imagecraft import errors
+from imagecraft.models.volume import (
+    GPTStructureItem,
+    GPTVolume,
+    PartitionSchema,
+)
+from imagecraft.pack import diskutil, gptutil, grubutil
+from imagecraft.pack.diskutil import DiskSize
+from imagecraft.pack.image import Image
+from imagecraft.utils.mount import mount_partition
+
+
+@pytest.fixture(autouse=True)
+def _require_fuse_tools():
+    missing = [
+        tool
+        for tool in ("fuse2fs", "fusefile", "fusermount3", "mkfs.vfat", "mke2fs")
+        if shutil.which(tool) is None
+    ]
+    if missing:
+        pytest.fail(
+            "Missing required tool(s) for grubutil integration tests: "
+            f"{', '.join(missing)}. Run `make setup` to install them.",
+            pytrace=False,
+        )
+
+
+def _copy_grub_target_files(src_dir: Path, dest_dir: Path) -> None:
+    """Copy a whole real /usr/lib/grub/<target> directory, skipping subdirs."""
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    for item in src_dir.iterdir():
+        if item.is_file():
+            shutil.copy2(item, dest_dir / item.name)
+
+
+def _copy_grub_mkimage(root_content: Path) -> None:
+    """Copy the host grub-mkimage binary and its libraries into the fake rootfs.
+
+    Inside the real flow the image's own rootfs provides grub-mkimage; these
+    fake trees have to be given one explicitly for the in-chroot build to run.
+    """
+    binary = Path("/usr/bin/grub-mkimage")
+    if not binary.is_file():
+        pytest.fail("grub-mkimage is required but not installed on this system")
+    dest_bin = root_content / "usr/bin/grub-mkimage"
+    dest_bin.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(binary, dest_bin)
+    for line in subprocess.run(
+        ["ldd", str(binary)], capture_output=True, text=True, check=True
+    ).stdout.splitlines():
+        parts = line.split()
+        lib = next((p for p in parts if p.startswith("/")), None)
+        if lib is None:
+            continue
+        lib_dest = root_content / lib.lstrip("/")
+        lib_dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(lib, lib_dest)
+
+
+def _build_and_inject_partition(
+    *,
+    disk_path: Path,
+    tmp_path: Path,
+    fstype,
+    content_dir: Path,
+    label: str | None,
+    partition_name: str,
+    partition_number: int | None = None,
+    sector_size: int = 512,
+) -> None:
+    if partition_number is not None:
+        # MBR partitions have no "name" field in sfdisk --json output, so
+        # they must be looked up positionally.
+        off = gptutil.get_partition_sector_offset_by_number(disk_path, partition_number)
+        size = gptutil.get_partition_size_sectors_by_number(disk_path, partition_number)
+    else:
+        off = gptutil.get_partition_sector_offset(disk_path, partition_name)
+        size = gptutil.get_partition_size_sectors(disk_path, partition_name)
+    part_file = tmp_path / f"{partition_name}.img"
+    subprocess.run(
+        ["truncate", "-s", str(size * sector_size), str(part_file)], check=True
+    )
+    diskutil.format_populate_partition(
+        fstype=fstype, content_dir=content_dir, partitionpath=part_file, label=label
+    )
+    diskutil.inject_partition_into_image(
+        partition=part_file,
+        imagepath=disk_path,
+        sector_offset=off,
+        disk_size=DiskSize(bytesize=size * sector_size, sector_size=sector_size),
+    )
+
+
+def _mount_ext_partition(disk_path: Path, name: str):
+    """Mount an ext partition by name through the FUSE utilities."""
+    offset = gptutil.get_partition_sector_offset(disk_path, name)
+    size = gptutil.get_partition_size_sectors(disk_path, name)
+    return mount_partition(disk_path, "ext4", offset=offset * 512, size=size * 512)
+
+
+def _esp_offset(disk_path: Path) -> int:
+    return gptutil.get_partition_sector_offset(disk_path, "efi") * 512
+
+
+def _esp_mdir(disk_path: Path, path: str) -> str:
+    """List an ESP directory with mtools (8.3 names render as columns)."""
+    result = subprocess.run(
+        ["mdir", "-i", f"{disk_path}@@{_esp_offset(disk_path)}", f"::{path}"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout
+
+
+def _esp_type(disk_path: Path, path: str) -> str:
+    """Read a file from the ESP with mtools."""
+    return subprocess.run(
+        ["mtype", "-i", f"{disk_path}@@{_esp_offset(disk_path)}", f"::{path}"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+
+
+def _make_volume(*, boot_partition: bool):
+    from imagecraft.models.volume import FileSystem, GptType, Role  # noqa: PLC0415
+
+    structure = [
+        GPTStructureItem(
+            name="efi",
+            role=Role.SYSTEM_BOOT,
+            size="64M",
+            filesystem=FileSystem.VFAT,
+            type=GptType("C12A7328-F81F-11D2-BA4B-00A0C93EC93B"),
+        )
+    ]
+    if boot_partition:
+        structure.append(
+            GPTStructureItem(
+                name="boot",
+                role=Role.SYSTEM_BOOT,
+                size="128M",
+                filesystem=FileSystem.EXT4,
+                type=GptType("0FC63DAF-8483-4772-8E79-3D69D8477DE4"),
+            )
+        )
+    structure.append(
+        GPTStructureItem(
+            name="rootfs",
+            role=Role.SYSTEM_DATA,
+            size="256M",
+            filesystem=FileSystem.EXT4,
+            type=GptType("0FC63DAF-8483-4772-8E79-3D69D8477DE4"),
+        )
+    )
+    return GPTVolume(schema=PartitionSchema.GPT, structure=structure)
+
+
+@pytest.fixture
+def fake_kernel_files():
+    def _make(boot_dir: Path) -> None:
+        boot_dir.mkdir(parents=True, exist_ok=True)
+        (boot_dir / "vmlinuz-6.8.0-generic").write_bytes(b"FAKEKERNEL" * 100)
+        (boot_dir / "initrd.img-6.8.0-generic").write_bytes(b"FAKEINITRD" * 100)
+
+    return _make
+
+
+@pytest.mark.slow
+@pytest.mark.requires_root
+@pytest.mark.usefixtures("new_dir")
+def test_setup_grub_efi_signed(new_dir, fake_kernel_files):
+    """Signed shim+GRUB, when present in the rootfs, are deployed as-is."""
+    from imagecraft.models.volume import FileSystem, GptType, Role  # noqa: PLC0415
+
+    tmp_path = Path(new_dir)
+    root_content = tmp_path / "root_content"
+    _copy_grub_target_files(
+        Path("/usr/lib/grub/x86_64-efi"), root_content / "usr/lib/grub/x86_64-efi"
+    )
+    signed_grub = Path("/usr/lib/grub/x86_64-efi-signed/grubx64.efi.signed")
+    signed_shim = Path("/usr/lib/shim/shimx64.efi.signed.latest")
+    if not (signed_grub.is_file() and signed_shim.is_file()):
+        pytest.skip("signed shim/grub not installed on this system")
+    (root_content / "usr/lib/grub/x86_64-efi-signed").mkdir(parents=True)
+    shutil.copy2(
+        signed_grub, root_content / "usr/lib/grub/x86_64-efi-signed/grubx64.efi.signed"
+    )
+    (root_content / "usr/lib/shim").mkdir(parents=True)
+    shutil.copy2(signed_shim, root_content / "usr/lib/shim/shimx64.efi.signed.latest")
+    fake_kernel_files(root_content / "boot")
+
+    esp_content = tmp_path / "esp_content"
+    (esp_content / "EFI/BOOT").mkdir(parents=True)
+
+    volume = GPTVolume(
+        schema=PartitionSchema.GPT,
+        structure=[
+            GPTStructureItem(
+                name="efi",
+                role=Role.SYSTEM_BOOT,
+                size="64M",
+                filesystem=FileSystem.VFAT,
+                type=GptType("C12A7328-F81F-11D2-BA4B-00A0C93EC93B"),
+            ),
+            GPTStructureItem(
+                name="rootfs",
+                role=Role.SYSTEM_DATA,
+                size="256M",
+                filesystem=FileSystem.EXT4,
+                type=GptType("0FC63DAF-8483-4772-8E79-3D69D8477DE4"),
+            ),
+        ],
+    )
+    disk_path = tmp_path / "disk.img"
+    gptutil.create_empty_gpt_image(imagepath=disk_path, sector_size=512, layout=volume)
+    for item, content in (
+        (volume.structure[0], esp_content),
+        (volume.structure[1], root_content),
+    ):
+        _build_and_inject_partition(
+            disk_path=disk_path,
+            tmp_path=tmp_path,
+            fstype=item.filesystem,
+            content_dir=content,
+            label=item.filesystem_label,
+            partition_name=item.name,
+        )
+
+    image = Image(volume=volume, disk_path=disk_path)
+    filesystem_mount = FilesystemMount.unmarshal(
+        [
+            {"mount": "/", "device": "(volume/pc/rootfs)"},
+            {"mount": "/boot/efi", "device": "(volume/pc/efi)"},
+        ]
+    )
+
+    grubutil.setup_grub(
+        image=image,
+        workdir=tmp_path / "work",
+        arch=DebianArchitecture.AMD64,
+        filesystem_mount=filesystem_mount,
+    )
+
+    ubuntu = _esp_mdir(disk_path, "/EFI/ubuntu")
+    assert "grubx64" in ubuntu
+    assert "shimx64" in ubuntu
+    boot = _esp_mdir(disk_path, "/EFI/BOOT")
+    # Shim chainloads grub from beside itself, so the removable path
+    # needs its own copy for the fallback boot to work.
+    assert "BOOTX64" in boot
+    assert "grubx64" in boot
+
+    with _mount_ext_partition(disk_path, "rootfs") as rootfs:
+        cfg = (rootfs / "boot/grub/grub.cfg").read_text()
+        assert "vmlinuz-6.8.0-generic" in cfg
+        assert "initrd.img-6.8.0-generic" in cfg
+
+
+@pytest.mark.slow
+@pytest.mark.requires_root
+@pytest.mark.usefixtures("new_dir")
+def test_setup_grub_efi_unsigned_requires_grub_mkimage_in_image(
+    new_dir, fake_kernel_files
+):
+    """The in-image grub-mkimage is required; modules alone do not suffice."""
+    tmp_path = Path(new_dir)
+    root_content = tmp_path / "root_content"
+    _copy_grub_target_files(
+        Path("/usr/lib/grub/x86_64-efi"), root_content / "usr/lib/grub/x86_64-efi"
+    )
+    fake_kernel_files(root_content / "boot")
+    esp_content = tmp_path / "esp_content"
+    (esp_content / "EFI/BOOT").mkdir(parents=True)
+
+    volume = _make_volume(boot_partition=False)
+    disk_path = tmp_path / "disk.img"
+    gptutil.create_empty_gpt_image(imagepath=disk_path, sector_size=512, layout=volume)
+    for item, content in (
+        (volume.structure[0], esp_content),
+        (volume.structure[1], root_content),
+    ):
+        _build_and_inject_partition(
+            disk_path=disk_path,
+            tmp_path=tmp_path,
+            fstype=item.filesystem,
+            content_dir=content,
+            label=item.filesystem_label,
+            partition_name=item.name,
+        )
+
+    image = Image(volume=volume, disk_path=disk_path)
+    filesystem_mount = FilesystemMount.unmarshal(
+        [
+            {"mount": "/", "device": "(volume/pc/rootfs)"},
+            {"mount": "/boot/efi", "device": "(volume/pc/efi)"},
+        ]
+    )
+
+    with pytest.raises(errors.GRUBInstallError, match="grub-mkimage failed"):
+        grubutil.setup_grub(
+            image=image,
+            workdir=tmp_path / "work",
+            arch=DebianArchitecture.AMD64,
+            filesystem_mount=filesystem_mount,
+        )
+
+
+@pytest.mark.slow
+@pytest.mark.requires_root
+@pytest.mark.usefixtures("new_dir")
+def test_setup_grub_efi_skips_without_grub_modules(new_dir, fake_kernel_files, emitter):
+    """A rootfs with no GRUB package installed gets no bootloader, not an error."""
+    tmp_path = Path(new_dir)
+    root_content = tmp_path / "root_content"
+    fake_kernel_files(root_content / "boot")
+    esp_content = tmp_path / "esp_content"
+    (esp_content / "EFI/BOOT").mkdir(parents=True)
+
+    volume = _make_volume(boot_partition=False)
+    disk_path = tmp_path / "disk.img"
+    gptutil.create_empty_gpt_image(imagepath=disk_path, sector_size=512, layout=volume)
+    for item, content in (
+        (volume.structure[0], esp_content),
+        (volume.structure[1], root_content),
+    ):
+        _build_and_inject_partition(
+            disk_path=disk_path,
+            tmp_path=tmp_path,
+            fstype=item.filesystem,
+            content_dir=content,
+            label=item.filesystem_label,
+            partition_name=item.name,
+        )
+
+    image = Image(volume=volume, disk_path=disk_path)
+    filesystem_mount = FilesystemMount.unmarshal(
+        [
+            {"mount": "/", "device": "(volume/pc/rootfs)"},
+            {"mount": "/boot/efi", "device": "(volume/pc/efi)"},
+        ]
+    )
+
+    grubutil.setup_grub(
+        image=image,
+        workdir=tmp_path / "work",
+        arch=DebianArchitecture.AMD64,
+        filesystem_mount=filesystem_mount,
+    )
+
+    emitter.assert_progress(
+        "Cannot install GRUB on this rootfs: GRUB modules for x86_64-efi "
+        "are not installed in the image",
+        permanent=True,
+    )
+
+
+@pytest.mark.slow
+@pytest.mark.requires_root
+@pytest.mark.usefixtures("new_dir")
+def test_setup_grub_efi_unsigned(new_dir, fake_kernel_files):
+    """Without signed shim/GRUB, an unsigned standalone image is built."""
+    tmp_path = Path(new_dir)
+    root_content = tmp_path / "root_content"
+    _copy_grub_target_files(
+        Path("/usr/lib/grub/x86_64-efi"), root_content / "usr/lib/grub/x86_64-efi"
+    )
+    _copy_grub_mkimage(root_content)
+    fake_kernel_files(root_content / "boot")
+    (root_content / "etc/default").mkdir(parents=True)
+    (root_content / "etc/default/grub").write_text(
+        'GRUB_CMDLINE_LINUX_DEFAULT="console=ttyS0,115200n8"\n'
+    )
+
+    esp_content = tmp_path / "esp_content"
+    (esp_content / "EFI/BOOT").mkdir(parents=True)
+
+    volume = _make_volume(boot_partition=False)
+    disk_path = tmp_path / "disk.img"
+    gptutil.create_empty_gpt_image(imagepath=disk_path, sector_size=512, layout=volume)
+    for item, content in (
+        (volume.structure[0], esp_content),
+        (volume.structure[1], root_content),
+    ):
+        _build_and_inject_partition(
+            disk_path=disk_path,
+            tmp_path=tmp_path,
+            fstype=item.filesystem,
+            content_dir=content,
+            label=item.filesystem_label,
+            partition_name=item.name,
+        )
+
+    image = Image(volume=volume, disk_path=disk_path)
+    filesystem_mount = FilesystemMount.unmarshal(
+        [
+            {"mount": "/", "device": "(volume/pc/rootfs)"},
+            {"mount": "/boot/efi", "device": "(volume/pc/efi)"},
+        ]
+    )
+
+    grubutil.setup_grub(
+        image=image,
+        workdir=tmp_path / "work",
+        arch=DebianArchitecture.AMD64,
+        filesystem_mount=filesystem_mount,
+    )
+
+    ubuntu = _esp_mdir(disk_path, "/EFI/ubuntu")
+    assert "grubx64" in ubuntu
+    # No signed shim was available, so no shim binary should be deployed.
+    assert "shimx64" not in ubuntu
+
+    with _mount_ext_partition(disk_path, "rootfs") as rootfs:
+        cfg = (rootfs / "boot/grub/grub.cfg").read_text()
+        assert "console=ttyS0,115200n8" in cfg
+        # The temporary in-image build output must not ship in the final image.
+        assert not (rootfs / "tmp/imagecraft-grubx64.efi").exists()
+
+
+@pytest.mark.slow
+@pytest.mark.requires_root
+@pytest.mark.usefixtures("new_dir")
+def test_setup_grub_efi_separate_boot_partition(new_dir, fake_kernel_files):
+    """With a dedicated /boot partition, its root (not /boot/...) holds GRUB/kernels."""
+    tmp_path = Path(new_dir)
+    root_content = tmp_path / "root_content"
+    _copy_grub_target_files(
+        Path("/usr/lib/grub/x86_64-efi"), root_content / "usr/lib/grub/x86_64-efi"
+    )
+    _copy_grub_mkimage(root_content)
+    boot_content = tmp_path / "boot_content"
+    fake_kernel_files(boot_content)
+
+    esp_content = tmp_path / "esp_content"
+    (esp_content / "EFI/BOOT").mkdir(parents=True)
+
+    volume = _make_volume(boot_partition=True)
+    disk_path = tmp_path / "disk.img"
+    gptutil.create_empty_gpt_image(imagepath=disk_path, sector_size=512, layout=volume)
+    content_map = {"efi": esp_content, "boot": boot_content, "rootfs": root_content}
+    for item in volume.structure:
+        _build_and_inject_partition(
+            disk_path=disk_path,
+            tmp_path=tmp_path,
+            fstype=item.filesystem,
+            content_dir=content_map[item.name],
+            label=item.filesystem_label,
+            partition_name=item.name,
+        )
+
+    image = Image(volume=volume, disk_path=disk_path)
+    filesystem_mount = FilesystemMount.unmarshal(
+        [
+            {"mount": "/", "device": "(volume/pc/rootfs)"},
+            {"mount": "/boot/", "device": "(volume/pc/boot)"},
+            {"mount": "/boot/efi/", "device": "(volume/pc/efi)"},
+        ]
+    )
+
+    grubutil.setup_grub(
+        image=image,
+        workdir=tmp_path / "work",
+        arch=DebianArchitecture.AMD64,
+        filesystem_mount=filesystem_mount,
+    )
+
+    with _mount_ext_partition(disk_path, "boot") as bootfs:
+        # The boot partition's *root* is /boot, so grub/kernels live directly
+        # at its root, not nested under an extra "boot/" directory.
+        entries = {entry.name for entry in bootfs.iterdir()}
+        assert "grub" in entries
+        assert "vmlinuz-6.8.0-generic" in entries
+        assert "initrd.img-6.8.0-generic" in entries
+        assert "boot" not in entries
+
+        cfg = (bootfs / "grub/grub.cfg").read_text()
+        # Paths in grub.cfg must not be prefixed with /boot, since the
+        # kernel/initrd already live at this partition's root.
+        assert "linux /vmlinuz-6.8.0-generic" in cfg
+        assert "linux /boot/vmlinuz-6.8.0-generic" not in cfg
+
+        boot_uuid = grubutil._read_ext_uuid(
+            disk_path,
+            gptutil.get_partition_sector_offset(disk_path, "boot") * 512,
+        )
+
+    root_uuid = grubutil._read_ext_uuid(
+        disk_path,
+        gptutil.get_partition_sector_offset(disk_path, "rootfs") * 512,
+    )
+
+    assert boot_uuid != root_uuid
+    # GRUB loads the kernel off the boot partition but boots the root one.
+    assert f"search --no-floppy --fs-uuid --set=root {boot_uuid}" in cfg
+    assert f"root=UUID={root_uuid}" in cfg
+
+    stub = _esp_type(disk_path, "/EFI/ubuntu/grub.cfg")
+    # The ESP stub has to chain to the config on the boot partition.
+    assert f"search.fs_uuid {boot_uuid} root" in stub
+    assert "set prefix=($root)'/grub'" in stub

--- a/tests/integration/pack/test_mbrutil.py
+++ b/tests/integration/pack/test_mbrutil.py
@@ -41,7 +41,13 @@ _VOLUME_SINGLE_SFDISK_EXPECTED = {
     "unit": "sectors",
     "sectorsize": 512,
     "partitions": [
-        {"node": "disk.img1", "start": 2048, "size": 4194304, "type": "83"},
+        {
+            "node": "disk.img1",
+            "start": 2048,
+            "size": 4194304,
+            "type": "83",
+            "bootable": True,
+        },
     ],
 }
 

--- a/tests/integration/plugins/test_mmdebstrap_plugin.py
+++ b/tests/integration/plugins/test_mmdebstrap_plugin.py
@@ -15,10 +15,19 @@
 #  with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Integration tests for the mmdebstrap plugin."""
 
+import platform
 from pathlib import Path
 
 import pytest
 from imagecraft import application
+
+
+def _host_is_noble() -> bool:
+    """Check if running on Ubuntu 24.04 (noble)."""
+    try:
+        return platform.freedesktop_os_release().get("VERSION_CODENAME") == "noble"
+    except (AttributeError, OSError):
+        return False
 
 
 @pytest.fixture
@@ -37,6 +46,11 @@ def test_mmdebstrap_cleanup(
     monkeypatch: pytest.MonkeyPatch,
 ):
     """Test that mmdebstrap plugin cleans up /sys, /proc and /dev."""
+    if not _host_is_noble():
+        pytest.skip(
+            "destructive-mode builds require the host series to match the "
+            "project's build-base (ubuntu@24.04)"
+        )
     monkeypatch.setattr(
         "sys.argv",
         ["imagecraft", "build", "--destructive-mode", "--verbosity", "debug"],

--- a/tests/integration/plugins/test_overlay_plugin.py
+++ b/tests/integration/plugins/test_overlay_plugin.py
@@ -14,6 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import platform
 from pathlib import Path
 from typing import Literal
 
@@ -23,6 +24,14 @@ from craft_parts.plugins import Plugin, PluginProperties
 from imagecraft import application
 from imagecraft.plugins import get_app_plugins
 from typing_extensions import override
+
+
+def _host_is_noble() -> bool:
+    """Check if running on Ubuntu 24.04 (noble)."""
+    try:
+        return platform.freedesktop_os_release().get("VERSION_CODENAME") == "noble"
+    except (AttributeError, OSError):
+        return False
 
 
 @pytest.fixture
@@ -84,6 +93,11 @@ def test_overlay_plugin(
     imagecraft_app: application.Imagecraft,
     monkeypatch: pytest.MonkeyPatch,
 ):
+    if not _host_is_noble():
+        pytest.skip(
+            "destructive-mode builds require the host series to match the "
+            "project's build-base (ubuntu@24.04)"
+        )
     monkeypatch.setattr(
         "sys.argv",
         ["imagecraft", "pack", "--destructive-mode", "--verbosity", "debug"],

--- a/tests/integration/utils/__init__.py
+++ b/tests/integration/utils/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2026 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.

--- a/tests/integration/utils/test_mount.py
+++ b/tests/integration/utils/test_mount.py
@@ -1,0 +1,320 @@
+# Copyright 2026 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import platform
+import shutil
+from pathlib import Path
+
+import pytest
+from imagecraft.models import FileSystem, GPTVolume, MBRVolume
+from imagecraft.pack import diskutil, gptutil, mbrutil
+from imagecraft.utils.mount import (
+    mount_partition,
+    mount_volume,
+)
+
+
+def _is_noble_non_amd64() -> bool:
+    """Check if running on Ubuntu Noble on a non-amd64 architecture.
+
+    The fusefat package is only available in Ubuntu universe repositories for
+    amd64 and i386 on Ubuntu 24.04 (Noble) and earlier. It was not built for
+    ARM64 or other non-x86 architectures on Noble.
+    """
+    if platform.machine() in ("x86_64", "AMD64"):
+        return False
+    try:
+        os_release = platform.freedesktop_os_release()
+        return os_release.get("VERSION_CODENAME") == "noble"
+    except (AttributeError, OSError):
+        pass
+    os_release_path = Path("/etc/os-release")
+    if os_release_path.exists():
+        for line in os_release_path.read_text().splitlines():
+            if line.startswith("VERSION_CODENAME="):
+                return line.split("=", 1)[1].strip("\"'") == "noble"
+    return False
+
+
+REQUIRED_EXECUTABLES: dict[str, str] = {
+    "fuse2fs": "fuse2fs",
+    "fusefile": "fusefile",
+    "fusermount3": "fuse3",
+}
+if not _is_noble_non_amd64():
+    REQUIRED_EXECUTABLES["fusefat"] = "fusefat"
+
+
+@pytest.fixture(autouse=True, scope="module")
+def check_required_executables() -> None:
+    missing: list[str] = [
+        f"{binary} (install package: {pkg})"
+        for binary, pkg in REQUIRED_EXECUTABLES.items()
+        if shutil.which(binary) is None
+    ]
+    if missing:
+        missing_str = "\n  - ".join(missing)
+        missing_pkgs = " ".join(
+            dict.fromkeys(
+                pkg
+                for binary, pkg in REQUIRED_EXECUTABLES.items()
+                if shutil.which(binary) is None
+            )
+        )
+        pytest.fail(
+            f"Missing required executables for FUSE integration tests:\n  - {missing_str}\n"
+            f"Install them with:\n  sudo apt-get install {missing_pkgs}"
+        )
+
+
+@pytest.fixture(
+    params=[
+        pytest.param(False, marks=pytest.mark.requires_root, id="as_root"),
+        pytest.param(True, id="with_fakeroot"),
+    ]
+)
+def fakeroot(request: pytest.FixtureRequest) -> bool:
+    return request.param
+
+
+@pytest.fixture(
+    params=[
+        pytest.param(
+            GPTVolume.unmarshal(
+                {
+                    "schema": "gpt",
+                    "structure": [
+                        {
+                            "name": "efi",
+                            "role": "system-boot",
+                            "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+                            "filesystem": "vfat",
+                            "size": "32M",
+                            "filesystem-label": "EFI",
+                        },
+                        {
+                            "name": "rootfs",
+                            "role": "system-data",
+                            "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                            "filesystem": "ext4",
+                            "size": "64M",
+                            "filesystem-label": "writable",
+                        },
+                    ],
+                }
+            ),
+            id="gpt",
+        ),
+        pytest.param(
+            MBRVolume.unmarshal(
+                {
+                    "schema": "mbr",
+                    "structure": [
+                        {
+                            "name": "ubuntu-seed",
+                            "role": "system-boot",
+                            "type": "0C",
+                            "filesystem": "vfat",
+                            "size": "32M",
+                            "filesystem-label": "seed",
+                        },
+                        {
+                            "name": "rootfs",
+                            "role": "system-data",
+                            "type": "83",
+                            "filesystem": "ext4",
+                            "size": "64M",
+                            "filesystem-label": "writable",
+                        },
+                    ],
+                }
+            ),
+            id="mbr",
+        ),
+    ]
+)
+def volume_definition(request: pytest.FixtureRequest) -> GPTVolume | MBRVolume:
+    return request.param
+
+
+@pytest.fixture(params=[pytest.param(fs, id=fs.value) for fs in FileSystem])
+def fstype(request: pytest.FixtureRequest) -> FileSystem:
+    return request.param
+
+
+def test_mount_partition_standalone(
+    tmp_path: Path,
+    fstype: FileSystem,
+    fakeroot: bool,  # noqa: FBT001
+):
+    if "fat" in fstype.value and _is_noble_non_amd64():
+        pytest.skip("fusefat is unavailable on noble on non-amd64 architectures")
+
+    img_path = tmp_path / f"standalone.{fstype.value}"
+    with img_path.open("wb") as f:
+        f.truncate(32 * 1024 * 1024)
+
+    content_dir = tmp_path / "empty_content"
+    content_dir.mkdir(exist_ok=True)
+    diskutil.format_populate_partition(
+        fstype=fstype,
+        content_dir=content_dir,
+        partitionpath=img_path,
+    )
+
+    mount = mount_partition(img_path, fstype, fakeroot=fakeroot)
+    with mount as root:
+        test_file = root / "hello.txt"
+        test_file.write_text(f"Hello {fstype.value} FUSE!\n")
+        sub_dir = root / "dir" / "subdir"
+        sub_dir.mkdir(parents=True)
+        (sub_dir / "data.bin").write_bytes(b"PAYLOAD_DATA")
+
+    assert not mount.is_mounted
+
+    # Verify data persisted across unmount
+    with mount as root:
+        assert (root / "hello.txt").read_text() == f"Hello {fstype.value} FUSE!\n"
+        assert (root / "dir" / "subdir" / "data.bin").read_bytes() == b"PAYLOAD_DATA"
+
+
+def test_mount_partition_offset(
+    tmp_path: Path,
+    fstype: FileSystem,
+    fakeroot: bool,  # noqa: FBT001
+):
+    if "fat" in fstype.value:
+        if _is_noble_non_amd64():
+            pytest.skip("fusefat is unavailable on noble on non-amd64 architectures")
+        if os.geteuid() != 0:
+            pytest.skip(
+                f"{fstype.value} offset mounts via fusefile require root permissions"
+            )
+
+    disk_path = tmp_path / f"disk_{fstype.value}.raw"
+    disk_size = 64 * 1024 * 1024
+    offset_bytes = 1048576  # 1 MiB
+    part_size_bytes = 32 * 1024 * 1024  # 32 MiB
+
+    with disk_path.open("wb") as f:
+        f.truncate(disk_size)
+
+    part_tmp = tmp_path / f"part_{fstype.value}.img"
+    with part_tmp.open("wb") as f:
+        f.truncate(part_size_bytes)
+    content_dir = tmp_path / "empty_content"
+    content_dir.mkdir(exist_ok=True)
+    diskutil.format_populate_partition(
+        fstype=fstype,
+        content_dir=content_dir,
+        partitionpath=part_tmp,
+    )
+
+    with part_tmp.open("rb") as src, disk_path.open("r+b") as dst:
+        dst.seek(offset_bytes)
+        dst.write(src.read())
+
+    part_tmp.unlink()
+
+    mount = mount_partition(
+        disk_path,
+        fstype,
+        offset=offset_bytes,
+        size=part_size_bytes,
+        fakeroot=fakeroot,
+    )
+
+    with mount as root:
+        (root / "config.txt").write_text(f"offset {fstype.value} config\n")
+        sub_dir = root / "sub"
+        sub_dir.mkdir(parents=True)
+        (sub_dir / "test.bin").write_bytes(b"OFFSET_BINARY")
+
+    assert not mount.is_mounted
+
+    # Verify persistence directly from the disk image at offset
+    with mount as root:
+        assert (root / "config.txt").read_text() == f"offset {fstype.value} config\n"
+        assert (root / "sub" / "test.bin").read_bytes() == b"OFFSET_BINARY"
+
+
+@pytest.mark.requires_root
+def test_volume_mount(
+    volume_definition: GPTVolume | MBRVolume,
+    tmp_path: Path,
+):
+    if _is_noble_non_amd64():
+        pytest.skip("fusefat is unavailable on noble on non-amd64 architectures")
+    disk_path = tmp_path / f"{volume_definition.volume_schema.value}_disk.raw"
+    sector_size = gptutil.SECTOR_SIZE_512
+
+    if isinstance(volume_definition, GPTVolume):
+        gptutil.create_empty_gpt_image(disk_path, sector_size, volume_definition)
+    else:
+        mbrutil.create_empty_mbr_image(disk_path, sector_size, volume_definition)
+
+    # Format and inject partitions into the image
+    for idx, item in enumerate(volume_definition.structure, start=1):
+        part_file = tmp_path / f"{item.name}.img"
+        with part_file.open("wb") as f:
+            f.truncate(int(item.size))
+        content_dir = tmp_path / f"{item.name}_content"
+        content_dir.mkdir(exist_ok=True)
+        diskutil.format_populate_partition(
+            fstype=item.filesystem,
+            content_dir=content_dir,
+            partitionpath=part_file,
+            label=item.filesystem_label,
+        )
+        if isinstance(volume_definition, GPTVolume):
+            start_sector = gptutil.get_partition_sector_offset(disk_path, item.name)
+        else:
+            start_sector = gptutil.get_partition_sector_offset_by_number(disk_path, idx)
+
+        diskutil.inject_partition_into_image(
+            partition=part_file,
+            imagepath=disk_path,
+            sector_offset=start_sector,
+            disk_size=diskutil.DiskSize(
+                bytesize=int(item.size), sector_size=sector_size
+            ),
+        )
+
+    # Mount full composite volume
+    with mount_volume(volume_definition, disk_path) as rootfs:
+        # Write to rootfs (ext4)
+        etc_dir = rootfs / "etc"
+        etc_dir.mkdir(parents=True, exist_ok=True)
+        (etc_dir / "hostname").write_text(
+            f"{volume_definition.volume_schema.value}-box\n"
+        )
+
+        # Write to EFI / boot partition (vfat, nested under /boot/efi)
+        efi_root = rootfs / "boot" / "efi"
+        if (efi_root / "EFI").is_file() and (efi_root / "EFI").stat().st_size == 0:
+            (efi_root / "EFI").unlink()
+
+        efi_boot = efi_root / "EFI" / "BOOT"
+        efi_boot.mkdir(parents=True, exist_ok=True)
+        (efi_boot / "grubx64.efi").write_bytes(b"GRUB_BINARY")
+
+    # Remount and verify both filesystems
+    with mount_volume(volume_definition, disk_path) as rootfs:
+        assert (rootfs / "etc" / "hostname").read_text() == (
+            f"{volume_definition.volume_schema.value}-box\n"
+        )
+        assert (
+            rootfs / "boot" / "efi" / "EFI" / "BOOT" / "grubx64.efi"
+        ).read_bytes() == b"GRUB_BINARY"

--- a/tests/spread/boot/classic-efi-secureboot/imagecraft.yaml
+++ b/tests/spread/boot/classic-efi-secureboot/imagecraft.yaml
@@ -1,0 +1,113 @@
+name: boot-test
+version: "0.1"
+summary: A test image to boot
+description: Runs a hello service and shuts down
+base: bare
+build-base: ubuntu@24.04
+
+platforms:
+  amd64:
+
+filesystems:
+  default:
+    - mount: /
+      device: (volume/pc/rootfs)
+    - mount: /boot/efi/
+      device: (volume/pc/efi)
+
+parts:
+  # build a simple rootfs
+  rootfs:
+    plugin: mmdebstrap
+    mmdebstrap-variant: "minbase"
+    mmdebstrap-packages:
+      - ubuntu-server-minimal
+      - grub2-common
+      - shim-signed
+      - linux-image-generic
+    override-build: |
+      craftctl default
+      mkdir -p $CRAFT_PART_INSTALL/boot/efi
+    organize:
+      "*": (overlay)/
+
+  efi-packages:
+    plugin: nil
+    after: [rootfs]
+    override-overlay: |
+      URL="http://archive.ubuntu.com/ubuntu"
+
+      echo "deb $URL noble main" > /etc/apt/sources.list
+      apt-get update
+      # grub-efi-amd64-signed ships a Canonical-signed grubx64.efi under
+      # /usr/lib/grub/x86_64-efi-signed, which grubutil deploys as-is
+      # (paired with signed shim) instead of building an unsigned image
+      # with grub-mkimage. This is what allows the image to boot with
+      # Secure Boot enabled.
+      apt-get install -y grub-efi-amd64-signed
+
+  disable-cloud-init:
+    plugin: nil
+    after: [rootfs]
+    override-overlay: |
+      touch /etc/cloud/cloud-init.disabled
+
+  fstab:
+    plugin: nil
+    after: [rootfs]
+    overlay-script: |
+      cat << EOF > $CRAFT_OVERLAY/etc/fstab
+      LABEL=writable	/	ext4	discard,errors=remount-ro	0	1
+      LABEL=UEFI	/boot/efi	vfat	umask=0077,x-systemd.device-timeout=300s	0 1
+      EOF
+
+  grub-menu:
+    plugin: nil
+    after: [rootfs]
+    override-overlay: |
+      cat << 'EOF' > /etc/default/grub
+      GRUB_TIMEOUT=0
+      GRUB_RECORDFAIL_TIMEOUT=0
+      GRUB_TIMEOUT_STYLE=hidden
+      GRUB_TERMINAL="console serial"
+      GRUB_SERIAL_COMMAND="serial --speed=115200 --unit=0 --word=8 --parity=no --stop=1"
+      GRUB_CMDLINE_LINUX_DEFAULT=""
+      GRUB_CMDLINE_LINUX="console=ttyS0,115200n8 console=tty1"
+      EOF
+
+  sentinel-service:
+    plugin: nil
+    after: [rootfs]
+    override-overlay: |
+      cat << EOF > /etc/systemd/system/boot-sentinel.service
+      [Unit]
+      Description=Boot sentinel
+
+      [Service]
+      Type=oneshot
+      ExecStart=/bin/bash -c 'echo HELLO FROM IMAGECRAFT > /var/lib/boot-sentinel.txt; echo HELLO FROM IMAGECRAFT > /dev/ttyS0 || true'
+      ExecStartPost=/sbin/poweroff
+
+      [Install]
+      WantedBy=multi-user.target
+      EOF
+
+      mkdir -p /etc/systemd/system/multi-user.target.wants
+      ln -sf /etc/systemd/system/boot-sentinel.service /etc/systemd/system/multi-user.target.wants/boot-sentinel.service
+
+volumes:
+  pc:
+    schema: gpt
+    structure:
+      - name: efi
+        type: C12A7328-F81F-11D2-BA4B-00A0C93EC93B
+        filesystem: vfat
+        role: system-boot
+        filesystem-label: UEFI
+        size: 256M
+      - name: rootfs
+        type: 0FC63DAF-8483-4772-8E79-3D69D8477DE4
+        filesystem: ext4
+        filesystem-label: writable
+        role: system-data
+        size: 3G

--- a/tests/spread/boot/classic-efi-secureboot/task.yaml
+++ b/tests/spread/boot/classic-efi-secureboot/task.yaml
@@ -1,0 +1,41 @@
+summary: Boot classic EFI image with Secure Boot enabled in QEMU
+
+systems: [ubuntu-24.04-64]
+
+prepare: |
+  tests.pkgs install qemu-system-x86 ovmf
+
+execute: |
+  imagecraft pack --destructive-mode
+
+  QEMU_BIN="qemu-system-x86_64"
+  # OVMF's "secboot" firmware build enforces Secure Boot policy, and the
+  # "ms" vars template ships the Microsoft UEFI CA that signs Canonical's
+  # shim/grub, so this is the combination that actually validates our
+  # signed boot chain rather than just booting with Secure Boot disabled.
+  UEFI_CODE=/usr/share/OVMF/OVMF_CODE_4M.secboot.fd
+  UEFI_VARS=/usr/share/OVMF/OVMF_VARS_4M.ms.fd
+  cp "$UEFI_VARS" /tmp/uefi_vars.fd
+
+  IMG_NAME=pc.img
+  test -f ${IMG_NAME}
+
+  script -q -c "$QEMU_BIN \
+    -accel kvm -accel tcg,thread=multi \
+    -smp \"\$(nproc)\" \
+    -nographic \
+    -m 1G \
+    -global driver=cfi.pflash01,property=secure,value=on \
+    -machine q35,smm=on \
+    -drive if=pflash,format=raw,unit=0,readonly=on,file=$UEFI_CODE \
+    -drive if=pflash,format=raw,unit=1,file=/tmp/uefi_vars.fd \
+    -drive file=${IMG_NAME},format=raw,index=0,if=virtio,cache=unsafe" output.log || true
+
+  MATCH "HELLO FROM IMAGECRAFT" output.log
+
+restore: |
+  imagecraft clean --destructive-mode || true
+  rm -f pc.img output.log /tmp/uefi_vars.fd
+
+debug: |
+  cat output.log 2>/dev/null || echo "No serial output log"

--- a/tests/spread/boot/classic-efi/imagecraft.yaml
+++ b/tests/spread/boot/classic-efi/imagecraft.yaml
@@ -67,8 +67,13 @@ parts:
     after: [rootfs]
     override-overlay: |
       cat << 'EOF' > /etc/default/grub
-      GRUB_TIMEOUT=1
+      GRUB_TIMEOUT=0
+      GRUB_RECORDFAIL_TIMEOUT=0
       GRUB_TIMEOUT_STYLE=hidden
+      GRUB_TERMINAL="console serial"
+      GRUB_SERIAL_COMMAND="serial --speed=115200 --unit=0 --word=8 --parity=no --stop=1"
+      GRUB_CMDLINE_LINUX_DEFAULT=""
+      GRUB_CMDLINE_LINUX="console=ttyS0,115200n8 console=tty1"
       EOF
 
   sentinel-service:
@@ -84,18 +89,18 @@ parts:
       cat << EOF > /etc/systemd/system/boot-sentinel.service
       [Unit]
       Description=Boot sentinel
-      After=multi-user.target
 
       [Service]
       Type=oneshot
-      ExecStart=/bin/bash -c 'echo HELLO FROM IMAGECRAFT > $SERIAL_CONSOLE'
+      ExecStart=/bin/bash -c 'echo HELLO FROM IMAGECRAFT > /var/lib/boot-sentinel.txt; echo HELLO FROM IMAGECRAFT > $SERIAL_CONSOLE || true'
       ExecStartPost=/sbin/poweroff
 
       [Install]
       WantedBy=multi-user.target
       EOF
 
-      systemctl enable boot-sentinel.service
+      mkdir -p /etc/systemd/system/multi-user.target.wants
+      ln -sf /etc/systemd/system/boot-sentinel.service /etc/systemd/system/multi-user.target.wants/boot-sentinel.service
 
 volumes:
   pc:

--- a/tests/spread/boot/classic-efi/task.yaml
+++ b/tests/spread/boot/classic-efi/task.yaml
@@ -1,4 +1,4 @@
-summary: Boot classic image in QEMU
+summary: Boot classic EFI image in QEMU
 
 systems: [ubuntu-24.04-64, ubuntu-24.04-arm-64]
 
@@ -31,18 +31,17 @@ execute: |
     echo "Unsupported arch: $ARCH"
     exit 1
   fi
-
   cp "$UEFI_VARS" /tmp/uefi_vars.fd
 
-  $QEMU_BIN \
+  script -q -c "$QEMU_BIN \
     $QEMU_ARGS \
     -accel kvm -accel tcg,thread=multi \
-    -smp "$(nproc)" \
+    -smp \"\$(nproc)\" \
     -nographic \
     -m 1G \
     -drive if=pflash,format=raw,readonly=on,file=$UEFI_CODE \
     -drive if=pflash,format=raw,file=/tmp/uefi_vars.fd \
-    -drive file=pc.img,format=raw,index=0,if=virtio 2>&1 | tee output.log || true
+    -drive file=pc.img,format=raw,index=0,if=virtio,cache=unsafe" output.log || true
 
   MATCH "HELLO FROM IMAGECRAFT" output.log
 

--- a/tests/spread/pack/mbr-grub/task.yaml
+++ b/tests/spread/pack/mbr-grub/task.yaml
@@ -29,6 +29,19 @@ execute: |
 
   LOOP=$(losetup --find --show --partscan ${IMG_NAME})
   echo $LOOP > loop.txt
+
+  # Partition devices are created asynchronously by the kernel after the
+  # partscan ioctl; wait for them to appear before using them.
+  count=0
+  until ls -d "$LOOP"p* >/dev/null 2>&1; do
+    count=$((count + 1))
+    if [ "$count" -ge 100 ]; then
+      echo "Timed out waiting for $LOOP partition devices" >&2
+      exit 1
+    fi
+    sleep 0.1
+  done
+
   for l in $(ls -d "$LOOP"p*)
   do
       p=${l#"$LOOP"}

--- a/tests/unit/pack/test_grubutil.py
+++ b/tests/unit/pack/test_grubutil.py
@@ -12,7 +12,18 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import contextlib
+"""Tests for imagecraft.pack.grubutil.
+
+This module covers the pure-logic parts of ``setup_grub``: skip/dispatch
+conditions and small helpers like ``_part_num``, ``_generate_grub_cfg``,
+``_read_grub_defaults``, ``_find_kernels`` and ``_dump_signed_efi_binaries``
+against plain directory trees.
+
+The full end-to-end flow (real disk images, FUSE mounts, chroot) is covered
+by ``tests/integration/pack/test_grubutil.py``.
+"""
+
+import shutil
 from pathlib import Path
 from typing import cast
 from unittest.mock import MagicMock
@@ -20,8 +31,7 @@ from unittest.mock import MagicMock
 import pytest
 from craft_parts.filesystem_mounts import FilesystemMount
 from craft_platforms import DebianArchitecture
-from imagecraft.errors import ImageError
-from imagecraft.models import Volume
+from imagecraft import errors
 from imagecraft.models.volume import (
     GPTStructureItem,
     GPTStructureList,
@@ -30,92 +40,39 @@ from imagecraft.models.volume import (
     MBRStructureList,
     MBRVolume,
 )
-from imagecraft.pack.chroot import Mount
-from imagecraft.pack.grubutil import _image_mounts, _part_num, setup_grub
+from imagecraft.pack import grubutil
 from imagecraft.pack.image import Image
 
-
-@pytest.fixture
-def volume():
-    return GPTVolume.unmarshal(
-        {
-            "schema": "gpt",
-            "structure": [
-                {
-                    "name": "efi",
-                    "role": "system-boot",
-                    "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
-                    "filesystem": "vfat",
-                    "size": "3G",
-                    "filesystem-label": "",
-                },
-                {
-                    "name": "boot",
-                    "role": "system-boot",
-                    "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
-                    "filesystem": "fat16",
-                    "size": "6G",
-                },
-                {
-                    "name": "rootfs",
-                    "role": "system-data",
-                    "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
-                    "filesystem": "ext4",
-                    "size": "0",
-                    "filesystem-label": "writable",
-                },
-            ],
-        }
-    )
-
-
-@contextlib.contextmanager
-def fake_loopdev_handler():
-    yield "loop99"
-
-
-@pytest.mark.parametrize(
-    ("filesystem_mount"),
-    [
-        FilesystemMount.unmarshal(
-            [
-                {"mount": "/", "device": "(volume/pc/rootfs)"},
-                {"mount": "/boot", "device": "(volume/pc/boot)"},
-                {"mount": "/boot/efi", "device": "(volume/pc/efi)"},
-            ]
-        ),
-        FilesystemMount.unmarshal(
-            [
-                {"mount": "/", "device": "(volume/pc/rootfs)"},
-                {"mount": "/boot/efi", "device": "(volume/pc/efi)"},
-            ]
-        ),
-    ],
+# Real tools this module's implementation shells out to. If any of these is
+# missing, the tests below fail (rather than silently skip) with a message
+# pointing at `make setup`, since these are declared dependencies of the
+# project (see snap/snapcraft.yaml and Makefile's APT_PACKAGES).
+_REQUIRED_TOOLS = (
+    "sfdisk",
+    "mke2fs",
+    "mkfs.vfat",
+    "dd",
 )
-@pytest.mark.usefixtures("new_dir")
-def test_setup_grub(mocker, new_dir, volume, filesystem_mount):
-    disk_path = Path(new_dir, "pc.img")
-    disk_path.touch(exist_ok=True)
-    image = Image(
-        volume=volume,
-        disk_path=disk_path,
-    )
-    workdir = Path(new_dir, "workdir")
-    workdir.mkdir()
-    mock_chroot = mocker.patch("imagecraft.pack.grubutil.Chroot")
-    mocker.patch.object(image, "attach_loopdev", side_effect=fake_loopdev_handler)
 
-    setup_grub(
-        image=image,
-        workdir=workdir,
-        arch=DebianArchitecture.AMD64,
-        filesystem_mount=filesystem_mount,
-    )
 
-    assert mock_chroot.return_value.execute.called
-    assert (
-        mock_chroot.return_value.execute.call_args.kwargs["grub_target"] == "x86_64-efi"
-    )
+@pytest.fixture(autouse=True, scope="session")
+def _require_grub_tools():
+    """Fail loudly if a real tool used by grubutil/imgfs is missing.
+
+    These aren't optional test-only dependencies: they're the actual tools
+    imagecraft's GRUB installation code shells out to, so a developer
+    machine missing them needs `make setup` regardless of these tests.
+    """
+    missing = [tool for tool in _REQUIRED_TOOLS if shutil.which(tool) is None]
+    if missing:
+        pytest.fail(
+            "Missing required tool(s) for grubutil tests: "
+            f"{', '.join(missing)}. Run `make setup` to install them.",
+            pytrace=False,
+        )
+
+
+# ── setup_grub: skip conditions and dispatch (mocked, no real tools) ──────
 
 
 @pytest.mark.parametrize(
@@ -131,7 +88,7 @@ def test_setup_grub(mocker, new_dir, volume, filesystem_mount):
                             "role": "system-data",
                             "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
                             "filesystem": "ext4",
-                            "size": "0",
+                            "size": "512M",
                             "filesystem-label": "writable",
                         },
                     ],
@@ -150,7 +107,7 @@ def test_setup_grub(mocker, new_dir, volume, filesystem_mount):
                             "role": "system-boot",
                             "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
                             "filesystem": "vfat",
-                            "size": "3G",
+                            "size": "64M",
                             "filesystem-label": "",
                         },
                     ],
@@ -169,7 +126,7 @@ def test_setup_grub(mocker, new_dir, volume, filesystem_mount):
                             "role": "system-boot",
                             "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
                             "filesystem": "vfat",
-                            "size": "3G",
+                            "size": "64M",
                             "filesystem-label": "",
                         },
                         {
@@ -177,7 +134,7 @@ def test_setup_grub(mocker, new_dir, volume, filesystem_mount):
                             "role": "system-data",
                             "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
                             "filesystem": "ext4",
-                            "size": "0",
+                            "size": "512M",
                             "filesystem-label": "writable",
                         },
                     ],
@@ -210,18 +167,11 @@ def test_setup_grub(mocker, new_dir, volume, filesystem_mount):
                     "schema": "mbr",
                     "structure": [
                         {
-                            "name": "boot",
-                            "role": "system-boot",
-                            "type": "83",
-                            "filesystem": "ext4",
-                            "size": "512M",
-                        },
-                        {
                             "name": "rootfs",
                             "role": "system-data",
                             "type": "83",
                             "filesystem": "ext4",
-                            "size": "5G",
+                            "size": "512M",
                         },
                     ],
                 }
@@ -232,7 +182,8 @@ def test_setup_grub(mocker, new_dir, volume, filesystem_mount):
     ],
 )
 @pytest.mark.usefixtures("new_dir")
-def test_setup_grub_partitions(mocker, new_dir, volume, arch, emitter, message):
+def test_setup_grub_skip_conditions(mocker, new_dir, volume, arch, emitter, message):
+    """setup_grub emits a permanent progress message and returns without acting."""
     disk_path = Path(new_dir, "pc.img")
     disk_path.touch(exist_ok=True)
     filesystem_mount = FilesystemMount.unmarshal(
@@ -240,209 +191,159 @@ def test_setup_grub_partitions(mocker, new_dir, volume, arch, emitter, message):
             {"mount": "/", "device": "(volume/pc/rootfs)"},
         ]
     )
-    image = Image(
-        volume=volume,
-        disk_path=disk_path,
-    )
+    image = Image(volume=volume, disk_path=disk_path)
     workdir = Path(new_dir, "workdir")
     workdir.mkdir()
-    mock_chroot = mocker.patch("imagecraft.pack.grubutil.Chroot")
-    mocker.patch.object(image, "attach_loopdev", side_effect=fake_loopdev_handler)
+    setup_efi = mocker.patch("imagecraft.pack.grubutil._setup_grub_efi")
+    setup_bios = mocker.patch("imagecraft.pack.grubutil._setup_grub_bios_chroot")
 
-    setup_grub(
+    grubutil.setup_grub(
         image=image, workdir=workdir, arch=arch, filesystem_mount=filesystem_mount
     )
 
-    mock_chroot.return_value.execute.assert_not_called()
-
+    setup_efi.assert_not_called()
+    setup_bios.assert_not_called()
     emitter.assert_progress(message, permanent=True)
 
 
-_MBR_VOLUME_WITH_BOOT = MBRVolume.unmarshal(
-    {
-        "schema": "mbr",
-        "structure": [
-            {
-                "name": "boot",
-                "role": "system-boot",
-                "type": "83",
-                "filesystem": "ext4",
-                "size": "512M",
-            },
-            {
-                "name": "rootfs",
-                "role": "system-data",
-                "type": "83",
-                "filesystem": "ext4",
-                "size": "5G",
-            },
-        ],
-    }
-)
-
-
-@pytest.mark.parametrize(
-    "arch",
-    [DebianArchitecture.AMD64, DebianArchitecture.I386],
-)
 @pytest.mark.usefixtures("new_dir")
-def test_setup_grub_mbr_bios(mocker, new_dir, arch):
+def test_setup_grub_dispatches_to_efi(mocker, new_dir):
+    volume = GPTVolume.unmarshal(
+        {
+            "schema": "gpt",
+            "structure": [
+                {
+                    "name": "efi",
+                    "role": "system-boot",
+                    "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                    "filesystem": "vfat",
+                    "size": "64M",
+                    "filesystem-label": "",
+                },
+                {
+                    "name": "rootfs",
+                    "role": "system-data",
+                    "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                    "filesystem": "ext4",
+                    "size": "512M",
+                    "filesystem-label": "writable",
+                },
+            ],
+        }
+    )
     disk_path = Path(new_dir, "pc.img")
     disk_path.touch(exist_ok=True)
-    image = Image(volume=_MBR_VOLUME_WITH_BOOT, disk_path=disk_path)
-    workdir = Path(new_dir, "workdir")
-    workdir.mkdir()
-    mock_chroot = mocker.patch("imagecraft.pack.grubutil.Chroot")
-    mocker.patch.object(image, "attach_loopdev", side_effect=fake_loopdev_handler)
     filesystem_mount = FilesystemMount.unmarshal(
         [
             {"mount": "/", "device": "(volume/pc/rootfs)"},
-            {"mount": "/boot", "device": "(volume/pc/boot)"},
+            {"mount": "/boot/efi", "device": "(volume/pc/efi)"},
         ]
     )
+    image = Image(volume=volume, disk_path=disk_path)
+    workdir = Path(new_dir, "workdir")
+    workdir.mkdir()
+    setup_efi = mocker.patch("imagecraft.pack.grubutil._setup_grub_efi")
 
-    setup_grub(
+    grubutil.setup_grub(
+        image=image,
+        workdir=workdir,
+        arch=DebianArchitecture.AMD64,
+        filesystem_mount=filesystem_mount,
+    )
+
+    setup_efi.assert_called_once_with(image, "x86_64-efi", filesystem_mount)
+
+
+@pytest.mark.parametrize("arch", [DebianArchitecture.AMD64, DebianArchitecture.I386])
+@pytest.mark.usefixtures("new_dir")
+def test_setup_grub_dispatches_to_bios(mocker, new_dir, arch):
+    volume = MBRVolume.unmarshal(
+        {
+            "schema": "mbr",
+            "structure": [
+                {
+                    "name": "rootfs",
+                    "role": "system-data",
+                    "type": "83",
+                    "filesystem": "ext4",
+                    "size": "512M",
+                },
+            ],
+        }
+    )
+    disk_path = Path(new_dir, "pc.img")
+    disk_path.touch(exist_ok=True)
+    filesystem_mount = FilesystemMount.unmarshal(
+        [{"mount": "/", "device": "(volume/pc/rootfs)"}]
+    )
+    image = Image(volume=volume, disk_path=disk_path)
+    workdir = Path(new_dir, "workdir")
+    workdir.mkdir()
+    setup_bios = mocker.patch("imagecraft.pack.grubutil._setup_grub_bios_chroot")
+
+    grubutil.setup_grub(
         image=image, workdir=workdir, arch=arch, filesystem_mount=filesystem_mount
     )
 
-    assert mock_chroot.return_value.execute.called
-    assert mock_chroot.return_value.execute.call_args.kwargs["grub_target"] == "i386-pc"
+    # BIOS/MBR still installs GRUB through a chroot until it is converted
+    # to direct disk image manipulation.
+    setup_bios.assert_called_once_with(image, workdir, "i386-pc", filesystem_mount)
 
 
-@pytest.mark.parametrize(
-    ("loop_dev", "volume", "filesystem_mount", "mounts"),
-    [
-        (
-            "/dev/loop99",
-            GPTVolume.unmarshal(
+@pytest.mark.usefixtures("new_dir")
+def test_setup_grub_catches_image_error(mocker, new_dir, emitter):
+    """A raised ImageError (e.g. missing mount) is turned into a progress message."""
+
+    volume = GPTVolume.unmarshal(
+        {
+            "schema": "gpt",
+            "structure": [
                 {
-                    "schema": "gpt",
-                    "structure": [
-                        {
-                            "name": "efi",
-                            "role": "system-boot",
-                            "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
-                            "filesystem": "vfat",
-                            "size": "3G",
-                            "filesystem-label": "",
-                        },
-                        {
-                            "name": "rootfs",
-                            "role": "system-data",
-                            "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
-                            "filesystem": "ext4",
-                            "size": "0",
-                            "filesystem-label": "writable",
-                        },
-                    ],
-                }
-            ),
-            FilesystemMount.unmarshal(
-                [
-                    {"mount": "/", "device": "(volume/pc/rootfs)"},
-                    {"mount": "/boot/efi", "device": "(volume/pc/efi)"},
-                ]
-            ),
-            [
-                Mount(
-                    fstype=None,
-                    src="/dev/loop99p2",
-                    relative_mountpoint="/",
-                ),
-                Mount(
-                    fstype=None,
-                    src="/dev/loop99p1",
-                    relative_mountpoint="/boot/efi",
-                ),
+                    "name": "efi",
+                    "role": "system-boot",
+                    "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                    "filesystem": "vfat",
+                    "size": "64M",
+                    "filesystem-label": "",
+                },
+                {
+                    "name": "rootfs",
+                    "role": "system-data",
+                    "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                    "filesystem": "ext4",
+                    "size": "512M",
+                    "filesystem-label": "writable",
+                },
             ],
-        ),
-        (
-            "/dev/loop99",
-            GPTVolume.unmarshal(
-                {
-                    "schema": "gpt",
-                    "structure": [
-                        {
-                            "name": "efi",
-                            "role": "system-boot",
-                            "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
-                            "filesystem": "vfat",
-                            "size": "3G",
-                            "filesystem-label": "",
-                        },
-                        {
-                            "name": "rootfs",
-                            "role": "system-data",
-                            "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
-                            "filesystem": "ext4",
-                            "size": "0",
-                            "filesystem-label": "writable",
-                        },
-                    ],
-                }
-            ),
-            FilesystemMount.unmarshal(
-                [
-                    {"mount": "/", "device": "(volume/pc/rootfs)"},
-                ]
-            ),
-            [
-                Mount(
-                    fstype=None,
-                    src="/dev/loop99p2",
-                    relative_mountpoint="/",
-                ),
-            ],
-        ),
-    ],
-)
-def test_image_mounts(
-    loop_dev: str,
-    volume: Volume,
-    filesystem_mount: FilesystemMount,
-    mounts: list[Mount],
-):
-    assert _image_mounts(loop_dev, volume.structure, filesystem_mount) == mounts
+        }
+    )
+    disk_path = Path(new_dir, "pc.img")
+    disk_path.touch(exist_ok=True)
+    filesystem_mount = FilesystemMount.unmarshal(
+        [
+            {"mount": "/", "device": "(volume/pc/rootfs)"},
+            {"mount": "/boot/efi", "device": "(volume/pc/efi)"},
+        ]
+    )
+    image = Image(volume=volume, disk_path=disk_path)
+    workdir = Path(new_dir, "workdir")
+    workdir.mkdir()
+    mocker.patch(
+        "imagecraft.pack.grubutil._setup_grub_efi",
+        side_effect=errors.ImageError(message="boom"),
+    )
+
+    grubutil.setup_grub(
+        image=image,
+        workdir=workdir,
+        arch=DebianArchitecture.AMD64,
+        filesystem_mount=filesystem_mount,
+    )
+
+    emitter.assert_progress("Cannot install GRUB on this rootfs: boom", permanent=True)
 
 
-@pytest.mark.parametrize(
-    ("loop_dev", "volume", "filesystem_mount"),
-    [
-        (
-            "/dev/loop99",
-            GPTVolume.unmarshal(
-                {
-                    "schema": "gpt",
-                    "structure": [
-                        {
-                            "name": "rootfs",
-                            "role": "system-data",
-                            "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
-                            "filesystem": "ext4",
-                            "size": "0",
-                            "filesystem-label": "writable",
-                        },
-                    ],
-                }
-            ),
-            FilesystemMount.unmarshal(
-                [
-                    {"mount": "/", "device": "(volume/pc/not-matching)"},
-                ]
-            ),
-        ),
-    ],
-)
-def test_image_mounts_errors(
-    loop_dev: str,
-    volume: Volume,
-    filesystem_mount: FilesystemMount,
-):
-    with pytest.raises(ImageError, match="Cannot find a partition named"):
-        _image_mounts(loop_dev, volume.structure, filesystem_mount)
-
-
-# ── _part_num ─────────────────────────────────────────────────────────────────
+# ── _part_num ───────────────────────────────────────────────────────────────
 
 
 @pytest.mark.parametrize(
@@ -483,7 +384,7 @@ def test_part_num_gpt(name, structure_spec, expected):
         items.append(item)
     structure = cast(GPTStructureList, items)
 
-    assert _part_num(name, structure) == expected
+    assert grubutil._part_num(name, structure) == expected
 
 
 def test_part_num_mbr_plain():
@@ -494,9 +395,9 @@ def test_part_num_mbr_plain():
     for i, name in enumerate(["boot", "data", "rootfs"]):
         structure[i].name = name
 
-    assert _part_num("boot", structure) == 1
-    assert _part_num("data", structure) == 2
-    assert _part_num("rootfs", structure) == 3
+    assert grubutil._part_num("boot", structure) == 1
+    assert grubutil._part_num("data", structure) == 2
+    assert grubutil._part_num("rootfs", structure) == 3
 
 
 def test_part_num_mbr_extended():
@@ -507,9 +408,238 @@ def test_part_num_mbr_extended():
     for i, name in enumerate(["boot", "p2", "p3", "logical1", "logical2"]):
         structure[i].name = name
 
-    assert _part_num("boot", structure) == 1
-    assert _part_num("p2", structure) == 2
-    assert _part_num("p3", structure) == 3
+    assert grubutil._part_num("boot", structure) == 1
+    assert grubutil._part_num("p2", structure) == 2
+    assert grubutil._part_num("p3", structure) == 3
     # slot 4 is the synthesised extended container — logical partitions start at 5
-    assert _part_num("logical1", structure) == 5
-    assert _part_num("logical2", structure) == 6
+    assert grubutil._part_num("logical1", structure) == 5
+    assert grubutil._part_num("logical2", structure) == 6
+
+
+def test_partition_name_from_device():
+    assert grubutil._partition_name_from_device("(volume/pc/rootfs)") == "rootfs"
+
+
+# ── Small pure-logic helpers ─────────────────────────────────────────────
+
+
+def test_generate_grub_cfg_no_kernels():
+    cfg = grubutil._generate_grub_cfg([], "some-uuid", "some-uuid", "/boot")
+    assert "search --no-floppy --fs-uuid --set=root some-uuid" in cfg
+    assert "menuentry" not in cfg
+
+
+def test_generate_grub_cfg_with_kernel_and_boot_prefix():
+    cfg = grubutil._generate_grub_cfg(
+        [("vmlinuz-1", "initrd.img-1")], "uuid-x", "uuid-x", "/boot"
+    )
+    assert 'menuentry "vmlinuz-1"' in cfg
+    assert "linux /boot/vmlinuz-1 root=UUID=uuid-x ro" in cfg
+    assert "initrd /boot/initrd.img-1" in cfg
+
+
+def test_generate_grub_cfg_with_separate_boot_partition_has_no_prefix():
+    """When /boot is its own partition, paths aren't prefixed with /boot."""
+    cfg = grubutil._generate_grub_cfg([("vmlinuz-1", "")], "uuid-x", "uuid-boot", "")
+    assert "linux /vmlinuz-1 root=UUID=uuid-x ro" in cfg
+    assert "initrd" not in cfg
+
+
+def test_generate_grub_cfg_searches_boot_partition_not_root():
+    """The kernel lives on /boot, so GRUB has to select that partition."""
+    cfg = grubutil._generate_grub_cfg([("vmlinuz-1", "")], "uuid-root", "uuid-boot", "")
+    assert "search --no-floppy --fs-uuid --set=root uuid-boot" in cfg
+    assert "root=UUID=uuid-root" in cfg
+
+
+def test_generate_grub_cfg_appends_configured_cmdline():
+    """Kernel arguments from /etc/default/grub end up on the linux line."""
+    cfg = grubutil._generate_grub_cfg(
+        [("vmlinuz-1", "")],
+        "uuid-x",
+        "uuid-x",
+        "/boot",
+        grubutil.GrubDefaults(cmdline="console=ttyS0 quiet"),
+    )
+    assert "linux /boot/vmlinuz-1 root=UUID=uuid-x ro console=ttyS0 quiet" in cfg
+
+
+def _root_tree_with(tmp_path, content: str) -> Path:
+    """Make a fake rootfs tree whose /etc/default/grub reads back as `content`."""
+    rootfs = tmp_path / "rootfs"
+    (rootfs / "etc/default").mkdir(parents=True)
+    (rootfs / "etc/default/grub").write_text(content)
+    return rootfs
+
+
+def test_read_grub_defaults_missing_file(tmp_path):
+    rootfs = tmp_path / "rootfs"
+    rootfs.mkdir()
+    assert grubutil._read_grub_defaults(rootfs) == grubutil.GrubDefaults()
+
+
+@pytest.mark.parametrize(
+    ("content", "expected"),
+    [
+        ('GRUB_CMDLINE_LINUX_DEFAULT="quiet splash"\n', "quiet splash"),
+        ('GRUB_CMDLINE_LINUX="console=ttyS0"\n', "console=ttyS0"),
+        (
+            (
+                'GRUB_CMDLINE_LINUX="console=ttyS0"\n'
+                'GRUB_CMDLINE_LINUX_DEFAULT="quiet"\n'
+            ),
+            "console=ttyS0 quiet",
+        ),
+        ("GRUB_CMDLINE_LINUX='single'\n", "single"),
+        ("GRUB_CMDLINE_LINUX=nomodeset\n", "nomodeset"),
+        ('#GRUB_CMDLINE_LINUX="ignored"\n', ""),
+        ('GRUB_CMDLINE_LINUX=""\n', ""),
+        ("GRUB_TIMEOUT=5\n", ""),
+        ('export GRUB_CMDLINE_LINUX="console=ttyS0"\n', "console=ttyS0"),
+        ("export GRUB_CMDLINE_LINUX=nomodeset\n", "nomodeset"),
+        (
+            (
+                'GRUB_CMDLINE_LINUX="console=ttyS0"\n'
+                'GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX quiet"\n'
+            ),
+            "console=ttyS0 quiet",
+        ),
+        (
+            (
+                'GRUB_CMDLINE_LINUX="console=ttyS0"\n'
+                'GRUB_CMDLINE_LINUX_DEFAULT="${GRUB_CMDLINE_LINUX} splash"\n'
+            ),
+            "console=ttyS0 console=ttyS0 splash",
+        ),
+        ("GRUB_CMDLINE_LINUX='$GRUB_TIMEOUT'\n", "$GRUB_TIMEOUT"),
+        ('GRUB_CMDLINE_LINUX="$UNSET_ELSEWHERE quiet"\n', "$UNSET_ELSEWHERE quiet"),
+        ('GRUB_CMDLINE_LINUX="console=ttyS0 \\\n    quiet"\n', "console=ttyS0 quiet"),
+        ("GRUB_CMDLINE_LINUX=nomodeset\\\n\n", "nomodeset"),
+        ('GRUB_CMDLINE_LINUX="a"\nGRUB_CMDLINE_LINUX="b"\n', "b"),
+    ],
+)
+def test_read_grub_defaults_cmdline(tmp_path, content, expected):
+    rootfs = _root_tree_with(tmp_path, content)
+    assert grubutil._read_grub_defaults(rootfs).cmdline == expected
+
+
+def _root_tree_with_shim(
+    tmp_path, files: dict[str, bytes], links: dict[str, str]
+) -> Path:
+    """Build a fake rootfs tree with regular files and (possibly dangling) links."""
+    rootfs = tmp_path / "rootfs"
+    for path, data in files.items():
+        dest = rootfs / path.lstrip("/")
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_bytes(data)
+    for link, target in links.items():
+        dest = rootfs / link.lstrip("/")
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.symlink_to(target)
+    return rootfs
+
+
+def test_dump_signed_efi_binaries_follows_symlinked_shim(tmp_path):
+    """Ubuntu ships /usr/lib/shim/shimx64.efi.signed as a symlink."""
+    rootfs = _root_tree_with_shim(
+        tmp_path,
+        {
+            "/usr/lib/shim/shimx64.efi.signed.real": b"shim binary",
+            "/usr/lib/grub/x86_64-efi-signed/grubx64.efi.signed": b"grub binary",
+        },
+        {"/usr/lib/shim/shimx64.efi.signed": "shimx64.efi.signed.real"},
+    )
+
+    result = grubutil._dump_signed_efi_binaries(rootfs, "x86_64-efi", tmp_path / "out")
+
+    assert result is not None
+    assert result["shim"].read_bytes() == b"shim binary"
+    assert result["grub"].read_bytes() == b"grub binary"
+
+
+def test_dump_signed_efi_binaries_skips_dangling_shim_symlink(tmp_path):
+    """A dangling link must not be deployed as an empty (unbootable) binary."""
+    rootfs = _root_tree_with_shim(
+        tmp_path,
+        {"/usr/lib/grub/x86_64-efi-signed/grubx64.efi.signed": b"grub binary"},
+        {"/usr/lib/shim/shimx64.efi.signed": "gone.efi"},
+    )
+
+    assert (
+        grubutil._dump_signed_efi_binaries(rootfs, "x86_64-efi", tmp_path / "out")
+        is None
+    )
+
+
+@pytest.mark.parametrize(
+    ("content", "expected"),
+    [
+        ("GRUB_TIMEOUT=0\n", 0),
+        ('GRUB_TIMEOUT="10"\n', 10),
+        ("GRUB_TIMEOUT=-1\n", -1),
+        ("GRUB_TIMEOUT=forever\n", 5),
+        ("#GRUB_TIMEOUT=0\n", 5),
+        ("", 5),
+    ],
+)
+def test_read_grub_defaults_timeout(tmp_path, content, expected):
+    rootfs = _root_tree_with(tmp_path, content)
+    assert grubutil._read_grub_defaults(rootfs).timeout == expected
+
+
+def test_find_kernels_orders_newest_first(tmp_path):
+    """`set default=0` boots the first entry, which has to be the newest kernel."""
+    boot_dir = tmp_path / "boot"
+    boot_dir.mkdir()
+    for name in (
+        "vmlinuz-6.8.0-9-generic",
+        "initrd.img-6.8.0-9-generic",
+        "vmlinuz-6.8.0-100-generic",
+        "initrd.img-6.8.0-100-generic",
+        "vmlinuz-6.11.0-1-generic",
+    ):
+        (boot_dir / name).write_bytes(b"k")
+
+    kernels = grubutil._find_kernels(tmp_path, "/boot")
+
+    assert kernels == [
+        ("vmlinuz-6.11.0-1-generic", ""),
+        ("vmlinuz-6.8.0-100-generic", "initrd.img-6.8.0-100-generic"),
+        ("vmlinuz-6.8.0-9-generic", "initrd.img-6.8.0-9-generic"),
+    ]
+
+
+def test_generate_grub_cfg_uses_configured_timeout():
+    cfg = grubutil._generate_grub_cfg(
+        [], "uuid-x", "uuid-x", "/boot", grubutil.GrubDefaults(timeout=0)
+    )
+    assert "set timeout=0" in cfg
+
+
+def test_generate_grub_cfg_without_fw_setup_has_no_uefi_entry():
+    cfg = grubutil._generate_grub_cfg([], "some-uuid", "some-uuid", "/boot")
+    assert "UEFI Firmware Settings" not in cfg
+    assert "fwsetup" not in cfg
+
+
+def test_generate_grub_cfg_with_fw_setup_adds_uefi_entry():
+    cfg = grubutil._generate_grub_cfg(
+        [], "some-uuid", "some-uuid", "/boot", include_fw_setup=True
+    )
+    assert "menuentry 'UEFI Firmware Settings'" in cfg
+    assert "fwsetup" in cfg
+    assert 'if [ "${grub_platform}" = "efi" ]; then' in cfg
+
+
+def test_efi_stub_grub_cfg():
+    cfg = grubutil._efi_stub_grub_cfg("abcd-uuid", "/boot")
+    assert "search.fs_uuid abcd-uuid root" in cfg
+    assert "set prefix=($root)'/boot/grub'" in cfg
+    assert "configfile $prefix/grub.cfg" in cfg
+
+
+def test_efi_stub_grub_cfg_separate_boot_partition():
+    """A separate /boot partition holds grub at /grub, and has its own UUID."""
+    cfg = grubutil._efi_stub_grub_cfg("boot-uuid", "")
+    assert "search.fs_uuid boot-uuid root" in cfg
+    assert "set prefix=($root)'/grub'" in cfg

--- a/tests/unit/pack/test_mbrutil.py
+++ b/tests/unit/pack/test_mbrutil.py
@@ -205,6 +205,97 @@ def test_create_mbr_layout_calls_sfdisk(mocker, tmp_path, volume):
     assert "bootable" in stdin  # ubuntu-seed has role system-boot
 
 
+def test_create_mbr_layout_no_system_boot_marks_system_data_bootable(mocker, tmp_path):
+    # Regression test: layouts with no system-boot partition (e.g. grub-pc
+    # BIOS-only images where core.img lives in the MBR gap) must still mark
+    # a partition bootable, or SeaBIOS has no active partition to boot from
+    # and hangs at "Booting from Hard Disk...".
+    layout = MBRVolume.unmarshal(_VOLUME_SINGLE)
+    mocked_run = mocker.patch("imagecraft.pack.mbrutil.subprocess.run", autospec=True)
+
+    mbrutil._create_mbr_layout(
+        imagepath=tmp_path / "image.img",
+        sector_size=512,
+        layout=layout,
+    )
+
+    stdin = mocked_run.call_args.kwargs["input"]
+    assert "bootable" in stdin
+
+
+_VOLUME_MULTI_DATA_NO_BOOT = {
+    "schema": "mbr",
+    "structure": [
+        {
+            "name": "rootfs",
+            "role": "system-data",
+            "type": "83",
+            "filesystem": "ext4",
+            "size": "2G",
+        },
+        {
+            "name": "data",
+            "role": "system-data",
+            "type": "83",
+            "filesystem": "ext4",
+            "size": "1G",
+        },
+        {
+            "name": "home",
+            "role": "system-data",
+            "type": "83",
+            "filesystem": "ext4",
+            "size": "1G",
+        },
+    ],
+}
+
+
+def test_create_mbr_layout_marks_exactly_one_partition_bootable(mocker, tmp_path):
+    # An MBR may only have one active partition. When several partitions share
+    # the system-data role and there is no system-boot partition, only the
+    # first may be flagged, otherwise sfdisk writes several active entries and
+    # the firmware picks one unpredictably.
+    layout = MBRVolume.unmarshal(_VOLUME_MULTI_DATA_NO_BOOT)
+    mocked_run = mocker.patch("imagecraft.pack.mbrutil.subprocess.run", autospec=True)
+
+    mbrutil._create_mbr_layout(
+        imagepath=tmp_path / "image.img",
+        sector_size=512,
+        layout=layout,
+    )
+
+    stdin = mocked_run.call_args.kwargs["input"]
+    partition_lines = [line for line in stdin.splitlines() if line.startswith("start=")]
+    bootable_lines = [line for line in partition_lines if "bootable" in line]
+
+    assert len(partition_lines) == 3
+    assert len(bootable_lines) == 1
+    # It must be the first partition, which is the one holding the root
+    # filesystem GRUB was pointed at.
+    assert bootable_lines[0] == partition_lines[0]
+
+
+def test_create_mbr_layout_prefers_system_boot_over_system_data(mocker, tmp_path):
+    # When a system-boot partition exists it wins, and the system-data
+    # partition must not also be flagged.
+    layout = MBRVolume.unmarshal(_VOLUME_TWO_PARTS)
+    mocked_run = mocker.patch("imagecraft.pack.mbrutil.subprocess.run", autospec=True)
+
+    mbrutil._create_mbr_layout(
+        imagepath=tmp_path / "image.img",
+        sector_size=512,
+        layout=layout,
+    )
+
+    stdin = mocked_run.call_args.kwargs["input"]
+    partition_lines = [line for line in stdin.splitlines() if line.startswith("start=")]
+    bootable_lines = [line for line in partition_lines if "bootable" in line]
+
+    assert len(bootable_lines) == 1
+    assert bootable_lines[0] == partition_lines[0]
+
+
 def test_create_mbr_layout_sfdisk_failure_raises(mocker, tmp_path, volume):
     mocked_run = mocker.patch("imagecraft.pack.mbrutil.subprocess.run", autospec=True)
     mocked_run.side_effect = subprocess.CalledProcessError(

--- a/tests/unit/services/test_image.py
+++ b/tests/unit/services/test_image.py
@@ -12,12 +12,14 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import pathlib
 import subprocess
 from typing import cast
 from unittest.mock import MagicMock, patch
 
 import pytest
 from craft_application import ServiceFactory
+from craft_cli import CraftError
 from imagecraft.models import Project, Volume
 from imagecraft.models.volume import GPTStructureItem, MBRVolume, PartitionSchema
 from imagecraft.services.image import ImageService
@@ -129,6 +131,7 @@ def test_attach_images_new(image_service, project_dir, mocker):
     mock_run = mocker.patch("imagecraft.services.image.run")
     # Mock _get_all_loop_devices returns empty
     mocker.patch.object(image_service, "_get_all_loop_devices", return_value=[])
+    mocker.patch.object(image_service, "_wait_for_partition_nodes")
 
     mock_run.return_value.stdout = "/dev/loop8\n"
 
@@ -144,6 +147,9 @@ def test_attach_images_new(image_service, project_dir, mocker):
             str(project_dir / ".pc.img.tmp"),
         )
         mock_atexit.assert_called_once_with(image_service.detach_images)
+        image_service._wait_for_partition_nodes.assert_called_once_with(
+            "/dev/loop8", "pc"
+        )
 
 
 def test_attach_images_reuse(image_service, project_dir, mocker):
@@ -161,11 +167,13 @@ def test_attach_images_reuse(image_service, project_dir, mocker):
     # Mock samefile to return True
     mocker.patch("pathlib.Path.samefile", return_value=True)
     mock_run = mocker.patch("imagecraft.services.image.run")
+    mocker.patch.object(image_service, "_wait_for_partition_nodes")
 
     devices = image_service.attach_images()
 
     assert devices == {"pc": "/dev/loop9"}
     mock_run.assert_not_called()  # Should not call losetup attach
+    image_service._wait_for_partition_nodes.assert_called_once_with("/dev/loop9", "pc")
 
 
 def test_attach_images_stale_inode(image_service, project_dir, mocker):
@@ -184,6 +192,7 @@ def test_attach_images_stale_inode(image_service, project_dir, mocker):
     mocker.patch("pathlib.Path.samefile", side_effect=FileNotFoundError)
     mock_run = mocker.patch("imagecraft.services.image.run")
     mock_run.return_value.stdout = "/dev/loop11\n"
+    mocker.patch.object(image_service, "_wait_for_partition_nodes")
 
     devices = image_service.attach_images()
 
@@ -194,6 +203,74 @@ def test_attach_images_stale_inode(image_service, project_dir, mocker):
     mock_run.assert_any_call(
         "losetup", "--find", "--show", "--partscan", str(image_path)
     )
+    image_service._wait_for_partition_nodes.assert_called_once_with("/dev/loop11", "pc")
+
+
+def test_wait_for_partition_nodes_immediate(
+    image_service, default_factory, mock_project, mocker
+):
+    """Partition nodes that already exist require no waiting."""
+    mocker.patch.object(
+        default_factory.get("project"), "get", return_value=mock_project
+    )
+
+    exists_calls: list[str] = []
+
+    def fake_exists(self):
+        exists_calls.append(str(self))
+        return True
+
+    mocker.patch.object(pathlib.Path, "exists", autospec=True, side_effect=fake_exists)
+    mock_sleep = mocker.patch("time.sleep")
+
+    image_service._wait_for_partition_nodes("/dev/loop8", "pc")
+
+    assert sorted(exists_calls) == ["/dev/loop8p1", "/dev/loop8p2"]
+    mock_sleep.assert_not_called()
+
+
+def test_wait_for_partition_nodes_after_delay(
+    image_service, default_factory, mock_project, mocker
+):
+    """The wait polls until all partition nodes appear."""
+    mocker.patch.object(
+        default_factory.get("project"), "get", return_value=mock_project
+    )
+    mocker.patch("imagecraft.services.image.time.monotonic", side_effect=[0, 0.5])
+    mock_sleep = mocker.patch("time.sleep")
+
+    p1_polls = 0
+
+    def fake_exists(self):
+        nonlocal p1_polls
+        if str(self).endswith("p1"):
+            p1_polls += 1
+            return p1_polls > 1  # Appear after the first poll.
+        return True
+
+    mocker.patch.object(pathlib.Path, "exists", autospec=True, side_effect=fake_exists)
+
+    image_service._wait_for_partition_nodes("/dev/loop8", "pc")
+
+    assert p1_polls == 2
+    mock_sleep.assert_called_once_with(0.1)
+
+
+def test_wait_for_partition_nodes_timeout(
+    image_service, default_factory, mock_project, mocker
+):
+    """A CraftError is raised when partition nodes never appear."""
+    mocker.patch.object(
+        default_factory.get("project"), "get", return_value=mock_project
+    )
+    mocker.patch("imagecraft.services.image.time.monotonic", side_effect=[0, 11])
+    mocker.patch("time.sleep")
+    mocker.patch.object(
+        pathlib.Path, "exists", autospec=True, side_effect=lambda self: False
+    )
+
+    with pytest.raises(CraftError, match="did not appear for /dev/loop8"):
+        image_service._wait_for_partition_nodes("/dev/loop8", "pc")
 
 
 def test_detach_images_success(image_service, mocker):

--- a/tests/unit/utils/__init__.py
+++ b/tests/unit/utils/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2026 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.

--- a/tests/unit/utils/test_mount.py
+++ b/tests/unit/utils/test_mount.py
@@ -1,0 +1,429 @@
+# Copyright 2026 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import subprocess
+from pathlib import Path
+from subprocess import CompletedProcess
+
+import pytest
+from imagecraft import errors
+from imagecraft.models import GPTVolume, MBRVolume
+from imagecraft.utils.mount import (
+    BaseMount,
+    CompositeMount,
+    ExtFuseMount,
+    FatFuseMount,
+    VirtualOffsetDevice,
+    mount_partition,
+    mount_volume,
+)
+
+
+@pytest.fixture
+def mock_run(mocker):
+    return mocker.patch(
+        "imagecraft.utils.mount.run",
+        return_value=CompletedProcess(args=[], returncode=0, stdout=""),
+    )
+
+
+@pytest.fixture
+def gpt_volume():
+    return GPTVolume.unmarshal(
+        {
+            "schema": "gpt",
+            "structure": [
+                {
+                    "name": "efi",
+                    "role": "system-boot",
+                    "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+                    "filesystem": "vfat",
+                    "size": "256M",
+                },
+                {
+                    "name": "rootfs",
+                    "role": "system-data",
+                    "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                    "filesystem": "ext4",
+                    "size": "4G",
+                },
+            ],
+        }
+    )
+
+
+@pytest.fixture
+def mbr_volume():
+    return MBRVolume.unmarshal(
+        {
+            "schema": "mbr",
+            "structure": [
+                {
+                    "name": "ubuntu-seed",
+                    "role": "system-boot",
+                    "type": "0C",
+                    "filesystem": "vfat",
+                    "size": "1200M",
+                },
+                {
+                    "name": "ubuntu-data",
+                    "role": "system-data",
+                    "type": "83",
+                    "filesystem": "ext4",
+                    "size": "2G",
+                },
+            ],
+        }
+    )
+
+
+def test_virtual_offset_device_mount_success(mock_run, tmp_path: Path):
+    disk_path = tmp_path / "disk.img"
+    disk_path.touch()
+    vdev = VirtualOffsetDevice(disk_path, offset=1048576, size=67108864)
+
+    assert not vdev.is_mounted
+    part_file = vdev.mount()
+
+    assert vdev.is_mounted
+    assert part_file.name == "part.img"
+    assert part_file.exists()
+    mock_run.assert_called_once_with(
+        "fusefile",
+        str(part_file),
+        f"{disk_path.resolve()}/1048576+67108864",
+    )
+
+    assert vdev.mount() == part_file
+    assert mock_run.call_count == 1
+
+    vdev.unmount()
+    assert not vdev.is_mounted
+    mock_run.assert_called_with("fusermount", "-u", str(part_file))
+
+
+def test_virtual_offset_device_mount_failure(mock_run, tmp_path: Path):
+    disk_path = tmp_path / "disk.img"
+    mock_run.side_effect = subprocess.CalledProcessError(1, "fusefile")
+    vdev = VirtualOffsetDevice(disk_path, offset=1048576, size=67108864)
+
+    with pytest.raises(
+        errors.MountError, match="Failed to create virtual offset device"
+    ):
+        vdev.mount()
+
+    assert not vdev.is_mounted
+    assert vdev.part_file is None
+
+
+def test_virtual_offset_device_unmount_lazy(mock_run, tmp_path: Path):
+    disk_path = tmp_path / "disk.img"
+    vdev = VirtualOffsetDevice(disk_path, offset=1048576, size=67108864)
+    part_file = vdev.mount()
+
+    vdev.unmount(lazy=True)
+    assert not vdev.is_mounted
+    mock_run.assert_called_with("fusermount", "-u", "-z", str(part_file))
+
+
+def test_virtual_offset_device_unmount_not_mounted(mock_run, tmp_path: Path):
+    disk_path = tmp_path / "disk.img"
+    vdev = VirtualOffsetDevice(disk_path, offset=1048576, size=67108864)
+    vdev.unmount()
+    mock_run.assert_not_called()
+
+
+def test_virtual_offset_device_context_manager(mock_run, tmp_path: Path):
+    disk_path = tmp_path / "disk.img"
+    vdev = VirtualOffsetDevice(disk_path, offset=1048576, size=67108864)
+
+    with vdev as part_file:
+        assert vdev.is_mounted
+        assert part_file.name == "part.img"
+
+    assert not vdev.is_mounted
+    mock_run.assert_called_with("fusermount", "-u", str(part_file))
+
+
+def test_ext_fuse_mount_standalone(mock_run, tmp_path: Path):
+    img_path = tmp_path / "rootfs.img"
+    mount = ExtFuseMount(img_path)
+
+    assert not mount.is_mounted
+    mountpoint = mount.mount()
+
+    assert mount.is_mounted
+    assert mountpoint.exists()
+    mock_run.assert_called_once_with(
+        "fuse2fs",
+        "-o",
+        "rw",
+        str(img_path.resolve()),
+        str(mountpoint.resolve()),
+    )
+
+    mount.unmount()
+    assert not mount.is_mounted
+    mock_run.assert_called_with("fusermount3", "-u", str(mountpoint.resolve()))
+
+
+def test_ext_fuse_mount_with_offset_and_options(mock_run, tmp_path: Path):
+    disk_path = tmp_path / "disk.img"
+    custom_mount = tmp_path / "custom_mount"
+    mount = ExtFuseMount(
+        disk_path,
+        offset=1048576,
+        mountpoint=custom_mount,
+        read_only=True,
+        allow_other=True,
+        fakeroot=True,
+    )
+
+    mountpoint = mount.mount()
+    assert mountpoint == custom_mount
+    mock_run.assert_called_once_with(
+        "fuse2fs",
+        "-o",
+        "offset=1048576,ro,allow_other,fakeroot",
+        str(disk_path.resolve()),
+        str(custom_mount.resolve()),
+    )
+
+    mount.unmount(lazy=True)
+    mock_run.assert_called_with("fusermount3", "-u", "-z", str(custom_mount.resolve()))
+
+
+def test_ext_fuse_mount_failure(mock_run, tmp_path: Path):
+    img_path = tmp_path / "rootfs.img"
+    mock_run.side_effect = subprocess.CalledProcessError(1, "fuse2fs")
+    mount = ExtFuseMount(img_path)
+
+    with pytest.raises(errors.MountError) as exc_info:
+        mount.mount()
+
+    assert "Failed to mount ext partition" in str(exc_info.value)
+    assert "at None" not in str(exc_info.value)
+    assert not mount.is_mounted
+
+
+def test_ext_fuse_mount_context_manager(mock_run, tmp_path: Path):
+    img_path = tmp_path / "rootfs.img"
+    mount = ExtFuseMount(img_path)
+
+    with mount as mnt:
+        assert mount.is_mounted
+        assert mnt.exists()
+
+    assert not mount.is_mounted
+
+
+def test_fat_fuse_mount_standalone(mock_run, tmp_path: Path):
+    img_path = tmp_path / "efi.img"
+    mount = FatFuseMount(img_path)
+
+    assert not mount.is_mounted
+    mountpoint = mount.mount()
+
+    assert mount.is_mounted
+    assert mountpoint.exists()
+    mock_run.assert_called_once_with(
+        "fusefat",
+        "-o",
+        "rw+",
+        str(img_path.resolve()),
+        str(mountpoint.resolve()),
+    )
+
+    mount.unmount()
+    assert not mount.is_mounted
+    mock_run.assert_called_with("fusermount3", "-u", str(mountpoint.resolve()))
+
+
+def test_fat_fuse_mount_with_offset_spawns_vdev(mock_run, tmp_path: Path):
+    disk_path = tmp_path / "disk.img"
+    mount = FatFuseMount(
+        disk_path,
+        offset=1048576,
+        size=67108864,
+        read_only=True,
+        allow_other=True,
+    )
+
+    mount.mount()
+    assert mount.is_mounted
+    assert mount._vpart is not None
+    assert mount._vpart.is_mounted
+
+    assert mock_run.call_count == 2
+    fusefile_call, fusefat_call = mock_run.call_args_list
+    assert fusefile_call[0][0] == "fusefile"
+    assert fusefat_call[0][0] == "fusefat"
+    assert fusefat_call[0][1] == "-o"
+    assert fusefat_call[0][2] == "ro,allow_other"
+
+    mount.unmount()
+    assert not mount.is_mounted
+    assert mock_run.call_count == 4
+    unmount_fat, unmount_vpart = mock_run.call_args_list[2:]
+    assert unmount_fat[0][0] == "fusermount3"
+    assert unmount_vpart[0][0] == "fusermount"
+
+
+def test_fat_fuse_mount_offset_missing_size_raises(tmp_path: Path):
+    disk_path = tmp_path / "disk.img"
+    mount = FatFuseMount(disk_path, offset=1048576, size=None)
+
+    with pytest.raises(errors.MountError, match="Partition size must be specified"):
+        mount.mount()
+
+
+def test_fat_fuse_mount_failure_cleans_up_vdev(mock_run, tmp_path: Path):
+    disk_path = tmp_path / "disk.img"
+    mock_run.side_effect = [
+        CompletedProcess(args=[], returncode=0, stdout=""),
+        subprocess.CalledProcessError(1, "fusefat"),
+        CompletedProcess(args=[], returncode=0, stdout=""),
+    ]
+    mount = FatFuseMount(disk_path, offset=1048576, size=67108864)
+
+    with pytest.raises(errors.MountError) as exc_info:
+        mount.mount()
+
+    assert "Failed to mount FAT partition" in str(exc_info.value)
+    assert "at None" not in str(exc_info.value)
+    assert not mount.is_mounted
+    assert mount._vpart is None
+    assert mock_run.call_count == 3
+    assert mock_run.call_args_list[2][0][0] == "fusermount"
+
+
+def test_mount_partition_factory(tmp_path: Path):
+    img_path = tmp_path / "test.img"
+
+    ext_mount = mount_partition(img_path, "ext4", offset=100, fakeroot=True)
+    assert isinstance(ext_mount, ExtFuseMount)
+    assert ext_mount.offset == 100
+    assert ext_mount.fakeroot is True
+
+    fat_mount = mount_partition(img_path, "vfat", offset=200, size=300)
+    assert isinstance(fat_mount, FatFuseMount)
+    assert fat_mount.offset == 200
+    assert fat_mount.size == 300
+
+    with pytest.raises(errors.MountError, match="Unsupported filesystem"):
+        mount_partition(img_path, "ntfs")
+
+
+def test_composite_mount_and_unmount_order(mocker, tmp_path: Path):
+    mount_a = mocker.MagicMock(spec=BaseMount)
+    mount_b = mocker.MagicMock(spec=BaseMount)
+    call_sequence: list[str] = []
+
+    mount_a.mount.side_effect = lambda: call_sequence.append("mount_a")
+    mount_b.mount.side_effect = lambda: call_sequence.append("mount_b")
+    mount_a.unmount.side_effect = lambda **_: call_sequence.append("unmount_a")
+    mount_b.unmount.side_effect = lambda **_: call_sequence.append("unmount_b")
+
+    composite = CompositeMount(
+        [
+            ("boot/efi", mount_b),
+            ("", mount_a),
+        ],
+        mountpoint=tmp_path / "rootfs",
+    )
+
+    root = composite.mount()
+    assert root == tmp_path / "rootfs"
+    assert composite.is_mounted
+
+    composite.unmount()
+    assert not composite.is_mounted
+
+    assert call_sequence == ["mount_a", "mount_b", "unmount_b", "unmount_a"]
+
+
+def test_composite_mount_failure_rolls_back(mocker, tmp_path: Path):
+    mount_a = mocker.MagicMock(spec=BaseMount)
+    mount_b = mocker.MagicMock(spec=BaseMount)
+    mount_b.mount.side_effect = errors.MountError("Failed B")
+
+    composite = CompositeMount(
+        [
+            ("", mount_a),
+            ("boot/efi", mount_b),
+        ],
+        mountpoint=tmp_path / "rootfs",
+    )
+
+    with pytest.raises(
+        errors.MountError,
+        match="Failed to mount composite mount hierarchy",
+    ):
+        composite.mount()
+
+    assert not composite.is_mounted
+    mount_a.unmount.assert_called_once()
+
+
+def test_mount_volume_gpt(mocker, gpt_volume, tmp_path: Path):
+    disk_path = tmp_path / "disk.img"
+    disk_path.touch()
+
+    mocker.patch(
+        "imagecraft.pack.gptutil.get_partition_sector_offset",
+        side_effect=lambda _, name: 2048 if name == "efi" else 526336,
+    )
+    mocker.patch(
+        "imagecraft.pack.gptutil.get_partition_size_sectors",
+        side_effect=lambda _, name: 524288 if name == "efi" else 8388608,
+    )
+
+    vol_mount = mount_volume(gpt_volume, disk_path, fakeroot=True)
+
+    assert len(vol_mount._mount_entries) == 2
+    paths_and_mounts = {p: type(m) for p, m in vol_mount._mount_entries}
+    assert paths_and_mounts == {
+        "boot/efi": FatFuseMount,
+        "": ExtFuseMount,
+    }
+    ext_m = next(m for p, m in vol_mount._mount_entries if p == "")
+    assert isinstance(ext_m, ExtFuseMount)
+    assert ext_m.fakeroot is True
+
+
+def test_mount_volume_mbr(mocker, mbr_volume, tmp_path: Path):
+    disk_path = tmp_path / "disk.img"
+    disk_path.touch()
+
+    mocker.patch(
+        "imagecraft.pack.gptutil.get_partition_sector_offset_by_number",
+        side_effect=lambda _, num: 2048 if num == 1 else 2459648,
+    )
+    mocker.patch(
+        "imagecraft.pack.gptutil.get_partition_size_sectors_by_number",
+        side_effect=lambda _, num: 2457600 if num == 1 else 4194304,
+    )
+
+    vol_mount = mount_volume(
+        mbr_volume,
+        disk_path,
+        mountpoint_overrides={"ubuntu-seed": "seed"},
+    )
+
+    assert len(vol_mount._mount_entries) == 2
+    paths_and_mounts = {p: type(m) for p, m in vol_mount._mount_entries}
+    assert paths_and_mounts == {
+        "seed": FatFuseMount,
+        "": ExtFuseMount,
+    }


### PR DESCRIPTION
Part 6 of a stack that makes GRUB installation work without root privileges.

Converts the remaining BIOS/MBR path to the same unprivileged approach the EFI
path already uses, and deletes the chroot implementation.

BIOS booting is fiddlier than EFI because there is no filesystem involved at the
start -- the firmware just executes the first sector. So instead of copying
files into a partition, we:

1. Build `core.img` on the host with `grub-mkimage`.
2. Copy the boot sector out of GRUB's `boot.img` into sector 0 of the image.
3. Write `core.img` into the post-MBR gap.
4. Patch the boot sector with the sector where `core.img` starts and its
   blocklist, which is the part `grub-install` would normally do for us.

With both firmware types converted, `setup_grub` no longer mounts anything or
attaches loop devices at all, so `_grub_install`, `_image_mounts` and the
transitional `_setup_grub_bios_chroot` wrapper introduced in the previous PR are
removed.

Adds `tests/spread/boot/classic-mbr`, which boots a BIOS image under QEMU's
SeaBIOS (no OVMF) and asserts it reaches userspace -- i.e. that the hand-written
boot sector and blocklist actually work.
