### PR TITLE
ci: use snaps output from snapcraft pack action

### DIFF
--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -62,7 +62,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: snap
-          path: ${{ steps.build-imagecraft.outputs.snap }}
+          path: ${{ steps.build-imagecraft.outputs.snaps }}
 
       - name: Get branch name
         id: vars
@@ -81,5 +81,5 @@ jobs:
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
         with:
-          snap: ${{ steps.build-imagecraft.outputs.snap }}
+          snap: ${{ steps.build-imagecraft.outputs.snaps }}
           release: edge/${{ steps.vars.outputs.branch }}


### PR DESCRIPTION
Fixes an issue where the snap workflow failed during the upload artifact step with `Input required and not supplied: path` (see [run 34387324540](https://github.com/canonical/imagecraft/actions/runs/34387324540/job/102587117930)).

The `canonical/craft-actions/snapcraft/pack` action exposes artifact outputs using plural naming (`snaps`), whereas the previous action used singular `snap`. This caused `${{ steps.build-imagecraft.outputs.snap }}` to evaluate to an empty string, causing `actions/upload-artifact` and `canonical/action-publish` to receive empty paths.

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/imagecraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [ ] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.