### PR TITLE
ci: fix security scan workflow

### DIFF
--- a/.github/workflows/policy.yaml
+++ b/.github/workflows/policy.yaml
@@ -17,3 +17,8 @@ jobs:
     uses: canonical/starflow/.github/workflows/scan-python.yaml@main
     with:
       uv-export-extra-args: "--group=docs --group=types"
+      osv-exclude-paths: |
+        docs
+      uv-export-no-groups: |
+        docs
+        docs-starter-pack

--- a/.github/workflows/policy.yaml
+++ b/.github/workflows/policy.yaml
@@ -8,6 +8,9 @@ on:
 
 jobs:
   policy:
+    permissions:
+      contents: read
+      security-events: write
     uses: canonical/starflow/.github/workflows/policy.yaml@main
   python-scans:
     name: Security scan


### PR DESCRIPTION
Replicating changes from https://github.com/canonical/craft-archives/pull/245 to fix zizmor CI by adding security-events: write permission to policy job.

This does not actually update the dependencies.