### PR TITLE
feat(utils): add FUSE partition and volume mounting utilities

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -47,9 +47,9 @@ jobs:
     needs: filter
     with:
       source-files: ${{ needs.filter.outputs.source-files }}
-      fast-test-platforms: '["ubuntu-24.04", "ubuntu-24.04-arm"]'
+      fast-test-platforms: '["ubuntu-24.04", "ubuntu-24.04-arm", "ubuntu-26.04-arm"]'
       fast-test-python-versions: '["3.12"]'
-      slow-test-platforms: '["ubuntu-24.04", "ubuntu-24.04-arm"]'
+      slow-test-platforms: '["ubuntu-24.04", "ubuntu-24.04-arm", "ubuntu-26.04-arm"]'
       slow-test-python-versions: '["3.12"]'
       lowest-python-version: ""
       pytest-markers: requires_root

--- a/Makefile
+++ b/Makefile
@@ -45,17 +45,35 @@ APT_PACKAGES :=
 ifeq ($(shell which mtools),)
 APT_PACKAGES += mtools
 endif
-ifeq ($(shell command -v grub-mkimage 2>/dev/null),)
+ifeq ($(shell which mkfs.vfat),)
+APT_PACKAGES += dosfstools
+endif
+ifeq ($(shell which grub-mkimage),)
 APT_PACKAGES += grub-common
 endif
-# debugfs and blkid live in /usr/sbin, which is not on the default non-root
-# PATH on every distribution, so search there explicitly to avoid reinstalling
-# packages that are already present.
-ifeq ($(shell PATH="$(PATH):/usr/sbin:/sbin" command -v debugfs 2>/dev/null),)
+ifeq ($(shell which mke2fs),)
 APT_PACKAGES += e2fsprogs
 endif
-ifeq ($(shell PATH="$(PATH):/usr/sbin:/sbin" command -v blkid 2>/dev/null),)
-APT_PACKAGES += util-linux
+ifeq ($(shell which sfdisk),)
+APT_PACKAGES += fdisk
+endif
+ifeq ($(shell which fuse2fs),)
+APT_PACKAGES += fuse2fs
+endif
+ifeq ($(shell which fusefile),)
+APT_PACKAGES += fusefile
+endif
+# fusefat is only packaged for amd64 in Ubuntu 24.04 (Noble) universe repositories.
+# On newer releases it may be available across architectures, but on Noble it is only
+# available on x86_64/amd64.
+ifneq ($(VERSION_CODENAME),noble)
+ifeq ($(shell which fusefat),)
+APT_PACKAGES += fusefat
+endif
+else ifeq ($(shell uname -m),x86_64)
+ifeq ($(shell which fusefat),)
+APT_PACKAGES += fusefat
+endif
 endif
 ifeq ($(wildcard /usr/include/libxml2/libxml/xpath.h),)
 APT_PACKAGES += libxml2-dev

--- a/imagecraft/errors.py
+++ b/imagecraft/errors.py
@@ -27,6 +27,10 @@ class ImageError(ImagecraftError):
     """Raised when an error occurs when dealing with the Image class."""
 
 
+class MountError(ImagecraftError):
+    """Raised when an error occurs mounting or unmounting an image or partition."""
+
+
 class GRUBInstallError(ImagecraftError):
     """Raised when an error occurs when installing grub."""
 

--- a/imagecraft/models/__init__.py
+++ b/imagecraft/models/__init__.py
@@ -23,26 +23,29 @@ from imagecraft.models.project import (
 )
 
 from imagecraft.models.volume import (
-    FileSystem,
     BaseVolume,
+    FileSystem,
+    GPTStructureItem,
     GPTVolume,
     MBRVolume,
-    Volume,
+    PartitionSchema,
     Role,
-    GPTStructureItem,
+    Volume,
 )
 from imagecraft.models.grammar import get_grammar_aware_volume_keywords
 
 __all__ = [
+    "BaseVolume",
     "FileSystem",
-    "Project",
-    "Platform",
+    "GPTStructureItem",
     "GPTVolume",
     "MBRVolume",
+    "PartitionSchema",
+    "Platform",
+    "Project",
+    "Role",
     "Volume",
     "VolumeFilesystemsModel",
-    "Role",
-    "GPTStructureItem",
-    "get_partition_name",
     "get_grammar_aware_volume_keywords",
+    "get_partition_name",
 ]

--- a/imagecraft/pack/__init__.py
+++ b/imagecraft/pack/__init__.py
@@ -33,14 +33,14 @@ from imagecraft.pack.grubutil import setup_grub
 from imagecraft.pack.image import Image
 
 __all__ = [
+    "Image",
+    "SUPPORTED_SECTOR_SIZES",
     "bytes_to_sectors",
+    "create_empty_gpt_image",
+    "create_empty_mbr_image",
     "create_zero_image",
     "format_populate_partition",
-    "inject_partition_into_image",
-    "SUPPORTED_SECTOR_SIZES",
-    "create_empty_gpt_image",
     "get_partition_sector_offset",
-    "create_empty_mbr_image",
+    "inject_partition_into_image",
     "setup_grub",
-    "Image",
 ]

--- a/imagecraft/services/image.py
+++ b/imagecraft/services/image.py
@@ -39,6 +39,9 @@ from imagecraft.subprocesses import run
 
 _LOSETUP_BIN = "losetup"
 
+# Maximum time to wait for kernel-created loop partition nodes to appear.
+_PARTSCAN_TIMEOUT_SECONDS = 10.0
+
 
 class ImageService(AppService):
     """Service for accessing the final image file."""
@@ -119,6 +122,9 @@ class ImageService(AppService):
         This method is idempotent. It will reuse existing loop devices if they
         are already attached to the correct files, and clean up stale devices
         pointing to deleted inodes.
+
+        Upon return, the partition device nodes for every attached image are
+        guaranteed to exist on disk.
         """
         if self._loop_devices:
             return self._loop_devices
@@ -168,12 +174,45 @@ class ImageService(AppService):
                     ) from err
 
             self._loop_devices[name] = attached_device
+            self._wait_for_partition_nodes(attached_device, name)
 
         if not self._atexit_registered:
             atexit.register(self.detach_images)
             self._atexit_registered = True
 
         return self._loop_devices
+
+    def _wait_for_partition_nodes(self, device: str, volume_name: str) -> None:
+        """Wait for a loop device's partition nodes to be created by the kernel.
+
+        After losetup sets up a device with ``--partscan``, the partition device
+        nodes (``/dev/loopXpN``) are created asynchronously by devtmpfs/udev, so
+        they may not be visible yet when losetup returns. Consumers of
+        :meth:`get_loop_paths` expect those nodes to exist immediately.
+
+        :raises CraftError: If the expected partition nodes do not appear within
+            the timeout.
+        """
+        project = cast(Project, self._services.get("project").get())
+        volume = project.volumes[volume_name]
+        part_numbers = sorted(set(self._get_partition_numbers(volume).values()))
+        expected_nodes = [pathlib.Path(f"{device}p{number}") for number in part_numbers]
+
+        deadline = time.monotonic() + _PARTSCAN_TIMEOUT_SECONDS
+        while missing := [node for node in expected_nodes if not node.exists()]:
+            if time.monotonic() > deadline:
+                raise CraftError(
+                    f"Partition devices did not appear for {device}: "
+                    f"{[str(node) for node in missing]}.",
+                    details=(
+                        "The kernel creates loop-device partition nodes asynchronously."
+                    ),
+                    resolution=(
+                        "Verify that udev is running and that the image has a "
+                        "valid partition table."
+                    ),
+                )
+            time.sleep(0.1)
 
     def detach_images(self) -> None:
         """Detach all attached loop devices.

--- a/imagecraft/utils/__init__.py
+++ b/imagecraft/utils/__init__.py
@@ -1,0 +1,37 @@
+# This file is part of imagecraft.
+#
+# Copyright 2026 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 3, as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Utility modules for Imagecraft."""
+
+from imagecraft.utils.mount import (
+    BaseMount,
+    CompositeMount,
+    ExtFuseMount,
+    FatFuseMount,
+    VirtualOffsetDevice,
+    mount_partition,
+    mount_volume,
+)
+
+__all__ = [
+    "BaseMount",
+    "CompositeMount",
+    "ExtFuseMount",
+    "FatFuseMount",
+    "VirtualOffsetDevice",
+    "mount_partition",
+    "mount_volume",
+]

--- a/imagecraft/utils/mount.py
+++ b/imagecraft/utils/mount.py
@@ -575,6 +575,13 @@ class CompositeMount(BaseMount):
             )
 
 
+_DEFAULT_ROLE_MOUNTS: dict[Role, str] = {
+    Role.SYSTEM_DATA: "",
+    Role.SYSTEM_BOOT: "boot/efi",
+    Role.SYSTEM_SEED: "var/lib/snapd/seed",
+}
+
+
 def mount_volume(
     volume: Volume,
     disk_path: Path,
@@ -610,18 +617,10 @@ def mount_volume(
         if not filesystem:
             continue
 
-        # Determine relative mount path
-        rel_path: str
-        if item.name in mountpoint_overrides:
-            rel_path = mountpoint_overrides[item.name]
-        elif item.role == Role.SYSTEM_DATA:
-            rel_path = ""
-        elif item.role == Role.SYSTEM_BOOT:
-            rel_path = "boot/efi"
-        elif item.role == Role.SYSTEM_SEED:
-            rel_path = "var/lib/snapd/seed"
-        else:
-            rel_path = f"mnt/{item.name}"
+        rel_path = mountpoint_overrides.get(
+            item.name,
+            _DEFAULT_ROLE_MOUNTS.get(item.role, f"mnt/{item.name}"),
+        )
 
         # Calculate byte offset and size
         if is_gpt:

--- a/imagecraft/utils/mount.py
+++ b/imagecraft/utils/mount.py
@@ -475,10 +475,11 @@ def mount_partition(
     :param fakeroot: If True, pass fakeroot option to FUSE (ext only).
     :raises errors.MountError: If the filesystem type is unsupported.
     """
-    if isinstance(filesystem, FileSystem):
-        fs_str = filesystem.value.lower()
-    else:
-        fs_str = str(filesystem).lower()
+    fs_str = (
+        filesystem.value.lower()
+        if isinstance(filesystem, FileSystem)
+        else str(filesystem).lower()
+    )
     if fs_str in ("ext2", "ext3", "ext4"):
         return ExtFuseMount(
             imagepath,
@@ -619,14 +620,11 @@ def mount_volume(
             start_sector = gptutil.get_partition_sector_offset_by_number(disk_path, idx)
             size_sectors = gptutil.get_partition_size_sectors_by_number(disk_path, idx)
 
-        offset_bytes = start_sector * gptutil.SECTOR_SIZE_512
-        size_bytes = size_sectors * gptutil.SECTOR_SIZE_512
-
         part_mount = mount_partition(
             disk_path,
             filesystem,
-            offset=offset_bytes,
-            size=size_bytes,
+            offset=start_sector * gptutil.SECTOR_SIZE_512,
+            size=size_sectors * gptutil.SECTOR_SIZE_512,
             read_only=read_only,
             allow_other=allow_other,
             fakeroot=fakeroot,

--- a/imagecraft/utils/mount.py
+++ b/imagecraft/utils/mount.py
@@ -80,18 +80,17 @@ def _unmount_path(
         raise last_err
 
 
-def _fuse_command(command: Sequence[str], description: str) -> None:
+def _try_fuse_command(command: Sequence[str], *, err_msg: str) -> None:
     """Run a FUSE helper command, wrapping failures in ``MountError``.
 
     :param command: The command and arguments to run.
-    :param description: Human-readable action description used when composing
-        the error message.
+    :param err_msg: Human-readable error message to raise on failure.
     :raises errors.MountError: If the command fails or the binary is missing.
     """
     try:
         run(*command)
     except (subprocess.CalledProcessError, FileNotFoundError) as err:
-        raise errors.MountError(f"{description}: {err}") from err
+        raise errors.MountError(f"{err_msg}: {err}") from err
 
 
 class BaseMount(abc.ABC):
@@ -197,9 +196,9 @@ class VirtualOffsetDevice(BaseMount):
         emit.debug(f"Mounting virtual offset device {self.part_file} from {spec}")
 
         try:
-            _fuse_command(
+            _try_fuse_command(
                 ["fusefile", str(self.part_file), spec],
-                "Failed to create virtual offset device with fusefile",
+                err_msg="Failed to create virtual offset device with fusefile",
             )
         except errors.MountError:
             self._cleanup()
@@ -289,9 +288,9 @@ class ExtFuseMount(BaseMount):
 
         emit.debug(f"Mounting ext partition with: {cmd}")
         try:
-            _fuse_command(
+            _try_fuse_command(
                 cmd,
-                f"Failed to mount ext partition {self.imagepath} at {mountpoint}",
+                err_msg=f"Failed to mount ext partition {self.imagepath} at {mountpoint}",
             )
         except errors.MountError:
             self._cleanup()
@@ -385,9 +384,9 @@ class FatFuseMount(BaseMount):
 
         emit.debug(f"Mounting FAT partition with: {cmd}")
         try:
-            _fuse_command(
+            _try_fuse_command(
                 cmd,
-                f"Failed to mount FAT partition {self.imagepath} at {mountpoint}",
+                err_msg=f"Failed to mount FAT partition {self.imagepath} at {mountpoint}",
             )
         except errors.MountError:
             if self._vpart is not None:

--- a/imagecraft/utils/mount.py
+++ b/imagecraft/utils/mount.py
@@ -80,6 +80,20 @@ def _unmount_path(
         raise last_err
 
 
+def _fuse_command(command: Sequence[str], description: str) -> None:
+    """Run a FUSE helper command, wrapping failures in ``MountError``.
+
+    :param command: The command and arguments to run.
+    :param description: Human-readable action description used when composing
+        the error message.
+    :raises errors.MountError: If the command fails or the binary is missing.
+    """
+    try:
+        run(*command)
+    except (subprocess.CalledProcessError, FileNotFoundError) as err:
+        raise errors.MountError(f"{description}: {err}") from err
+
+
 class BaseMount(abc.ABC):
     """Abstract base class for all filesystem mounts.
 
@@ -100,15 +114,6 @@ class BaseMount(abc.ABC):
     def is_mounted(self) -> bool:
         """Check if the filesystem is currently mounted."""
         return self._is_mounted
-
-    @property
-    def _mountpoint(self) -> Path | None:
-        """Alias for mountpoint property for internal consistency."""
-        return self.mountpoint
-
-    @_mountpoint.setter
-    def _mountpoint(self, value: Path | None) -> None:
-        self.mountpoint = value
 
     def _ensure_mountpoint(self, prefix: str) -> Path:
         """Ensure mountpoint directory exists and return it as a Path."""
@@ -147,8 +152,17 @@ class BaseMount(abc.ABC):
         """Exit context manager."""
         self.unmount()
 
+    def _cleanup(self) -> None:
+        """Reset mount state and remove the temporary mountpoint directory."""
+        self._is_mounted = False
+        if self._temp_dir is not None:
+            with contextlib.suppress(Exception):
+                self._temp_dir.cleanup()
+            self._temp_dir = None
+            self.mountpoint = None
 
-class VirtualOffsetDevice:
+
+class VirtualOffsetDevice(BaseMount):
     """Virtual partition device exposing a sub-slice of a disk image via fusefile.
 
     Used when mounting FAT filesystems with an offset > 0, as fusefat lacks native
@@ -159,21 +173,13 @@ class VirtualOffsetDevice:
     offset: int
     size: int
     part_file: Path | None
-    _temp_dir: tempfile.TemporaryDirectory[str] | None
-    _is_mounted: bool
 
     def __init__(self, disk_path: Path, offset: int, size: int) -> None:
+        super().__init__()
         self.disk_path = disk_path
         self.offset = offset
         self.size = size
         self.part_file = None
-        self._temp_dir = None
-        self._is_mounted = False
-
-    @property
-    def is_mounted(self) -> bool:
-        """Check if the virtual device is mounted."""
-        return self._is_mounted
 
     def mount(self) -> Path:
         """Create the virtual file and mount the slice via fusefile.
@@ -191,12 +197,13 @@ class VirtualOffsetDevice:
         emit.debug(f"Mounting virtual offset device {self.part_file} from {spec}")
 
         try:
-            run("fusefile", str(self.part_file), spec)
-        except (subprocess.CalledProcessError, FileNotFoundError) as err:
+            _fuse_command(
+                ["fusefile", str(self.part_file), spec],
+                "Failed to create virtual offset device with fusefile",
+            )
+        except errors.MountError:
             self._cleanup()
-            raise errors.MountError(
-                f"Failed to create virtual offset device with fusefile: {err}"
-            ) from err
+            raise
 
         self._is_mounted = True
         return self.part_file
@@ -218,25 +225,8 @@ class VirtualOffsetDevice:
             self._cleanup()
 
     def _cleanup(self) -> None:
-        self._is_mounted = False
+        super()._cleanup()
         self.part_file = None
-        if self._temp_dir is not None:
-            with contextlib.suppress(Exception):
-                self._temp_dir.cleanup()
-            self._temp_dir = None
-
-    def __enter__(self) -> Path:
-        """Enter context manager."""
-        return self.mount()
-
-    def __exit__(
-        self,
-        exc_type: type[BaseException] | None,
-        exc_val: BaseException | None,
-        exc_tb: TracebackType | None,
-    ) -> None:
-        """Exit context manager."""
-        self.unmount()
 
 
 class ExtFuseMount(BaseMount):
@@ -299,22 +289,23 @@ class ExtFuseMount(BaseMount):
 
         emit.debug(f"Mounting ext partition with: {cmd}")
         try:
-            run(*cmd)
-        except (subprocess.CalledProcessError, FileNotFoundError) as err:
+            _fuse_command(
+                cmd,
+                f"Failed to mount ext partition {self.imagepath} at {mountpoint}",
+            )
+        except errors.MountError:
             self._cleanup()
-            raise errors.MountError(
-                f"Failed to mount ext partition {self.imagepath} at {mountpoint}: {err}"
-            ) from err
+            raise
 
         self._is_mounted = True
         return mountpoint
 
     def unmount(self, *, lazy: bool = False) -> None:
         """Unmount the ext partition."""
-        if not self.is_mounted or self._mountpoint is None:
+        if not self.is_mounted or self.mountpoint is None:
             return
 
-        mountpoint = self._mountpoint
+        mountpoint = self.mountpoint
         emit.debug(f"Unmounting ext partition at {mountpoint}")
         try:
             _unmount_path(mountpoint, lazy=lazy, retries=10)
@@ -324,14 +315,6 @@ class ExtFuseMount(BaseMount):
             ) from err
         finally:
             self._cleanup()
-
-    def _cleanup(self) -> None:
-        self._is_mounted = False
-        if self._temp_dir is not None:
-            with contextlib.suppress(Exception):
-                self._temp_dir.cleanup()
-            self._temp_dir = None
-            self._mountpoint = None
 
 
 class FatFuseMount(BaseMount):
@@ -402,26 +385,27 @@ class FatFuseMount(BaseMount):
 
         emit.debug(f"Mounting FAT partition with: {cmd}")
         try:
-            run(*cmd)
-        except (subprocess.CalledProcessError, FileNotFoundError) as err:
+            _fuse_command(
+                cmd,
+                f"Failed to mount FAT partition {self.imagepath} at {mountpoint}",
+            )
+        except errors.MountError:
             if self._vpart is not None:
                 with contextlib.suppress(Exception):
                     self._vpart.unmount()
                 self._vpart = None
             self._cleanup()
-            raise errors.MountError(
-                f"Failed to mount FAT partition {self.imagepath} at {mountpoint}: {err}"
-            ) from err
+            raise
 
         self._is_mounted = True
         return mountpoint
 
     def unmount(self, *, lazy: bool = False) -> None:
         """Unmount the FAT partition and its virtual offset device if used."""
-        if not self.is_mounted or self._mountpoint is None:
+        if not self.is_mounted or self.mountpoint is None:
             return
 
-        mountpoint = self._mountpoint
+        mountpoint = self.mountpoint
         emit.debug(f"Unmounting FAT partition at {mountpoint}")
         err_mount: Exception | None = None
         try:
@@ -443,14 +427,6 @@ class FatFuseMount(BaseMount):
             raise errors.MountError(
                 f"Failed to unmount FAT partition at {mountpoint}: {err_mount}"
             ) from err_mount
-
-    def _cleanup(self) -> None:
-        self._is_mounted = False
-        if self._temp_dir is not None:
-            with contextlib.suppress(Exception):
-                self._temp_dir.cleanup()
-            self._temp_dir = None
-            self._mountpoint = None
 
 
 def mount_partition(
@@ -568,7 +544,7 @@ class CompositeMount(BaseMount):
             with contextlib.suppress(Exception):
                 self._temp_dir.cleanup()
             self._temp_dir = None
-            self._mountpoint = None
+            self.mountpoint = None
 
         if errors_encountered:
             raise errors.MountError(

--- a/imagecraft/utils/mount.py
+++ b/imagecraft/utils/mount.py
@@ -1,0 +1,649 @@
+# Copyright 2026 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""FUSE partition and volume mounting utilities."""
+
+import abc
+import contextlib
+import shutil
+import subprocess
+import tempfile
+import time
+from collections.abc import Sequence
+from pathlib import Path
+from types import TracebackType
+
+from craft_cli import emit
+
+from imagecraft import errors
+from imagecraft.models import (
+    FileSystem,
+    GPTVolume,
+    PartitionSchema,
+    Role,
+    Volume,
+)
+from imagecraft.pack import gptutil
+from imagecraft.subprocesses import run
+
+
+def _unmount_path(
+    target: Path,
+    *,
+    lazy: bool = False,
+    prefer_fuse2: bool = False,
+    retries: int = 1,
+) -> None:
+    """Unmount a FUSE mountpoint or virtual device file.
+
+    Tries fusermount, fusermount3, and umount depending on prefer_fuse2.
+    """
+    fuser_args = ["-u"]
+    if lazy:
+        fuser_args.append("-z")
+    fuser_args.append(str(target.resolve()))
+
+    umount_args = ["-l", str(target.resolve())] if lazy else [str(target.resolve())]
+
+    candidates = (
+        ["fusermount", "fusermount3", "umount"]
+        if prefer_fuse2
+        else ["fusermount3", "fusermount", "umount"]
+    )
+
+    last_err: Exception | None = None
+    for _ in range(retries):
+        for cmd in candidates:
+            if shutil.which(cmd) is None:
+                continue
+            args = umount_args if cmd == "umount" else fuser_args
+            try:
+                run(cmd, *args)
+            except (subprocess.CalledProcessError, FileNotFoundError) as err:
+                last_err = err
+            else:
+                return
+        time.sleep(0.1)
+
+    if last_err is not None:
+        raise last_err
+
+
+class BaseMount(abc.ABC):
+    """Abstract base class for all filesystem mounts.
+
+    Subclasses implement mounting and unmounting of specific filesystems or virtual
+    offset devices. Implements Python context manager protocol (__enter__/__exit__).
+    """
+
+    mountpoint: Path | None
+    _temp_dir: tempfile.TemporaryDirectory[str] | None
+    _is_mounted: bool
+
+    def __init__(self, *, mountpoint: Path | None = None) -> None:
+        self.mountpoint = mountpoint
+        self._temp_dir = None
+        self._is_mounted = False
+
+    @property
+    def is_mounted(self) -> bool:
+        """Check if the filesystem is currently mounted."""
+        return self._is_mounted
+
+    @property
+    def _mountpoint(self) -> Path | None:
+        """Alias for mountpoint property for internal consistency."""
+        return self.mountpoint
+
+    @_mountpoint.setter
+    def _mountpoint(self, value: Path | None) -> None:
+        self.mountpoint = value
+
+    def _ensure_mountpoint(self, prefix: str) -> Path:
+        """Ensure mountpoint directory exists and return it as a Path."""
+        if self.mountpoint is None:
+            self._temp_dir = tempfile.TemporaryDirectory(prefix=prefix)
+            self.mountpoint = Path(self._temp_dir.name)
+        else:
+            self.mountpoint.mkdir(parents=True, exist_ok=True)
+        return self.mountpoint
+
+    @abc.abstractmethod
+    def mount(self) -> Path:
+        """Mount the filesystem and return the mountpoint path.
+
+        :raises errors.MountError: If mounting fails.
+        """
+
+    @abc.abstractmethod
+    def unmount(self, *, lazy: bool = False) -> None:
+        """Unmount the filesystem.
+
+        :param lazy: If True, request lazy/detach unmount.
+        :raises errors.MountError: If unmounting fails.
+        """
+
+    def __enter__(self) -> Path:
+        """Enter context manager."""
+        return self.mount()
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        """Exit context manager."""
+        self.unmount()
+
+
+class VirtualOffsetDevice:
+    """Virtual partition device exposing a sub-slice of a disk image via fusefile.
+
+    Used when mounting FAT filesystems with an offset > 0, as fusefat lacks native
+    offset parameters.
+    """
+
+    disk_path: Path
+    offset: int
+    size: int
+    part_file: Path | None
+    _temp_dir: tempfile.TemporaryDirectory[str] | None
+    _is_mounted: bool
+
+    def __init__(self, disk_path: Path, offset: int, size: int) -> None:
+        self.disk_path = disk_path
+        self.offset = offset
+        self.size = size
+        self.part_file = None
+        self._temp_dir = None
+        self._is_mounted = False
+
+    @property
+    def is_mounted(self) -> bool:
+        """Check if the virtual device is mounted."""
+        return self._is_mounted
+
+    def mount(self) -> Path:
+        """Create the virtual file and mount the slice via fusefile.
+
+        :raises errors.MountError: If mounting the virtual device fails.
+        """
+        if self._is_mounted and self.part_file is not None:
+            return self.part_file
+
+        self._temp_dir = tempfile.TemporaryDirectory(prefix="imagecraft-vpart-")
+        self.part_file = Path(self._temp_dir.name) / "part.img"
+        self.part_file.touch()
+
+        spec = f"{self.disk_path.resolve()}/{self.offset}+{self.size}"
+        emit.debug(f"Mounting virtual offset device {self.part_file} from {spec}")
+
+        try:
+            run("fusefile", str(self.part_file), spec)
+        except (subprocess.CalledProcessError, FileNotFoundError) as err:
+            self._cleanup()
+            raise errors.MountError(
+                f"Failed to create virtual offset device with fusefile: {err}"
+            ) from err
+
+        self._is_mounted = True
+        return self.part_file
+
+    def unmount(self, *, lazy: bool = False) -> None:
+        """Unmount the virtual device."""
+        if not self._is_mounted or self.part_file is None:
+            return
+
+        part_file = self.part_file
+        emit.debug(f"Unmounting virtual offset device {part_file}")
+        try:
+            _unmount_path(part_file, lazy=lazy, prefer_fuse2=True, retries=30)
+        except (subprocess.CalledProcessError, FileNotFoundError) as err:
+            raise errors.MountError(
+                f"Failed to unmount virtual offset device {part_file}: {err}"
+            ) from err
+        finally:
+            self._cleanup()
+
+    def _cleanup(self) -> None:
+        self._is_mounted = False
+        self.part_file = None
+        if self._temp_dir is not None:
+            with contextlib.suppress(Exception):
+                self._temp_dir.cleanup()
+            self._temp_dir = None
+
+    def __enter__(self) -> Path:
+        """Enter context manager."""
+        return self.mount()
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        """Exit context manager."""
+        self.unmount()
+
+
+class ExtFuseMount(BaseMount):
+    """Mount an ext2/ext3/ext4 partition using fuse2fs.
+
+    :param imagepath: Path to the disk image or partition image.
+    :param offset: Byte offset of the partition within the image (0 if standalone).
+    :param mountpoint: Optional host directory mount point.
+    :param read_only: If True, mount read-only.
+    :param allow_other: If True, allow other users to access the mount.
+    :param fakeroot: If True, pass fakeroot option to fuse2fs.
+    """
+
+    imagepath: Path
+    offset: int
+    read_only: bool
+    allow_other: bool
+    fakeroot: bool
+
+    def __init__(
+        self,
+        imagepath: Path,
+        *,
+        offset: int = 0,
+        mountpoint: Path | None = None,
+        read_only: bool = False,
+        allow_other: bool = False,
+        fakeroot: bool = False,
+    ) -> None:
+        super().__init__(mountpoint=mountpoint)
+        self.imagepath = imagepath
+        self.offset = offset
+        self.read_only = read_only
+        self.allow_other = allow_other
+        self.fakeroot = fakeroot
+
+    def mount(self) -> Path:
+        """Mount the ext partition using fuse2fs."""
+        if self.is_mounted and self.mountpoint is not None:
+            return self.mountpoint
+
+        mountpoint = self._ensure_mountpoint("imagecraft-ext-mount-")
+
+        options: list[str] = []
+        if self.offset > 0:
+            options.append(f"offset={self.offset}")
+        if self.read_only:
+            options.append("ro")
+        else:
+            options.append("rw")
+        if self.allow_other:
+            options.append("allow_other")
+        if self.fakeroot:
+            options.append("fakeroot")
+
+        cmd: list[str] = ["fuse2fs"]
+        if options:
+            cmd.extend(["-o", ",".join(options)])
+        cmd.extend([str(self.imagepath.resolve()), str(mountpoint.resolve())])
+
+        emit.debug(f"Mounting ext partition with: {cmd}")
+        try:
+            run(*cmd)
+        except (subprocess.CalledProcessError, FileNotFoundError) as err:
+            self._cleanup()
+            raise errors.MountError(
+                f"Failed to mount ext partition {self.imagepath} at {mountpoint}: {err}"
+            ) from err
+
+        self._is_mounted = True
+        return mountpoint
+
+    def unmount(self, *, lazy: bool = False) -> None:
+        """Unmount the ext partition."""
+        if not self.is_mounted or self._mountpoint is None:
+            return
+
+        mountpoint = self._mountpoint
+        emit.debug(f"Unmounting ext partition at {mountpoint}")
+        try:
+            _unmount_path(mountpoint, lazy=lazy, retries=10)
+        except (subprocess.CalledProcessError, FileNotFoundError) as err:
+            raise errors.MountError(
+                f"Failed to unmount ext partition at {mountpoint}: {err}"
+            ) from err
+        finally:
+            self._cleanup()
+
+    def _cleanup(self) -> None:
+        self._is_mounted = False
+        if self._temp_dir is not None:
+            with contextlib.suppress(Exception):
+                self._temp_dir.cleanup()
+            self._temp_dir = None
+            self._mountpoint = None
+
+
+class FatFuseMount(BaseMount):
+    """Mount a FAT16/FAT32/VFAT partition using fusefat.
+
+    :param imagepath: Path to the disk image or partition image.
+    :param offset: Byte offset of the partition within the image (0 if standalone).
+    :param size: Byte size of the partition (required if offset > 0).
+    :param mountpoint: Optional host directory mount point.
+    :param read_only: If True, mount read-only.
+    :param allow_other: If True, allow other users to access the mount.
+    """
+
+    imagepath: Path
+    offset: int
+    size: int | None
+    read_only: bool
+    allow_other: bool
+    _vpart: VirtualOffsetDevice | None
+
+    def __init__(
+        self,
+        imagepath: Path,
+        *,
+        offset: int = 0,
+        size: int | None = None,
+        mountpoint: Path | None = None,
+        read_only: bool = False,
+        allow_other: bool = False,
+    ) -> None:
+        super().__init__(mountpoint=mountpoint)
+        self.imagepath = imagepath
+        self.offset = offset
+        self.size = size
+        self.read_only = read_only
+        self.allow_other = allow_other
+        self._vpart = None
+
+    def mount(self) -> Path:
+        """Mount the FAT partition using fusefat."""
+        if self.is_mounted and self.mountpoint is not None:
+            return self.mountpoint
+
+        mountpoint = self._ensure_mountpoint("imagecraft-fat-mount-")
+
+        target_file: Path
+        if self.offset > 0:
+            if self.size is None:
+                raise errors.MountError(
+                    "Partition size must be specified when offset > 0 for FAT partition."
+                )
+            self._vpart = VirtualOffsetDevice(self.imagepath, self.offset, self.size)
+            target_file = self._vpart.mount()
+        else:
+            target_file = self.imagepath
+
+        options = ["ro"] if self.read_only else ["rw+"]
+        if self.allow_other:
+            options.append("allow_other")
+
+        cmd = [
+            "fusefat",
+            "-o",
+            ",".join(options),
+            str(target_file.resolve()),
+            str(mountpoint.resolve()),
+        ]
+
+        emit.debug(f"Mounting FAT partition with: {cmd}")
+        try:
+            run(*cmd)
+        except (subprocess.CalledProcessError, FileNotFoundError) as err:
+            if self._vpart is not None:
+                with contextlib.suppress(Exception):
+                    self._vpart.unmount()
+                self._vpart = None
+            self._cleanup()
+            raise errors.MountError(
+                f"Failed to mount FAT partition {self.imagepath} at {mountpoint}: {err}"
+            ) from err
+
+        self._is_mounted = True
+        return mountpoint
+
+    def unmount(self, *, lazy: bool = False) -> None:
+        """Unmount the FAT partition and its virtual offset device if used."""
+        if not self.is_mounted or self._mountpoint is None:
+            return
+
+        mountpoint = self._mountpoint
+        emit.debug(f"Unmounting FAT partition at {mountpoint}")
+        err_mount: Exception | None = None
+        try:
+            _unmount_path(mountpoint, lazy=lazy, retries=10)
+        except (subprocess.CalledProcessError, FileNotFoundError) as err:
+            err_mount = err
+        finally:
+            if self._vpart is not None:
+                try:
+                    self._vpart.unmount(lazy=lazy)
+                except Exception as err_vpart:  # noqa: BLE001
+                    if err_mount is None:
+                        err_mount = err_vpart
+                finally:
+                    self._vpart = None
+            self._cleanup()
+
+        if err_mount is not None:
+            raise errors.MountError(
+                f"Failed to unmount FAT partition at {mountpoint}: {err_mount}"
+            ) from err_mount
+
+    def _cleanup(self) -> None:
+        self._is_mounted = False
+        if self._temp_dir is not None:
+            with contextlib.suppress(Exception):
+                self._temp_dir.cleanup()
+            self._temp_dir = None
+            self._mountpoint = None
+
+
+def mount_partition(
+    imagepath: Path,
+    filesystem: FileSystem | str,
+    *,
+    offset: int = 0,
+    size: int | None = None,
+    mountpoint: Path | None = None,
+    read_only: bool = False,
+    allow_other: bool = False,
+    fakeroot: bool = False,
+) -> BaseMount:
+    """Create the appropriate BaseMount instance for a partition.
+
+    :param imagepath: Path to the disk image or partition image.
+    :param filesystem: Filesystem type (e.g. ext4, fat32, vfat).
+    :param offset: Byte offset within the disk image.
+    :param size: Byte size of the partition (required for FAT when offset > 0).
+    :param mountpoint: Optional host mountpoint path.
+    :param read_only: If True, mount read-only.
+    :param allow_other: If True, pass allow_other option to FUSE.
+    :param fakeroot: If True, pass fakeroot option to FUSE (ext only).
+    :raises errors.MountError: If the filesystem type is unsupported.
+    """
+    if isinstance(filesystem, FileSystem):
+        fs_str = filesystem.value.lower()
+    else:
+        fs_str = str(filesystem).lower()
+    if fs_str in ("ext2", "ext3", "ext4"):
+        return ExtFuseMount(
+            imagepath,
+            offset=offset,
+            mountpoint=mountpoint,
+            read_only=read_only,
+            allow_other=allow_other,
+            fakeroot=fakeroot,
+        )
+    if fs_str in ("fat16", "fat32", "vfat"):
+        return FatFuseMount(
+            imagepath,
+            offset=offset,
+            size=size,
+            mountpoint=mountpoint,
+            read_only=read_only,
+            allow_other=allow_other,
+        )
+    raise errors.MountError(f"Unsupported filesystem for mounting: {filesystem}")
+
+
+class CompositeMount(BaseMount):
+    """Hierarchical composite mount managing multiple nested partition mounts.
+
+    :param mounts: Sequence of (relative_mountpoint_str, mount_instance) pairs.
+        The root filesystem should have relative mountpoint "" or "/".
+    :param mountpoint: Optional base host directory to mount under.
+    """
+
+    _mount_entries: list[tuple[str, BaseMount]]
+    _mounted_stack: list[BaseMount]
+
+    def __init__(
+        self,
+        mounts: Sequence[tuple[str, BaseMount]],
+        mountpoint: Path | None = None,
+    ) -> None:
+        super().__init__(mountpoint=mountpoint)
+        self._mount_entries = list(mounts)
+        self._mounted_stack = []
+
+    def mount(self) -> Path:
+        """Mount all sub-mounts in topological order (root to leaf)."""
+        if self.is_mounted and self.mountpoint is not None:
+            return self.mountpoint
+
+        mountpoint = self._ensure_mountpoint("imagecraft-composite-mount-")
+
+        sorted_entries = sorted(
+            self._mount_entries,
+            key=lambda item: (
+                len(Path(item[0].strip("/")).parts) if item[0].strip("/") else 0
+            ),
+        )
+
+        try:
+            for rel_path_str, mount_obj in sorted_entries:
+                rel_path = rel_path_str.strip("/")
+                target_dir = mountpoint if not rel_path else mountpoint / rel_path
+                target_dir.mkdir(parents=True, exist_ok=True)
+                mount_obj.mountpoint = target_dir
+                mount_obj.mount()
+                self._mounted_stack.append(mount_obj)
+        except Exception as err:
+            self.unmount()
+            raise errors.MountError(
+                f"Failed to mount composite mount hierarchy: {err}"
+            ) from err
+
+        self._is_mounted = True
+        return mountpoint
+
+    def unmount(self, *, lazy: bool = False) -> None:
+        """Unmount all sub-mounts in reverse topological order (leaf to root)."""
+        errors_encountered: list[Exception] = []
+
+        while self._mounted_stack:
+            mount_obj = self._mounted_stack.pop()
+            try:
+                mount_obj.unmount(lazy=lazy)
+            except Exception as err:  # noqa: BLE001
+                errors_encountered.append(err)
+
+        self._is_mounted = False
+        if self._temp_dir is not None:
+            with contextlib.suppress(Exception):
+                self._temp_dir.cleanup()
+            self._temp_dir = None
+            self._mountpoint = None
+
+        if errors_encountered:
+            raise errors.MountError(
+                f"Errors occurred during composite unmount: {errors_encountered}"
+            )
+
+
+def mount_volume(
+    volume: Volume,
+    disk_path: Path,
+    *,
+    mountpoint_overrides: dict[str, str] | None = None,
+    mountpoint: Path | None = None,
+    read_only: bool = False,
+    allow_other: bool = False,
+    fakeroot: bool = False,
+) -> CompositeMount:
+    """Mount all filesystems in a Volume as a composite tree.
+
+    :param volume: Volume definition containing partition structures.
+    :param disk_path: Path to the disk image.
+    :param mountpoint_overrides: Mapping from structure names to relative
+        mount paths inside the mounted root.
+    :param mountpoint: Optional host mountpoint path.
+    :param read_only: If True, mount all partitions read-only.
+    :param allow_other: If True, pass allow_other option to all mounts.
+    :param fakeroot: If True, pass fakeroot option to ext mounts.
+    :returns: A CompositeMount managing all partition mounts.
+    """
+    mountpoint_overrides = mountpoint_overrides or {}
+    mount_entries: list[tuple[str, BaseMount]] = []
+
+    is_gpt = (
+        isinstance(volume, GPTVolume)
+        or getattr(volume, "volume_schema", None) == PartitionSchema.GPT
+    )
+
+    for idx, item in enumerate(volume.structure, start=1):
+        filesystem = getattr(item, "filesystem", None)
+        if not filesystem:
+            continue
+
+        # Determine relative mount path
+        rel_path: str
+        if item.name in mountpoint_overrides:
+            rel_path = mountpoint_overrides[item.name]
+        elif item.role == Role.SYSTEM_DATA:
+            rel_path = ""
+        elif item.role == Role.SYSTEM_BOOT:
+            rel_path = "boot/efi"
+        elif item.role == Role.SYSTEM_SEED:
+            rel_path = "var/lib/snapd/seed"
+        else:
+            rel_path = f"mnt/{item.name}"
+
+        # Calculate byte offset and size
+        if is_gpt:
+            start_sector = gptutil.get_partition_sector_offset(disk_path, item.name)
+            size_sectors = gptutil.get_partition_size_sectors(disk_path, item.name)
+        else:
+            start_sector = gptutil.get_partition_sector_offset_by_number(disk_path, idx)
+            size_sectors = gptutil.get_partition_size_sectors_by_number(disk_path, idx)
+
+        offset_bytes = start_sector * gptutil.SECTOR_SIZE_512
+        size_bytes = size_sectors * gptutil.SECTOR_SIZE_512
+
+        part_mount = mount_partition(
+            disk_path,
+            filesystem,
+            offset=offset_bytes,
+            size=size_bytes,
+            read_only=read_only,
+            allow_other=allow_other,
+            fakeroot=fakeroot,
+        )
+        mount_entries.append((rel_path, part_mount))
+
+    return CompositeMount(mounts=mount_entries, mountpoint=mountpoint)

--- a/imagecraft/utils/mount.py
+++ b/imagecraft/utils/mount.py
@@ -526,18 +526,15 @@ class CompositeMount(BaseMount):
             return self.mountpoint
 
         mountpoint = self._ensure_mountpoint("imagecraft-composite-mount-")
-
         sorted_entries = sorted(
             self._mount_entries,
-            key=lambda item: (
-                len(Path(item[0].strip("/")).parts) if item[0].strip("/") else 0
-            ),
+            key=lambda item: len(Path(item[0].strip("/")).parts),
         )
 
         try:
             for rel_path_str, mount_obj in sorted_entries:
                 rel_path = rel_path_str.strip("/")
-                target_dir = mountpoint if not rel_path else mountpoint / rel_path
+                target_dir = mountpoint / rel_path if rel_path else mountpoint
                 target_dir.mkdir(parents=True, exist_ok=True)
                 mount_obj.mountpoint = target_dir
                 mount_obj.mount()
@@ -554,21 +551,13 @@ class CompositeMount(BaseMount):
     def unmount(self, *, lazy: bool = False) -> None:
         """Unmount all sub-mounts in reverse topological order (leaf to root)."""
         errors_encountered: list[Exception] = []
-
         while self._mounted_stack:
-            mount_obj = self._mounted_stack.pop()
             try:
-                mount_obj.unmount(lazy=lazy)
-            except Exception as err:  # noqa: BLE001
+                self._mounted_stack.pop().unmount(lazy=lazy)
+            except Exception as err:  # noqa: BLE001, PERF203
                 errors_encountered.append(err)
 
-        self._is_mounted = False
-        if self._temp_dir is not None:
-            with contextlib.suppress(Exception):
-                self._temp_dir.cleanup()
-            self._temp_dir = None
-            self.mountpoint = None
-
+        self._cleanup()
         if errors_encountered:
             raise errors.MountError(
                 f"Errors occurred during composite unmount: {errors_encountered}"

--- a/imagecraft/utils/mount.py
+++ b/imagecraft/utils/mount.py
@@ -38,6 +38,19 @@ from imagecraft.pack import gptutil
 from imagecraft.subprocesses import run
 
 
+def _try_fuse_command(command: Sequence[str], *, err_msg: str) -> None:
+    """Run a FUSE helper command, wrapping failures in ``MountError``.
+
+    :param command: The command and arguments to run.
+    :param err_msg: Human-readable error message to raise on failure.
+    :raises errors.MountError: If the command fails or the binary is missing.
+    """
+    try:
+        run(*command)
+    except (subprocess.CalledProcessError, FileNotFoundError) as err:
+        raise errors.MountError(f"{err_msg}: {err}") from err
+
+
 def _unmount_path(
     target: Path,
     *,
@@ -63,35 +76,22 @@ def _unmount_path(
         else ["fusermount3", "fusermount", "umount"]
     )
 
-    last_err: Exception | None = None
+    last_err: errors.MountError | None = None
     for _ in range(retries):
         for cmd in candidates:
             if shutil.which(cmd) is None:
                 continue
             args = umount_args if cmd == "umount" else fuser_args
             try:
-                run(cmd, *args)
-            except (subprocess.CalledProcessError, FileNotFoundError) as err:
+                _try_fuse_command([cmd, *args], err_msg=err_msg)
+            except errors.MountError as err:
                 last_err = err
             else:
                 return
         time.sleep(0.1)
 
     if last_err is not None:
-        raise errors.MountError(f"{err_msg}: {last_err}") from last_err
-
-
-def _try_fuse_command(command: Sequence[str], *, err_msg: str) -> None:
-    """Run a FUSE helper command, wrapping failures in ``MountError``.
-
-    :param command: The command and arguments to run.
-    :param err_msg: Human-readable error message to raise on failure.
-    :raises errors.MountError: If the command fails or the binary is missing.
-    """
-    try:
-        run(*command)
-    except (subprocess.CalledProcessError, FileNotFoundError) as err:
-        raise errors.MountError(f"{err_msg}: {err}") from err
+        raise last_err
 
 
 class BaseMount(abc.ABC):

--- a/imagecraft/utils/mount.py
+++ b/imagecraft/utils/mount.py
@@ -44,6 +44,7 @@ def _unmount_path(
     lazy: bool = False,
     prefer_fuse2: bool = False,
     retries: int = 1,
+    err_msg: str = "Failed to unmount",
 ) -> None:
     """Unmount a FUSE mountpoint or virtual device file.
 
@@ -77,7 +78,7 @@ def _unmount_path(
         time.sleep(0.1)
 
     if last_err is not None:
-        raise last_err
+        raise errors.MountError(f"{err_msg}: {last_err}") from last_err
 
 
 def _try_fuse_command(command: Sequence[str], *, err_msg: str) -> None:
@@ -215,11 +216,13 @@ class VirtualOffsetDevice(BaseMount):
         part_file = self.part_file
         emit.debug(f"Unmounting virtual offset device {part_file}")
         try:
-            _unmount_path(part_file, lazy=lazy, prefer_fuse2=True, retries=30)
-        except (subprocess.CalledProcessError, FileNotFoundError) as err:
-            raise errors.MountError(
-                f"Failed to unmount virtual offset device {part_file}: {err}"
-            ) from err
+            _unmount_path(
+                part_file,
+                lazy=lazy,
+                prefer_fuse2=True,
+                retries=30,
+                err_msg=f"Failed to unmount virtual offset device {part_file}",
+            )
         finally:
             self._cleanup()
 
@@ -307,11 +310,12 @@ class ExtFuseMount(BaseMount):
         mountpoint = self.mountpoint
         emit.debug(f"Unmounting ext partition at {mountpoint}")
         try:
-            _unmount_path(mountpoint, lazy=lazy, retries=10)
-        except (subprocess.CalledProcessError, FileNotFoundError) as err:
-            raise errors.MountError(
-                f"Failed to unmount ext partition at {mountpoint}: {err}"
-            ) from err
+            _unmount_path(
+                mountpoint,
+                lazy=lazy,
+                retries=10,
+                err_msg=f"Failed to unmount ext partition at {mountpoint}",
+            )
         finally:
             self._cleanup()
 
@@ -408,8 +412,13 @@ class FatFuseMount(BaseMount):
         emit.debug(f"Unmounting FAT partition at {mountpoint}")
         err_mount: Exception | None = None
         try:
-            _unmount_path(mountpoint, lazy=lazy, retries=10)
-        except (subprocess.CalledProcessError, FileNotFoundError) as err:
+            _unmount_path(
+                mountpoint,
+                lazy=lazy,
+                retries=10,
+                err_msg=f"Failed to unmount FAT partition at {mountpoint}",
+            )
+        except errors.MountError as err:
             err_mount = err
         finally:
             if self._vpart is not None:
@@ -423,9 +432,7 @@ class FatFuseMount(BaseMount):
             self._cleanup()
 
         if err_mount is not None:
-            raise errors.MountError(
-                f"Failed to unmount FAT partition at {mountpoint}: {err_mount}"
-            ) from err_mount
+            raise err_mount
 
 
 def mount_partition(

--- a/imagecraft/utils/mount.py
+++ b/imagecraft/utils/mount.py
@@ -231,7 +231,62 @@ class VirtualOffsetDevice(BaseMount):
         self.part_file = None
 
 
-class ExtFuseMount(BaseMount):
+class BasePartitionMount(BaseMount):
+    """Abstract base class for FUSE partition mounts.
+
+    :param imagepath: Path to the disk image or partition image.
+    :param offset: Byte offset of the partition within the image (0 if standalone).
+    :param mountpoint: Optional host directory mount point.
+    :param read_only: If True, mount read-only.
+    :param allow_other: If True, allow other users to access the mount.
+    """
+
+    imagepath: Path
+    offset: int
+    read_only: bool
+    allow_other: bool
+
+    def __init__(
+        self,
+        imagepath: Path,
+        *,
+        offset: int = 0,
+        mountpoint: Path | None = None,
+        read_only: bool = False,
+        allow_other: bool = False,
+    ) -> None:
+        super().__init__(mountpoint=mountpoint)
+        self.imagepath = imagepath
+        self.offset = offset
+        self.read_only = read_only
+        self.allow_other = allow_other
+
+    def _build_options(self, *, rw_flag: str = "rw") -> list[str]:
+        """Build common FUSE mount options."""
+        options = ["ro"] if self.read_only else [rw_flag]
+        if self.allow_other:
+            options.append("allow_other")
+        return options
+
+    def unmount(self, *, lazy: bool = False) -> None:
+        """Unmount the partition."""
+        if not self.is_mounted or self.mountpoint is None:
+            return
+
+        mountpoint = self.mountpoint
+        emit.debug(f"Unmounting partition at {mountpoint}")
+        try:
+            _unmount_path(
+                mountpoint,
+                lazy=lazy,
+                retries=10,
+                err_msg=f"Failed to unmount partition at {mountpoint}",
+            )
+        finally:
+            self._cleanup()
+
+
+class ExtFuseMount(BasePartitionMount):
     """Mount an ext2/ext3/ext4 partition using fuse2fs.
 
     :param imagepath: Path to the disk image or partition image.
@@ -242,10 +297,6 @@ class ExtFuseMount(BaseMount):
     :param fakeroot: If True, pass fakeroot option to fuse2fs.
     """
 
-    imagepath: Path
-    offset: int
-    read_only: bool
-    allow_other: bool
     fakeroot: bool
 
     def __init__(
@@ -258,11 +309,13 @@ class ExtFuseMount(BaseMount):
         allow_other: bool = False,
         fakeroot: bool = False,
     ) -> None:
-        super().__init__(mountpoint=mountpoint)
-        self.imagepath = imagepath
-        self.offset = offset
-        self.read_only = read_only
-        self.allow_other = allow_other
+        super().__init__(
+            imagepath,
+            offset=offset,
+            mountpoint=mountpoint,
+            read_only=read_only,
+            allow_other=allow_other,
+        )
         self.fakeroot = fakeroot
 
     def mount(self) -> Path:
@@ -272,22 +325,19 @@ class ExtFuseMount(BaseMount):
 
         mountpoint = self._ensure_mountpoint("imagecraft-ext-mount-")
 
-        options: list[str] = []
+        options = self._build_options(rw_flag="rw")
         if self.offset > 0:
-            options.append(f"offset={self.offset}")
-        if self.read_only:
-            options.append("ro")
-        else:
-            options.append("rw")
-        if self.allow_other:
-            options.append("allow_other")
+            options.insert(0, f"offset={self.offset}")
         if self.fakeroot:
             options.append("fakeroot")
 
-        cmd: list[str] = ["fuse2fs"]
-        if options:
-            cmd.extend(["-o", ",".join(options)])
-        cmd.extend([str(self.imagepath.resolve()), str(mountpoint.resolve())])
+        cmd = [
+            "fuse2fs",
+            "-o",
+            ",".join(options),
+            str(self.imagepath.resolve()),
+            str(mountpoint.resolve()),
+        ]
 
         emit.debug(f"Mounting ext partition with: {cmd}")
         try:
@@ -302,25 +352,8 @@ class ExtFuseMount(BaseMount):
         self._is_mounted = True
         return mountpoint
 
-    def unmount(self, *, lazy: bool = False) -> None:
-        """Unmount the ext partition."""
-        if not self.is_mounted or self.mountpoint is None:
-            return
 
-        mountpoint = self.mountpoint
-        emit.debug(f"Unmounting ext partition at {mountpoint}")
-        try:
-            _unmount_path(
-                mountpoint,
-                lazy=lazy,
-                retries=10,
-                err_msg=f"Failed to unmount ext partition at {mountpoint}",
-            )
-        finally:
-            self._cleanup()
-
-
-class FatFuseMount(BaseMount):
+class FatFuseMount(BasePartitionMount):
     """Mount a FAT16/FAT32/VFAT partition using fusefat.
 
     :param imagepath: Path to the disk image or partition image.
@@ -331,11 +364,7 @@ class FatFuseMount(BaseMount):
     :param allow_other: If True, allow other users to access the mount.
     """
 
-    imagepath: Path
-    offset: int
     size: int | None
-    read_only: bool
-    allow_other: bool
     _vpart: VirtualOffsetDevice | None
 
     def __init__(
@@ -348,12 +377,14 @@ class FatFuseMount(BaseMount):
         read_only: bool = False,
         allow_other: bool = False,
     ) -> None:
-        super().__init__(mountpoint=mountpoint)
-        self.imagepath = imagepath
-        self.offset = offset
+        super().__init__(
+            imagepath,
+            offset=offset,
+            mountpoint=mountpoint,
+            read_only=read_only,
+            allow_other=allow_other,
+        )
         self.size = size
-        self.read_only = read_only
-        self.allow_other = allow_other
         self._vpart = None
 
     def mount(self) -> Path:
@@ -374,10 +405,7 @@ class FatFuseMount(BaseMount):
         else:
             target_file = self.imagepath
 
-        options = ["ro"] if self.read_only else ["rw+"]
-        if self.allow_other:
-            options.append("allow_other")
-
+        options = self._build_options(rw_flag="rw+")
         cmd = [
             "fusefat",
             "-o",
@@ -405,19 +433,9 @@ class FatFuseMount(BaseMount):
 
     def unmount(self, *, lazy: bool = False) -> None:
         """Unmount the FAT partition and its virtual offset device if used."""
-        if not self.is_mounted or self.mountpoint is None:
-            return
-
-        mountpoint = self.mountpoint
-        emit.debug(f"Unmounting FAT partition at {mountpoint}")
         err_mount: Exception | None = None
         try:
-            _unmount_path(
-                mountpoint,
-                lazy=lazy,
-                retries=10,
-                err_msg=f"Failed to unmount FAT partition at {mountpoint}",
-            )
+            super().unmount(lazy=lazy)
         except errors.MountError as err:
             err_mount = err
         finally:
@@ -429,7 +447,6 @@ class FatFuseMount(BaseMount):
                         err_mount = err_vpart
                 finally:
                     self._vpart = None
-            self._cleanup()
 
         if err_mount is not None:
             raise err_mount

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -75,6 +75,8 @@ parts:
       - fdisk
       - coreutils
       - util-linux
+      - fusefile
+      - fuse3
     stage:
       - "-usr/lib/x86_64-linux-gnu/libicuio.so.*"
       - "-usr/lib/x86_64-linux-gnu/libicutest.so.*"
@@ -87,7 +89,33 @@ parts:
       "usr/bin/mtools": "libexec/imagecraft/mtools"
       "usr/bin/dd": "libexec/imagecraft/dd"
       "usr/bin/truncate": "libexec/imagecraft/truncate"
+      "usr/sbin/fuse2fs": "libexec/imagecraft/fuse2fs"
+      "usr/sbin/fusefile": "libexec/imagecraft/fusefile"
+      "usr/bin/fusermount3": "libexec/imagecraft/fusermount3"
       "usr/sbin/mkfs*": "libexec/imagecraft/"
+  # Build fusefat 0.4 from source because the archive only provides it on amd64 in Noble.
+  # TODO: Remove when upgrading base to core26.
+  fusefat:
+    source: https://github.com/virtualsquare/fusefatfs.git
+    source-commit: 9d612e83909f2719f004b8aad843ad9d320fece1 # 0.4
+    plugin: cmake
+    build-attributes:
+      - enable-patchelf
+    build-packages:
+      - libfuse3-dev
+      - pkgconf
+    stage-packages:
+      - libfuse3-3
+    override-build: |
+      craftctl default
+      for bindir in "${CRAFT_PART_INSTALL}/usr/local/bin" "${CRAFT_PART_INSTALL}/usr/bin"; do
+        if [ -f "${bindir}/fusefatfs" ] && [ ! -f "${bindir}/fusefat" ]; then
+          ln -sf fusefatfs "${bindir}/fusefat"
+        fi
+      done
+    organize:
+      "usr/local/bin/fusefat*": "libexec/imagecraft/"
+      "usr/bin/fusefat*": "libexec/imagecraft/"
   # Build our own version of fuse-overlayfs due to https://github.com/containers/fuse-overlayfs/issues/429
   # The apt and Launchpad repositories as of 23/07/25 do not have a sufficiently new version to get this patch
   fuse-overlayfs:
@@ -120,7 +148,7 @@ parts:
     prime:
       - -*
   imagecraft:
-    after: [imagecraft-libs, rustc]
+    after: [imagecraft-libs, rustc, fusefat]
     source: .
     plugin: uv
     build-attributes:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,7 @@
 # You should have received a copy of the GNU General Public License along
 # with this program.  If not, see <http://www.gnu.org/licenses/>.
 import os
+import platform
 import types
 from pathlib import Path
 from unittest import mock
@@ -22,6 +23,38 @@ import pytest
 from craft_application import ProjectService, ServiceFactory
 from imagecraft import cli, plugins
 from imagecraft.application import APP_METADATA
+
+
+def is_noble() -> bool:
+    """Check if running on Ubuntu 24.04 (noble)."""
+    try:
+        return platform.freedesktop_os_release().get("VERSION_CODENAME") == "noble"
+    except (AttributeError, OSError):
+        pass
+    os_release_path = Path("/etc/os-release")
+    if os_release_path.exists():
+        for line in os_release_path.read_text().splitlines():
+            if line.startswith("VERSION_CODENAME="):
+                return line.split("=", 1)[1].strip("\"'") == "noble"
+    return False
+
+
+def is_noble_non_amd64() -> bool:
+    """Check if running on Ubuntu Noble on a non-amd64 architecture.
+
+    The fusefat package is only available in Ubuntu universe repositories for
+    amd64 and i386 on Ubuntu 24.04 (Noble) and earlier. It was not built for
+    ARM64 or other non-x86 architectures on Noble.
+    """
+    if platform.machine() in ("x86_64", "AMD64"):
+        return False
+    return is_noble()
+
+
+@pytest.fixture
+def host_is_noble() -> bool:
+    """Fixture indicating if the host system is Ubuntu Noble."""
+    return is_noble()
 
 
 def pytest_runtest_setup(item: pytest.Item) -> None:

--- a/tests/integration/plugins/test_mmdebstrap_plugin.py
+++ b/tests/integration/plugins/test_mmdebstrap_plugin.py
@@ -15,19 +15,12 @@
 #  with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Integration tests for the mmdebstrap plugin."""
 
-import platform
 from pathlib import Path
 
 import pytest
 from imagecraft import application
 
-
-def _host_is_noble() -> bool:
-    """Check if running on Ubuntu 24.04 (noble)."""
-    try:
-        return platform.freedesktop_os_release().get("VERSION_CODENAME") == "noble"
-    except (AttributeError, OSError):
-        return False
+from tests.conftest import is_noble
 
 
 @pytest.fixture
@@ -46,7 +39,7 @@ def test_mmdebstrap_cleanup(
     monkeypatch: pytest.MonkeyPatch,
 ):
     """Test that mmdebstrap plugin cleans up /sys, /proc and /dev."""
-    if not _host_is_noble():
+    if not is_noble():
         pytest.skip(
             "destructive-mode builds require the host series to match the "
             "project's build-base (ubuntu@24.04)"

--- a/tests/integration/plugins/test_mmdebstrap_plugin.py
+++ b/tests/integration/plugins/test_mmdebstrap_plugin.py
@@ -15,10 +15,19 @@
 #  with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Integration tests for the mmdebstrap plugin."""
 
+import platform
 from pathlib import Path
 
 import pytest
 from imagecraft import application
+
+
+def _host_is_noble() -> bool:
+    """Check if running on Ubuntu 24.04 (noble)."""
+    try:
+        return platform.freedesktop_os_release().get("VERSION_CODENAME") == "noble"
+    except (AttributeError, OSError):
+        return False
 
 
 @pytest.fixture
@@ -37,6 +46,11 @@ def test_mmdebstrap_cleanup(
     monkeypatch: pytest.MonkeyPatch,
 ):
     """Test that mmdebstrap plugin cleans up /sys, /proc and /dev."""
+    if not _host_is_noble():
+        pytest.skip(
+            "destructive-mode builds require the host series to match the "
+            "project's build-base (ubuntu@24.04)"
+        )
     monkeypatch.setattr(
         "sys.argv",
         ["imagecraft", "build", "--destructive-mode", "--verbosity", "debug"],

--- a/tests/integration/plugins/test_overlay_plugin.py
+++ b/tests/integration/plugins/test_overlay_plugin.py
@@ -14,6 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import platform
 from pathlib import Path
 from typing import Literal
 
@@ -23,6 +24,14 @@ from craft_parts.plugins import Plugin, PluginProperties
 from imagecraft import application
 from imagecraft.plugins import get_app_plugins
 from typing_extensions import override
+
+
+def _host_is_noble() -> bool:
+    """Check if running on Ubuntu 24.04 (noble)."""
+    try:
+        return platform.freedesktop_os_release().get("VERSION_CODENAME") == "noble"
+    except (AttributeError, OSError):
+        return False
 
 
 @pytest.fixture
@@ -84,6 +93,11 @@ def test_overlay_plugin(
     imagecraft_app: application.Imagecraft,
     monkeypatch: pytest.MonkeyPatch,
 ):
+    if not _host_is_noble():
+        pytest.skip(
+            "destructive-mode builds require the host series to match the "
+            "project's build-base (ubuntu@24.04)"
+        )
     monkeypatch.setattr(
         "sys.argv",
         ["imagecraft", "pack", "--destructive-mode", "--verbosity", "debug"],

--- a/tests/integration/plugins/test_overlay_plugin.py
+++ b/tests/integration/plugins/test_overlay_plugin.py
@@ -14,7 +14,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import platform
 from pathlib import Path
 from typing import Literal
 
@@ -25,13 +24,7 @@ from imagecraft import application
 from imagecraft.plugins import get_app_plugins
 from typing_extensions import override
 
-
-def _host_is_noble() -> bool:
-    """Check if running on Ubuntu 24.04 (noble)."""
-    try:
-        return platform.freedesktop_os_release().get("VERSION_CODENAME") == "noble"
-    except (AttributeError, OSError):
-        return False
+from tests.conftest import is_noble
 
 
 @pytest.fixture
@@ -93,7 +86,7 @@ def test_overlay_plugin(
     imagecraft_app: application.Imagecraft,
     monkeypatch: pytest.MonkeyPatch,
 ):
-    if not _host_is_noble():
+    if not is_noble():
         pytest.skip(
             "destructive-mode builds require the host series to match the "
             "project's build-base (ubuntu@24.04)"

--- a/tests/integration/utils/__init__.py
+++ b/tests/integration/utils/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2026 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.

--- a/tests/integration/utils/test_mount.py
+++ b/tests/integration/utils/test_mount.py
@@ -1,0 +1,320 @@
+# Copyright 2026 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import platform
+import shutil
+from pathlib import Path
+
+import pytest
+from imagecraft.models import FileSystem, GPTVolume, MBRVolume
+from imagecraft.pack import diskutil, gptutil, mbrutil
+from imagecraft.utils.mount import (
+    mount_partition,
+    mount_volume,
+)
+
+
+def _is_noble_non_amd64() -> bool:
+    """Check if running on Ubuntu Noble on a non-amd64 architecture.
+
+    The fusefat package is only available in Ubuntu universe repositories for
+    amd64 and i386 on Ubuntu 24.04 (Noble) and earlier. It was not built for
+    ARM64 or other non-x86 architectures on Noble.
+    """
+    if platform.machine() in ("x86_64", "AMD64"):
+        return False
+    try:
+        os_release = platform.freedesktop_os_release()
+        return os_release.get("VERSION_CODENAME") == "noble"
+    except (AttributeError, OSError):
+        pass
+    os_release_path = Path("/etc/os-release")
+    if os_release_path.exists():
+        for line in os_release_path.read_text().splitlines():
+            if line.startswith("VERSION_CODENAME="):
+                return line.split("=", 1)[1].strip("\"'") == "noble"
+    return False
+
+
+REQUIRED_EXECUTABLES: dict[str, str] = {
+    "fuse2fs": "fuse2fs",
+    "fusefile": "fusefile",
+    "fusermount3": "fuse3",
+}
+if not _is_noble_non_amd64():
+    REQUIRED_EXECUTABLES["fusefat"] = "fusefat"
+
+
+@pytest.fixture(autouse=True, scope="module")
+def check_required_executables() -> None:
+    missing: list[str] = [
+        f"{binary} (install package: {pkg})"
+        for binary, pkg in REQUIRED_EXECUTABLES.items()
+        if shutil.which(binary) is None
+    ]
+    if missing:
+        missing_str = "\n  - ".join(missing)
+        missing_pkgs = " ".join(
+            dict.fromkeys(
+                pkg
+                for binary, pkg in REQUIRED_EXECUTABLES.items()
+                if shutil.which(binary) is None
+            )
+        )
+        pytest.fail(
+            f"Missing required executables for FUSE integration tests:\n  - {missing_str}\n"
+            f"Install them with:\n  sudo apt-get install {missing_pkgs}"
+        )
+
+
+@pytest.fixture(
+    params=[
+        pytest.param(False, marks=pytest.mark.requires_root, id="as_root"),
+        pytest.param(True, id="with_fakeroot"),
+    ]
+)
+def fakeroot(request: pytest.FixtureRequest) -> bool:
+    return request.param
+
+
+@pytest.fixture(
+    params=[
+        pytest.param(
+            GPTVolume.unmarshal(
+                {
+                    "schema": "gpt",
+                    "structure": [
+                        {
+                            "name": "efi",
+                            "role": "system-boot",
+                            "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+                            "filesystem": "vfat",
+                            "size": "32M",
+                            "filesystem-label": "EFI",
+                        },
+                        {
+                            "name": "rootfs",
+                            "role": "system-data",
+                            "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                            "filesystem": "ext4",
+                            "size": "64M",
+                            "filesystem-label": "writable",
+                        },
+                    ],
+                }
+            ),
+            id="gpt",
+        ),
+        pytest.param(
+            MBRVolume.unmarshal(
+                {
+                    "schema": "mbr",
+                    "structure": [
+                        {
+                            "name": "ubuntu-seed",
+                            "role": "system-boot",
+                            "type": "0C",
+                            "filesystem": "vfat",
+                            "size": "32M",
+                            "filesystem-label": "seed",
+                        },
+                        {
+                            "name": "rootfs",
+                            "role": "system-data",
+                            "type": "83",
+                            "filesystem": "ext4",
+                            "size": "64M",
+                            "filesystem-label": "writable",
+                        },
+                    ],
+                }
+            ),
+            id="mbr",
+        ),
+    ]
+)
+def volume_definition(request: pytest.FixtureRequest) -> GPTVolume | MBRVolume:
+    return request.param
+
+
+@pytest.fixture(params=[pytest.param(fs, id=fs.value) for fs in FileSystem])
+def fstype(request: pytest.FixtureRequest) -> FileSystem:
+    return request.param
+
+
+def test_mount_partition_standalone(
+    tmp_path: Path,
+    fstype: FileSystem,
+    fakeroot: bool,  # noqa: FBT001
+):
+    if "fat" in fstype.value and _is_noble_non_amd64():
+        pytest.skip("fusefat is unavailable on noble on non-amd64 architectures")
+
+    img_path = tmp_path / f"standalone.{fstype.value}"
+    with img_path.open("wb") as f:
+        f.truncate(32 * 1024 * 1024)
+
+    content_dir = tmp_path / "empty_content"
+    content_dir.mkdir(exist_ok=True)
+    diskutil.format_populate_partition(
+        fstype=fstype,
+        content_dir=content_dir,
+        partitionpath=img_path,
+    )
+
+    mount = mount_partition(img_path, fstype, fakeroot=fakeroot)
+    with mount as root:
+        test_file = root / "hello.txt"
+        test_file.write_text(f"Hello {fstype.value} FUSE!\n")
+        sub_dir = root / "dir" / "subdir"
+        sub_dir.mkdir(parents=True)
+        (sub_dir / "data.bin").write_bytes(b"PAYLOAD_DATA")
+
+    assert not mount.is_mounted
+
+    # Verify data persisted across unmount
+    with mount as root:
+        assert (root / "hello.txt").read_text() == f"Hello {fstype.value} FUSE!\n"
+        assert (root / "dir" / "subdir" / "data.bin").read_bytes() == b"PAYLOAD_DATA"
+
+
+def test_mount_partition_offset(
+    tmp_path: Path,
+    fstype: FileSystem,
+    fakeroot: bool,  # noqa: FBT001
+):
+    if "fat" in fstype.value:
+        if _is_noble_non_amd64():
+            pytest.skip("fusefat is unavailable on noble on non-amd64 architectures")
+        if os.geteuid() != 0:
+            pytest.skip(
+                f"{fstype.value} offset mounts via fusefile require root permissions"
+            )
+
+    disk_path = tmp_path / f"disk_{fstype.value}.raw"
+    disk_size = 64 * 1024 * 1024
+    offset_bytes = 1048576  # 1 MiB
+    part_size_bytes = 32 * 1024 * 1024  # 32 MiB
+
+    with disk_path.open("wb") as f:
+        f.truncate(disk_size)
+
+    part_tmp = tmp_path / f"part_{fstype.value}.img"
+    with part_tmp.open("wb") as f:
+        f.truncate(part_size_bytes)
+    content_dir = tmp_path / "empty_content"
+    content_dir.mkdir(exist_ok=True)
+    diskutil.format_populate_partition(
+        fstype=fstype,
+        content_dir=content_dir,
+        partitionpath=part_tmp,
+    )
+
+    with part_tmp.open("rb") as src, disk_path.open("r+b") as dst:
+        dst.seek(offset_bytes)
+        dst.write(src.read())
+
+    part_tmp.unlink()
+
+    mount = mount_partition(
+        disk_path,
+        fstype,
+        offset=offset_bytes,
+        size=part_size_bytes,
+        fakeroot=fakeroot,
+    )
+
+    with mount as root:
+        (root / "config.txt").write_text(f"offset {fstype.value} config\n")
+        sub_dir = root / "sub"
+        sub_dir.mkdir(parents=True)
+        (sub_dir / "test.bin").write_bytes(b"OFFSET_BINARY")
+
+    assert not mount.is_mounted
+
+    # Verify persistence directly from the disk image at offset
+    with mount as root:
+        assert (root / "config.txt").read_text() == f"offset {fstype.value} config\n"
+        assert (root / "sub" / "test.bin").read_bytes() == b"OFFSET_BINARY"
+
+
+@pytest.mark.requires_root
+def test_volume_mount(
+    volume_definition: GPTVolume | MBRVolume,
+    tmp_path: Path,
+):
+    if _is_noble_non_amd64():
+        pytest.skip("fusefat is unavailable on noble on non-amd64 architectures")
+    disk_path = tmp_path / f"{volume_definition.volume_schema.value}_disk.raw"
+    sector_size = gptutil.SECTOR_SIZE_512
+
+    if isinstance(volume_definition, GPTVolume):
+        gptutil.create_empty_gpt_image(disk_path, sector_size, volume_definition)
+    else:
+        mbrutil.create_empty_mbr_image(disk_path, sector_size, volume_definition)
+
+    # Format and inject partitions into the image
+    for idx, item in enumerate(volume_definition.structure, start=1):
+        part_file = tmp_path / f"{item.name}.img"
+        with part_file.open("wb") as f:
+            f.truncate(int(item.size))
+        content_dir = tmp_path / f"{item.name}_content"
+        content_dir.mkdir(exist_ok=True)
+        diskutil.format_populate_partition(
+            fstype=item.filesystem,
+            content_dir=content_dir,
+            partitionpath=part_file,
+            label=item.filesystem_label,
+        )
+        if isinstance(volume_definition, GPTVolume):
+            start_sector = gptutil.get_partition_sector_offset(disk_path, item.name)
+        else:
+            start_sector = gptutil.get_partition_sector_offset_by_number(disk_path, idx)
+
+        diskutil.inject_partition_into_image(
+            partition=part_file,
+            imagepath=disk_path,
+            sector_offset=start_sector,
+            disk_size=diskutil.DiskSize(
+                bytesize=int(item.size), sector_size=sector_size
+            ),
+        )
+
+    # Mount full composite volume
+    with mount_volume(volume_definition, disk_path) as rootfs:
+        # Write to rootfs (ext4)
+        etc_dir = rootfs / "etc"
+        etc_dir.mkdir(parents=True, exist_ok=True)
+        (etc_dir / "hostname").write_text(
+            f"{volume_definition.volume_schema.value}-box\n"
+        )
+
+        # Write to EFI / boot partition (vfat, nested under /boot/efi)
+        efi_root = rootfs / "boot" / "efi"
+        if (efi_root / "EFI").is_file() and (efi_root / "EFI").stat().st_size == 0:
+            (efi_root / "EFI").unlink()
+
+        efi_boot = efi_root / "EFI" / "BOOT"
+        efi_boot.mkdir(parents=True, exist_ok=True)
+        (efi_boot / "grubx64.efi").write_bytes(b"GRUB_BINARY")
+
+    # Remount and verify both filesystems
+    with mount_volume(volume_definition, disk_path) as rootfs:
+        assert (rootfs / "etc" / "hostname").read_text() == (
+            f"{volume_definition.volume_schema.value}-box\n"
+        )
+        assert (
+            rootfs / "boot" / "efi" / "EFI" / "BOOT" / "grubx64.efi"
+        ).read_bytes() == b"GRUB_BINARY"

--- a/tests/integration/utils/test_mount.py
+++ b/tests/integration/utils/test_mount.py
@@ -13,7 +13,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
-import platform
 import shutil
 from pathlib import Path
 
@@ -25,35 +24,14 @@ from imagecraft.utils.mount import (
     mount_volume,
 )
 
-
-def _is_noble_non_amd64() -> bool:
-    """Check if running on Ubuntu Noble on a non-amd64 architecture.
-
-    The fusefat package is only available in Ubuntu universe repositories for
-    amd64 and i386 on Ubuntu 24.04 (Noble) and earlier. It was not built for
-    ARM64 or other non-x86 architectures on Noble.
-    """
-    if platform.machine() in ("x86_64", "AMD64"):
-        return False
-    try:
-        os_release = platform.freedesktop_os_release()
-        return os_release.get("VERSION_CODENAME") == "noble"
-    except (AttributeError, OSError):
-        pass
-    os_release_path = Path("/etc/os-release")
-    if os_release_path.exists():
-        for line in os_release_path.read_text().splitlines():
-            if line.startswith("VERSION_CODENAME="):
-                return line.split("=", 1)[1].strip("\"'") == "noble"
-    return False
-
+from tests.conftest import is_noble_non_amd64
 
 REQUIRED_EXECUTABLES: dict[str, str] = {
     "fuse2fs": "fuse2fs",
     "fusefile": "fusefile",
     "fusermount3": "fuse3",
 }
-if not _is_noble_non_amd64():
+if not is_noble_non_amd64():
     REQUIRED_EXECUTABLES["fusefat"] = "fusefat"
 
 
@@ -159,7 +137,7 @@ def test_mount_partition_standalone(
     fstype: FileSystem,
     fakeroot: bool,  # noqa: FBT001
 ):
-    if "fat" in fstype.value and _is_noble_non_amd64():
+    if "fat" in fstype.value and is_noble_non_amd64():
         pytest.skip("fusefat is unavailable on noble on non-amd64 architectures")
 
     img_path = tmp_path / f"standalone.{fstype.value}"
@@ -196,7 +174,7 @@ def test_mount_partition_offset(
     fakeroot: bool,  # noqa: FBT001
 ):
     if "fat" in fstype.value:
-        if _is_noble_non_amd64():
+        if is_noble_non_amd64():
             pytest.skip("fusefat is unavailable on noble on non-amd64 architectures")
         if os.geteuid() != 0:
             pytest.skip(
@@ -255,7 +233,7 @@ def test_volume_mount(
     volume_definition: GPTVolume | MBRVolume,
     tmp_path: Path,
 ):
-    if _is_noble_non_amd64():
+    if is_noble_non_amd64():
         pytest.skip("fusefat is unavailable on noble on non-amd64 architectures")
     disk_path = tmp_path / f"{volume_definition.volume_schema.value}_disk.raw"
     sector_size = gptutil.SECTOR_SIZE_512

--- a/tests/integration/utils/test_mount.py
+++ b/tests/integration/utils/test_mount.py
@@ -26,36 +26,6 @@ from imagecraft.utils.mount import (
 
 from tests.conftest import is_noble_non_amd64
 
-REQUIRED_EXECUTABLES: dict[str, str] = {
-    "fuse2fs": "fuse2fs",
-    "fusefile": "fusefile",
-    "fusermount3": "fuse3",
-}
-if not is_noble_non_amd64():
-    REQUIRED_EXECUTABLES["fusefat"] = "fusefat"
-
-
-@pytest.fixture(autouse=True, scope="module")
-def check_required_executables() -> None:
-    missing: list[str] = [
-        f"{binary} (install package: {pkg})"
-        for binary, pkg in REQUIRED_EXECUTABLES.items()
-        if shutil.which(binary) is None
-    ]
-    if missing:
-        missing_str = "\n  - ".join(missing)
-        missing_pkgs = " ".join(
-            dict.fromkeys(
-                pkg
-                for binary, pkg in REQUIRED_EXECUTABLES.items()
-                if shutil.which(binary) is None
-            )
-        )
-        pytest.fail(
-            f"Missing required executables for FUSE integration tests:\n  - {missing_str}\n"
-            f"Install them with:\n  sudo apt-get install {missing_pkgs}"
-        )
-
 
 @pytest.fixture(
     params=[
@@ -137,8 +107,13 @@ def test_mount_partition_standalone(
     fstype: FileSystem,
     fakeroot: bool,  # noqa: FBT001
 ):
-    if "fat" in fstype.value and is_noble_non_amd64():
-        pytest.skip("fusefat is unavailable on noble on non-amd64 architectures")
+    if "ext" in fstype.value and shutil.which("fuse2fs") is None:
+        pytest.skip("fuse2fs is not installed")
+    if "fat" in fstype.value:
+        if is_noble_non_amd64():
+            pytest.skip("fusefat is unavailable on noble on non-amd64 architectures")
+        if shutil.which("fusefat") is None:
+            pytest.skip("fusefat is not installed")
 
     img_path = tmp_path / f"standalone.{fstype.value}"
     with img_path.open("wb") as f:
@@ -173,9 +148,15 @@ def test_mount_partition_offset(
     fstype: FileSystem,
     fakeroot: bool,  # noqa: FBT001
 ):
+    if "ext" in fstype.value and shutil.which("fuse2fs") is None:
+        pytest.skip("fuse2fs is not installed")
     if "fat" in fstype.value:
         if is_noble_non_amd64():
             pytest.skip("fusefat is unavailable on noble on non-amd64 architectures")
+        if shutil.which("fusefat") is None:
+            pytest.skip("fusefat is not installed")
+        if shutil.which("fusefile") is None:
+            pytest.skip("fusefile is not installed")
         if os.geteuid() != 0:
             pytest.skip(
                 f"{fstype.value} offset mounts via fusefile require root permissions"
@@ -235,6 +216,14 @@ def test_volume_mount(
 ):
     if is_noble_non_amd64():
         pytest.skip("fusefat is unavailable on noble on non-amd64 architectures")
+    if (
+        shutil.which("fuse2fs") is None
+        or shutil.which("fusefat") is None
+        or shutil.which("fusefile") is None
+    ):
+        pytest.skip(
+            "Required FUSE binaries (fuse2fs, fusefat, fusefile) are not installed"
+        )
     disk_path = tmp_path / f"{volume_definition.volume_schema.value}_disk.raw"
     sector_size = gptutil.SECTOR_SIZE_512
 

--- a/tests/spread/pack/mbr-grub/task.yaml
+++ b/tests/spread/pack/mbr-grub/task.yaml
@@ -29,6 +29,19 @@ execute: |
 
   LOOP=$(losetup --find --show --partscan ${IMG_NAME})
   echo $LOOP > loop.txt
+
+  # Partition devices are created asynchronously by the kernel after the
+  # partscan ioctl; wait for them to appear before using them.
+  count=0
+  until ls -d "$LOOP"p* >/dev/null 2>&1; do
+    count=$((count + 1))
+    if [ "$count" -ge 100 ]; then
+      echo "Timed out waiting for $LOOP partition devices" >&2
+      exit 1
+    fi
+    sleep 0.1
+  done
+
   for l in $(ls -d "$LOOP"p*)
   do
       p=${l#"$LOOP"}

--- a/tests/unit/services/test_image.py
+++ b/tests/unit/services/test_image.py
@@ -12,12 +12,14 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import pathlib
 import subprocess
 from typing import cast
 from unittest.mock import MagicMock, patch
 
 import pytest
 from craft_application import ServiceFactory
+from craft_cli import CraftError
 from imagecraft.models import Project, Volume
 from imagecraft.models.volume import GPTStructureItem, MBRVolume, PartitionSchema
 from imagecraft.services.image import ImageService
@@ -129,6 +131,7 @@ def test_attach_images_new(image_service, project_dir, mocker):
     mock_run = mocker.patch("imagecraft.services.image.run")
     # Mock _get_all_loop_devices returns empty
     mocker.patch.object(image_service, "_get_all_loop_devices", return_value=[])
+    mocker.patch.object(image_service, "_wait_for_partition_nodes")
 
     mock_run.return_value.stdout = "/dev/loop8\n"
 
@@ -144,6 +147,9 @@ def test_attach_images_new(image_service, project_dir, mocker):
             str(project_dir / ".pc.img.tmp"),
         )
         mock_atexit.assert_called_once_with(image_service.detach_images)
+        image_service._wait_for_partition_nodes.assert_called_once_with(
+            "/dev/loop8", "pc"
+        )
 
 
 def test_attach_images_reuse(image_service, project_dir, mocker):
@@ -161,11 +167,13 @@ def test_attach_images_reuse(image_service, project_dir, mocker):
     # Mock samefile to return True
     mocker.patch("pathlib.Path.samefile", return_value=True)
     mock_run = mocker.patch("imagecraft.services.image.run")
+    mocker.patch.object(image_service, "_wait_for_partition_nodes")
 
     devices = image_service.attach_images()
 
     assert devices == {"pc": "/dev/loop9"}
     mock_run.assert_not_called()  # Should not call losetup attach
+    image_service._wait_for_partition_nodes.assert_called_once_with("/dev/loop9", "pc")
 
 
 def test_attach_images_stale_inode(image_service, project_dir, mocker):
@@ -184,6 +192,7 @@ def test_attach_images_stale_inode(image_service, project_dir, mocker):
     mocker.patch("pathlib.Path.samefile", side_effect=FileNotFoundError)
     mock_run = mocker.patch("imagecraft.services.image.run")
     mock_run.return_value.stdout = "/dev/loop11\n"
+    mocker.patch.object(image_service, "_wait_for_partition_nodes")
 
     devices = image_service.attach_images()
 
@@ -194,6 +203,74 @@ def test_attach_images_stale_inode(image_service, project_dir, mocker):
     mock_run.assert_any_call(
         "losetup", "--find", "--show", "--partscan", str(image_path)
     )
+    image_service._wait_for_partition_nodes.assert_called_once_with("/dev/loop11", "pc")
+
+
+def test_wait_for_partition_nodes_immediate(
+    image_service, default_factory, mock_project, mocker
+):
+    """Partition nodes that already exist require no waiting."""
+    mocker.patch.object(
+        default_factory.get("project"), "get", return_value=mock_project
+    )
+
+    exists_calls: list[str] = []
+
+    def fake_exists(self):
+        exists_calls.append(str(self))
+        return True
+
+    mocker.patch.object(pathlib.Path, "exists", autospec=True, side_effect=fake_exists)
+    mock_sleep = mocker.patch("time.sleep")
+
+    image_service._wait_for_partition_nodes("/dev/loop8", "pc")
+
+    assert sorted(exists_calls) == ["/dev/loop8p1", "/dev/loop8p2"]
+    mock_sleep.assert_not_called()
+
+
+def test_wait_for_partition_nodes_after_delay(
+    image_service, default_factory, mock_project, mocker
+):
+    """The wait polls until all partition nodes appear."""
+    mocker.patch.object(
+        default_factory.get("project"), "get", return_value=mock_project
+    )
+    mocker.patch("imagecraft.services.image.time.monotonic", side_effect=[0, 0.5])
+    mock_sleep = mocker.patch("time.sleep")
+
+    p1_polls = 0
+
+    def fake_exists(self):
+        nonlocal p1_polls
+        if str(self).endswith("p1"):
+            p1_polls += 1
+            return p1_polls > 1  # Appear after the first poll.
+        return True
+
+    mocker.patch.object(pathlib.Path, "exists", autospec=True, side_effect=fake_exists)
+
+    image_service._wait_for_partition_nodes("/dev/loop8", "pc")
+
+    assert p1_polls == 2
+    mock_sleep.assert_called_once_with(0.1)
+
+
+def test_wait_for_partition_nodes_timeout(
+    image_service, default_factory, mock_project, mocker
+):
+    """A CraftError is raised when partition nodes never appear."""
+    mocker.patch.object(
+        default_factory.get("project"), "get", return_value=mock_project
+    )
+    mocker.patch("imagecraft.services.image.time.monotonic", side_effect=[0, 11])
+    mocker.patch("time.sleep")
+    mocker.patch.object(
+        pathlib.Path, "exists", autospec=True, side_effect=lambda self: False
+    )
+
+    with pytest.raises(CraftError, match="did not appear for /dev/loop8"):
+        image_service._wait_for_partition_nodes("/dev/loop8", "pc")
 
 
 def test_detach_images_success(image_service, mocker):

--- a/tests/unit/utils/__init__.py
+++ b/tests/unit/utils/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2026 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.

--- a/tests/unit/utils/test_mount.py
+++ b/tests/unit/utils/test_mount.py
@@ -1,0 +1,429 @@
+# Copyright 2026 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import subprocess
+from pathlib import Path
+from subprocess import CompletedProcess
+
+import pytest
+from imagecraft import errors
+from imagecraft.models import GPTVolume, MBRVolume
+from imagecraft.utils.mount import (
+    BaseMount,
+    CompositeMount,
+    ExtFuseMount,
+    FatFuseMount,
+    VirtualOffsetDevice,
+    mount_partition,
+    mount_volume,
+)
+
+
+@pytest.fixture
+def mock_run(mocker):
+    return mocker.patch(
+        "imagecraft.utils.mount.run",
+        return_value=CompletedProcess(args=[], returncode=0, stdout=""),
+    )
+
+
+@pytest.fixture
+def gpt_volume():
+    return GPTVolume.unmarshal(
+        {
+            "schema": "gpt",
+            "structure": [
+                {
+                    "name": "efi",
+                    "role": "system-boot",
+                    "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+                    "filesystem": "vfat",
+                    "size": "256M",
+                },
+                {
+                    "name": "rootfs",
+                    "role": "system-data",
+                    "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                    "filesystem": "ext4",
+                    "size": "4G",
+                },
+            ],
+        }
+    )
+
+
+@pytest.fixture
+def mbr_volume():
+    return MBRVolume.unmarshal(
+        {
+            "schema": "mbr",
+            "structure": [
+                {
+                    "name": "ubuntu-seed",
+                    "role": "system-boot",
+                    "type": "0C",
+                    "filesystem": "vfat",
+                    "size": "1200M",
+                },
+                {
+                    "name": "ubuntu-data",
+                    "role": "system-data",
+                    "type": "83",
+                    "filesystem": "ext4",
+                    "size": "2G",
+                },
+            ],
+        }
+    )
+
+
+def test_virtual_offset_device_mount_success(mock_run, tmp_path: Path):
+    disk_path = tmp_path / "disk.img"
+    disk_path.touch()
+    vdev = VirtualOffsetDevice(disk_path, offset=1048576, size=67108864)
+
+    assert not vdev.is_mounted
+    part_file = vdev.mount()
+
+    assert vdev.is_mounted
+    assert part_file.name == "part.img"
+    assert part_file.exists()
+    mock_run.assert_called_once_with(
+        "fusefile",
+        str(part_file),
+        f"{disk_path.resolve()}/1048576+67108864",
+    )
+
+    assert vdev.mount() == part_file
+    assert mock_run.call_count == 1
+
+    vdev.unmount()
+    assert not vdev.is_mounted
+    mock_run.assert_called_with("fusermount", "-u", str(part_file))
+
+
+def test_virtual_offset_device_mount_failure(mock_run, tmp_path: Path):
+    disk_path = tmp_path / "disk.img"
+    mock_run.side_effect = subprocess.CalledProcessError(1, "fusefile")
+    vdev = VirtualOffsetDevice(disk_path, offset=1048576, size=67108864)
+
+    with pytest.raises(
+        errors.MountError, match="Failed to create virtual offset device"
+    ):
+        vdev.mount()
+
+    assert not vdev.is_mounted
+    assert vdev.part_file is None
+
+
+def test_virtual_offset_device_unmount_lazy(mock_run, tmp_path: Path):
+    disk_path = tmp_path / "disk.img"
+    vdev = VirtualOffsetDevice(disk_path, offset=1048576, size=67108864)
+    part_file = vdev.mount()
+
+    vdev.unmount(lazy=True)
+    assert not vdev.is_mounted
+    mock_run.assert_called_with("fusermount", "-u", "-z", str(part_file))
+
+
+def test_virtual_offset_device_unmount_not_mounted(mock_run, tmp_path: Path):
+    disk_path = tmp_path / "disk.img"
+    vdev = VirtualOffsetDevice(disk_path, offset=1048576, size=67108864)
+    vdev.unmount()
+    mock_run.assert_not_called()
+
+
+def test_virtual_offset_device_context_manager(mock_run, tmp_path: Path):
+    disk_path = tmp_path / "disk.img"
+    vdev = VirtualOffsetDevice(disk_path, offset=1048576, size=67108864)
+
+    with vdev as part_file:
+        assert vdev.is_mounted
+        assert part_file.name == "part.img"
+
+    assert not vdev.is_mounted
+    mock_run.assert_called_with("fusermount", "-u", str(part_file))
+
+
+def test_ext_fuse_mount_standalone(mock_run, tmp_path: Path):
+    img_path = tmp_path / "rootfs.img"
+    mount = ExtFuseMount(img_path)
+
+    assert not mount.is_mounted
+    mountpoint = mount.mount()
+
+    assert mount.is_mounted
+    assert mountpoint.exists()
+    mock_run.assert_called_once_with(
+        "fuse2fs",
+        "-o",
+        "rw",
+        str(img_path.resolve()),
+        str(mountpoint.resolve()),
+    )
+
+    mount.unmount()
+    assert not mount.is_mounted
+    mock_run.assert_called_with("fusermount3", "-u", str(mountpoint.resolve()))
+
+
+def test_ext_fuse_mount_with_offset_and_options(mock_run, tmp_path: Path):
+    disk_path = tmp_path / "disk.img"
+    custom_mount = tmp_path / "custom_mount"
+    mount = ExtFuseMount(
+        disk_path,
+        offset=1048576,
+        mountpoint=custom_mount,
+        read_only=True,
+        allow_other=True,
+        fakeroot=True,
+    )
+
+    mountpoint = mount.mount()
+    assert mountpoint == custom_mount
+    mock_run.assert_called_once_with(
+        "fuse2fs",
+        "-o",
+        "offset=1048576,ro,allow_other,fakeroot",
+        str(disk_path.resolve()),
+        str(custom_mount.resolve()),
+    )
+
+    mount.unmount(lazy=True)
+    mock_run.assert_called_with("fusermount3", "-u", "-z", str(custom_mount.resolve()))
+
+
+def test_ext_fuse_mount_failure(mock_run, tmp_path: Path):
+    img_path = tmp_path / "rootfs.img"
+    mock_run.side_effect = subprocess.CalledProcessError(1, "fuse2fs")
+    mount = ExtFuseMount(img_path)
+
+    with pytest.raises(errors.MountError) as exc_info:
+        mount.mount()
+
+    assert "Failed to mount ext partition" in str(exc_info.value)
+    assert "at None" not in str(exc_info.value)
+    assert not mount.is_mounted
+
+
+def test_ext_fuse_mount_context_manager(mock_run, tmp_path: Path):
+    img_path = tmp_path / "rootfs.img"
+    mount = ExtFuseMount(img_path)
+
+    with mount as mnt:
+        assert mount.is_mounted
+        assert mnt.exists()
+
+    assert not mount.is_mounted
+
+
+def test_fat_fuse_mount_standalone(mock_run, tmp_path: Path):
+    img_path = tmp_path / "efi.img"
+    mount = FatFuseMount(img_path)
+
+    assert not mount.is_mounted
+    mountpoint = mount.mount()
+
+    assert mount.is_mounted
+    assert mountpoint.exists()
+    mock_run.assert_called_once_with(
+        "fusefat",
+        "-o",
+        "rw+",
+        str(img_path.resolve()),
+        str(mountpoint.resolve()),
+    )
+
+    mount.unmount()
+    assert not mount.is_mounted
+    mock_run.assert_called_with("fusermount3", "-u", str(mountpoint.resolve()))
+
+
+def test_fat_fuse_mount_with_offset_spawns_vdev(mock_run, tmp_path: Path):
+    disk_path = tmp_path / "disk.img"
+    mount = FatFuseMount(
+        disk_path,
+        offset=1048576,
+        size=67108864,
+        read_only=True,
+        allow_other=True,
+    )
+
+    mount.mount()
+    assert mount.is_mounted
+    assert mount._vpart is not None
+    assert mount._vpart.is_mounted
+
+    assert mock_run.call_count == 2
+    fusefile_call, fusefat_call = mock_run.call_args_list
+    assert fusefile_call[0][0] == "fusefile"
+    assert fusefat_call[0][0] == "fusefat"
+    assert fusefat_call[0][1] == "-o"
+    assert fusefat_call[0][2] == "ro,allow_other"
+
+    mount.unmount()
+    assert not mount.is_mounted
+    assert mock_run.call_count == 4
+    unmount_fat, unmount_vpart = mock_run.call_args_list[2:]
+    assert unmount_fat[0][0] == "fusermount3"
+    assert unmount_vpart[0][0] == "fusermount"
+
+
+def test_fat_fuse_mount_offset_missing_size_raises(tmp_path: Path):
+    disk_path = tmp_path / "disk.img"
+    mount = FatFuseMount(disk_path, offset=1048576, size=None)
+
+    with pytest.raises(errors.MountError, match="Partition size must be specified"):
+        mount.mount()
+
+
+def test_fat_fuse_mount_failure_cleans_up_vdev(mock_run, tmp_path: Path):
+    disk_path = tmp_path / "disk.img"
+    mock_run.side_effect = [
+        CompletedProcess(args=[], returncode=0, stdout=""),
+        subprocess.CalledProcessError(1, "fusefat"),
+        CompletedProcess(args=[], returncode=0, stdout=""),
+    ]
+    mount = FatFuseMount(disk_path, offset=1048576, size=67108864)
+
+    with pytest.raises(errors.MountError) as exc_info:
+        mount.mount()
+
+    assert "Failed to mount FAT partition" in str(exc_info.value)
+    assert "at None" not in str(exc_info.value)
+    assert not mount.is_mounted
+    assert mount._vpart is None
+    assert mock_run.call_count == 3
+    assert mock_run.call_args_list[2][0][0] == "fusermount"
+
+
+def test_mount_partition_factory(tmp_path: Path):
+    img_path = tmp_path / "test.img"
+
+    ext_mount = mount_partition(img_path, "ext4", offset=100, fakeroot=True)
+    assert isinstance(ext_mount, ExtFuseMount)
+    assert ext_mount.offset == 100
+    assert ext_mount.fakeroot is True
+
+    fat_mount = mount_partition(img_path, "vfat", offset=200, size=300)
+    assert isinstance(fat_mount, FatFuseMount)
+    assert fat_mount.offset == 200
+    assert fat_mount.size == 300
+
+    with pytest.raises(errors.MountError, match="Unsupported filesystem"):
+        mount_partition(img_path, "ntfs")
+
+
+def test_composite_mount_and_unmount_order(mocker, tmp_path: Path):
+    mount_a = mocker.MagicMock(spec=BaseMount)
+    mount_b = mocker.MagicMock(spec=BaseMount)
+    call_sequence: list[str] = []
+
+    mount_a.mount.side_effect = lambda: call_sequence.append("mount_a")
+    mount_b.mount.side_effect = lambda: call_sequence.append("mount_b")
+    mount_a.unmount.side_effect = lambda **_: call_sequence.append("unmount_a")
+    mount_b.unmount.side_effect = lambda **_: call_sequence.append("unmount_b")
+
+    composite = CompositeMount(
+        [
+            ("boot/efi", mount_b),
+            ("", mount_a),
+        ],
+        mountpoint=tmp_path / "rootfs",
+    )
+
+    root = composite.mount()
+    assert root == tmp_path / "rootfs"
+    assert composite.is_mounted
+
+    composite.unmount()
+    assert not composite.is_mounted
+
+    assert call_sequence == ["mount_a", "mount_b", "unmount_b", "unmount_a"]
+
+
+def test_composite_mount_failure_rolls_back(mocker, tmp_path: Path):
+    mount_a = mocker.MagicMock(spec=BaseMount)
+    mount_b = mocker.MagicMock(spec=BaseMount)
+    mount_b.mount.side_effect = errors.MountError("Failed B")
+
+    composite = CompositeMount(
+        [
+            ("", mount_a),
+            ("boot/efi", mount_b),
+        ],
+        mountpoint=tmp_path / "rootfs",
+    )
+
+    with pytest.raises(
+        errors.MountError,
+        match="Failed to mount composite mount hierarchy",
+    ):
+        composite.mount()
+
+    assert not composite.is_mounted
+    mount_a.unmount.assert_called_once()
+
+
+def test_mount_volume_gpt(mocker, gpt_volume, tmp_path: Path):
+    disk_path = tmp_path / "disk.img"
+    disk_path.touch()
+
+    mocker.patch(
+        "imagecraft.pack.gptutil.get_partition_sector_offset",
+        side_effect=lambda _, name: 2048 if name == "efi" else 526336,
+    )
+    mocker.patch(
+        "imagecraft.pack.gptutil.get_partition_size_sectors",
+        side_effect=lambda _, name: 524288 if name == "efi" else 8388608,
+    )
+
+    vol_mount = mount_volume(gpt_volume, disk_path, fakeroot=True)
+
+    assert len(vol_mount._mount_entries) == 2
+    paths_and_mounts = {p: type(m) for p, m in vol_mount._mount_entries}
+    assert paths_and_mounts == {
+        "boot/efi": FatFuseMount,
+        "": ExtFuseMount,
+    }
+    ext_m = next(m for p, m in vol_mount._mount_entries if p == "")
+    assert isinstance(ext_m, ExtFuseMount)
+    assert ext_m.fakeroot is True
+
+
+def test_mount_volume_mbr(mocker, mbr_volume, tmp_path: Path):
+    disk_path = tmp_path / "disk.img"
+    disk_path.touch()
+
+    mocker.patch(
+        "imagecraft.pack.gptutil.get_partition_sector_offset_by_number",
+        side_effect=lambda _, num: 2048 if num == 1 else 2459648,
+    )
+    mocker.patch(
+        "imagecraft.pack.gptutil.get_partition_size_sectors_by_number",
+        side_effect=lambda _, num: 2457600 if num == 1 else 4194304,
+    )
+
+    vol_mount = mount_volume(
+        mbr_volume,
+        disk_path,
+        mountpoint_overrides={"ubuntu-seed": "seed"},
+    )
+
+    assert len(vol_mount._mount_entries) == 2
+    paths_and_mounts = {p: type(m) for p, m in vol_mount._mount_entries}
+    assert paths_and_mounts == {
+        "seed": FatFuseMount,
+        "": ExtFuseMount,
+    }


### PR DESCRIPTION
## Description

Adds FUSE-based partition and volume mounting utilities under `imagecraft.utils.mount` using `fuse2fs`, `fusefat`, and `fusefile`, enabling mounting of ext4, FAT, and composite GPT/MBR volume hierarchies without kernel loop devices.

Also fixes a race condition where `/dev/loopXpY` partition device nodes are accessed before udev finishes creating them after `losetup --partscan`.

### Key Changes
- **FUSE Mounts (`imagecraft.utils.mount`)**: `mount_partition()` and `mount_volume()` context managers supporting ext4 (`fuse2fs`), FAT (`fusefat`), and partition offsets via `fusefile`.
- **Loop Device Partition Sync (`imagecraft.services.image`)**: Polls for `/dev/loopXpY` nodes after `losetup --partscan`.
- **Packaging & Tests**: Stages FUSE utilities in snapcraft and adds unit and integration tests.

IMAGECRAFT-176

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/imagecraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.